### PR TITLE
Switch from contact_id to email id as primary key

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -28,16 +28,16 @@ app = FastAPI(
 )
 
 
-async def get_contact_or_404(contact_id) -> ContactSchema:
+async def get_contact_or_404(email_id) -> ContactSchema:
     """
-    Get a contact by ID, or raise a 404 exception.
+    Get a contact by email_ID, or raise a 404 exception.
 
     TODO: implement a database backend
     """
     try:
-        return SAMPLE_CONTACTS[contact_id]
+        return SAMPLE_CONTACTS[email_id]
     except KeyError:
-        raise HTTPException(status_code=404, detail="Unknown contact_id")
+        raise HTTPException(status_code=404, detail="Unknown email_id")
 
 
 @app.get("/", include_in_schema=False)
@@ -54,16 +54,15 @@ async def root():
 
 
 @app.get(
-    "/ctms/{contact_id}",
+    "/ctms/{email_id}",
     summary="Get all contact details in basket format",
     response_model=CTMSResponse,
     responses={404: {"model": NotFoundResponse}},
     tags=["Public"],
 )
-async def read_ctms(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_ctms(email_id: UUID = Path(..., title="The Email ID")):
+    contact = await get_contact_or_404(email_id)
     return CTMSResponse(
-        id=contact.id,
         amo=contact.amo or ContactAddonsSchema(),
         contact=contact.contact or ContactMainSchema(),
         cv=contact.cv or ContactCommonVoiceSchema(),
@@ -76,86 +75,86 @@ async def read_ctms(contact_id: UUID = Path(..., title="The Contact ID")):
 
 
 @app.get(
-    "/identity/{contact_id}",
+    "/identity/{email_id}",
     summary="Get identities associated with the ID",
     response_model=IdentityResponse,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
-async def read_identity(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_identity(email_id: UUID = Path(..., title="The email ID")):
+    contact = await get_contact_or_404(email_id)
     return contact.as_identity_response()
 
 
 @app.get(
-    "/contact/main/{contact_id}",
+    "/contact/main/{email_id}",
     summary="Get contact's main details",
     response_model=ContactMainSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
-async def read_contact_main(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_contact_main(email_id: UUID = Path(..., title="The email ID")):
+    contact = await get_contact_or_404(email_id)
     return contact.contact or ContactMainSchema()
 
 
 @app.get(
-    "/contact/amo/{contact_id}",
+    "/contact/amo/{email_id}",
     summary="Get contact's add-ons details",
     response_model=ContactAddonsSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
-async def read_contact_amo(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_contact_amo(email_id: UUID = Path(..., title="The email ID")):
+    contact = await get_contact_or_404(email_id)
     return contact.amo or ContactAddonsSchema()
 
 
 @app.get(
-    "/contact/cv/{contact_id}",
+    "/contact/cv/{email_id}",
     summary="Get contact's Common Voice details",
     response_model=ContactCommonVoiceSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
-async def read_contact_cv(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_contact_cv(email_id: UUID = Path(..., title="The email ID")):
+    contact = await get_contact_or_404(email_id)
     return contact.cv or ContactCommonVoiceSchema()
 
 
 @app.get(
-    "/contact/fpn/{contact_id}",
+    "/contact/fpn/{email_id}",
     summary="Get contact's Firefox Private Network details",
     response_model=ContactFirefoxPrivateNetworkSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
-async def read_contact_fpn(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_contact_fpn(email_id: UUID = Path(..., title="The email ID")):
+    contact = await get_contact_or_404(email_id)
     return contact.fpn or ContactFirefoxPrivateNetworkSchema()
 
 
 @app.get(
-    "/contact/fsa/{contact_id}",
+    "/contact/fsa/{email_id}",
     summary="Get contact's FSA details",
     response_model=ContactFirefoxStudentAmbassadorSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
-async def read_contact_fsa(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_contact_fsa(email_id: UUID = Path(..., title="The email ID")):
+    contact = await get_contact_or_404(email_id)
     return contact.fsa or ContactFirefoxStudentAmbassadorSchema()
 
 
 @app.get(
-    "/contact/fxa/{contact_id}",
+    "/contact/fxa/{email_id}",
     summary="Get contact's Firefox Account details",
     response_model=ContactFirefoxAccountsSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
-async def read_contact_fxa(contact_id: UUID = Path(..., title="The Contact ID")):
-    contact = await get_contact_or_404(contact_id)
+async def read_contact_fxa(email_id: UUID = Path(..., title="The email ID")):
+    contact = await get_contact_or_404(email_id)
     return contact.fxa or ContactFirefoxAccountsSchema()
 
 

--- a/ctms/models.py
+++ b/ctms/models.py
@@ -1,14 +1,13 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from pydantic import BaseModel, EmailStr, Field, HttpUrl
+from pydantic import UUID4, BaseModel, EmailStr, Field, HttpUrl
 
 
 class ContactSchema(BaseModel):
     """A complete contact."""
 
-    id: UUID
     amo: Optional["ContactAddonsSchema"] = None
     contact: Optional["ContactMainSchema"] = None
     cv: Optional["ContactCommonVoiceSchema"] = None
@@ -21,6 +20,7 @@ class ContactSchema(BaseModel):
         """Return the identities of a contact"""
         return IdentityResponse(
             id=getattr(self.contact, "id", None),
+            email_id=self.contact.email_id,
             amo_id=getattr(self.amo, "id", None),
             fxa_id=getattr(self.fxa, "id", None),
             fxa_primary_email=getattr(self.fxa, "primary_email", None),
@@ -100,6 +100,7 @@ class ContactMainSchema(BaseModel):
     email: Optional[EmailStr] = Field(
         default=None, description="Contact email address, Email in Salesforce"
     )
+    email_id: UUID4 = Field(default_factory=uuid4, description="ID for email")
     first_name: Optional[str] = Field(
         default=None,
         max_length=40,
@@ -168,6 +169,7 @@ class ContactMainSchema(BaseModel):
                 "email": "contact@example.com",
                 "first_name": None,
                 "format": "H",
+                "email_id": "332de237-cab7-4461-bcc3-48e68f42bd5c",
                 "id": "001A000023aABcDEFG",
                 "lang": "en",
                 "last_modified_date": "2021-01-28T21:26:57.511Z",
@@ -351,7 +353,6 @@ ContactSchema.update_forward_refs()
 class CTMSResponse(BaseModel):
     """ContactSchema but sub-schemas are required."""
 
-    id: UUID
     amo: ContactAddonsSchema
     contact: ContactMainSchema
     cv: ContactCommonVoiceSchema
@@ -371,6 +372,7 @@ class CTMSResponse(BaseModel):
 class IdentityResponse(BaseModel):
     """The identity keys for a contact."""
 
+    email_id: UUID
     id: Optional[str] = None
     amo_id: Optional[int] = None
     fxa_id: Optional[str] = None

--- a/ctms/sample_data.py
+++ b/ctms/sample_data.py
@@ -12,8 +12,8 @@ from .models import (
 
 # A contact that has just some of the fields entered
 SAMPLE_MINIMAL = ContactSchema(
-    id=UUID("93db83d4-4119-4e0c-af87-a713786fa81d"),
     contact=ContactMainSchema(
+        email_id=UUID("93db83d4-4119-4e0c-af87-a713786fa81d"),
         id="001A000001aABcDEFG",
         country="us",
         created_date="2014-01-22T15:24:00+00:00",
@@ -36,7 +36,6 @@ SAMPLE_MINIMAL = ContactSchema(
 
 # A contact that has all of the fields set
 SAMPLE_MAXIMAL = ContactSchema(
-    id=UUID("67e52c77-950f-4f28-accb-bb3ea1a2c51a"),
     amo=ContactAddonsSchema(
         display_name="#1 Mozilla Fan",
         homepage="https://www.mozilla.org/en-US/firefox/new/",
@@ -49,6 +48,7 @@ SAMPLE_MAXIMAL = ContactSchema(
         country="ca",
         created_date="2010-01-01T08:04:00+00:00",
         email="mozilla-fan@example.com",
+        email_id=UUID("67e52c77-950f-4f28-accb-bb3ea1a2c51a"),
         first_name="Fan of",
         format="H",
         id="001A000001aMozFan",
@@ -145,7 +145,6 @@ SAMPLE_MAXIMAL = ContactSchema(
 
 # A sample user that has the OpenAPI schema examples
 SAMPLE_EXAMPLE = ContactSchema(
-    id=UUID("332de237-cab7-4461-bcc3-48e68f42bd5c"),
     amo=ContactAddonsSchema(**ContactAddonsSchema.Config.schema_extra["example"]),
     contact=ContactMainSchema(**ContactMainSchema.Config.schema_extra["example"]),
     cv=ContactCommonVoiceSchema(
@@ -164,7 +163,7 @@ SAMPLE_EXAMPLE = ContactSchema(
 
 
 SAMPLE_CONTACTS = {
-    SAMPLE_MINIMAL.id: SAMPLE_MINIMAL,
-    SAMPLE_MAXIMAL.id: SAMPLE_MAXIMAL,
-    SAMPLE_EXAMPLE.id: SAMPLE_EXAMPLE,
+    SAMPLE_MINIMAL.contact.email_id: SAMPLE_MINIMAL,
+    SAMPLE_MAXIMAL.contact.email_id: SAMPLE_MAXIMAL,
+    SAMPLE_EXAMPLE.contact.email_id: SAMPLE_EXAMPLE,
 }

--- a/tests/behave/get_test_contact.feature
+++ b/tests/behave/get_test_contact.feature
@@ -7,14 +7,13 @@ Feature: Getting the test user's information works
     And the test contact 332de237-cab7-4461-bcc3-48e68f42bd5c is setup
 
   Scenario: User wants to get full contact info for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /ctms/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /ctms/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
-        "id": "93db83d4-4119-4e0c-af87-a713786fa81d",
         "amo": {
           "display_name": null,
           "homepage": null,
@@ -27,6 +26,7 @@ Feature: Getting the test user's information works
           "country": "us",
           "created_date": "2014-01-22T15:24:00+00:00",
           "email": "ctms-user@example.com",
+          "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
           "first_name": null,
           "format": "H",
           "id": "001A000001aABcDEFG",
@@ -81,14 +81,13 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to get full contact info for the maximal contact
-    Given the contact_id 67e52c77-950f-4f28-accb-bb3ea1a2c51a
-    And the desired endpoint /ctms/(contact_id)
+    Given the email_id 67e52c77-950f-4f28-accb-bb3ea1a2c51a
+    And the desired endpoint /ctms/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
-        "id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
         "amo": {
           "display_name": "#1 Mozilla Fan",
           "homepage": "https://www.mozilla.org/en-US/firefox/new/",
@@ -101,6 +100,7 @@ Feature: Getting the test user's information works
           "country": "ca",
           "created_date": "2010-01-01T08:04:00+00:00",
           "email": "mozilla-fan@example.com",
+          "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
           "first_name": "Fan of",
           "format": "H",
           "id": "001A000001aMozFan",
@@ -199,14 +199,13 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to get full contact info for the example contact
-    Given the contact_id 332de237-cab7-4461-bcc3-48e68f42bd5c
-    And the desired endpoint /ctms/(contact_id)
+    Given the email_id 332de237-cab7-4461-bcc3-48e68f42bd5c
+    And the desired endpoint /ctms/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
-        "id": "332de237-cab7-4461-bcc3-48e68f42bd5c",
         "amo": {
           "display_name": "Add-ons Author",
           "homepage": "https://my-mozilla-addon.example.org/",
@@ -219,6 +218,7 @@ Feature: Getting the test user's information works
           "country": "us",
           "created_date": "2020-03-28T15:41:00+00:00",
           "email": "contact@example.com",
+          "email_id": "332de237-cab7-4461-bcc3-48e68f42bd5c",
           "first_name": null,
           "format": "H",
           "id": "001A000023aABcDEFG",
@@ -268,30 +268,32 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read identity data for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /identity/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /identity/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
-        "id": "001A000001aABcDEFG",
         "amo_id": null,
+        "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
         "fxa_id": null,
         "fxa_primary_email": null,
+        "id": "001A000001aABcDEFG",
         "token": "142e20b6-1ef5-43d8-b5f4-597430e956d7"
       }
       """
 
   Scenario: User wants to read identity data for the maximal contact
-    Given the contact_id 67e52c77-950f-4f28-accb-bb3ea1a2c51a
-    And the desired endpoint /identity/(contact_id)
+    Given the email_id 67e52c77-950f-4f28-accb-bb3ea1a2c51a
+    And the desired endpoint /identity/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
         "amo_id": 123,
+        "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
         "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
         "fxa_primary_email": "fxa-firefox-fan@example.com",
         "id": "001A000001aMozFan",
@@ -300,14 +302,15 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read identity data for the example contact
-    Given the contact_id 332de237-cab7-4461-bcc3-48e68f42bd5c
-    And the desired endpoint /identity/(contact_id)
+    Given the email_id 332de237-cab7-4461-bcc3-48e68f42bd5c
+    And the desired endpoint /identity/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
         "amo_id": 98765,
+        "email_id": "332de237-cab7-4461-bcc3-48e68f42bd5c",
         "fxa_id": "6eb6ed6a-c3b6-4259-968a-a490c6c0b9df",
         "fxa_primary_email": "my-fxa-acct@example.com",
         "id": "001A000023aABcDEFG",
@@ -316,8 +319,8 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read the main contact data for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/main/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /contact/main/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
@@ -326,6 +329,7 @@ Feature: Getting the test user's information works
         "country": "us",
         "created_date": "2014-01-22T15:24:00+00:00",
         "email": "ctms-user@example.com",
+        "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
         "first_name": null,
         "format": "H",
         "id": "001A000001aABcDEFG",
@@ -344,8 +348,8 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read the AMO data for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/amo/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /contact/amo/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
@@ -361,8 +365,8 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read the CV data for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/cv/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /contact/cv/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
@@ -378,8 +382,8 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read the FPN data for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/fpn/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /contact/fpn/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
@@ -391,8 +395,8 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read the FSA data for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/fsa/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /contact/fsa/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
@@ -408,8 +412,8 @@ Feature: Getting the test user's information works
       """
 
   Scenario: User wants to read the FXA data for the minimal contact
-    Given the contact_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/fxa/(contact_id)
+    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
+    And the desired endpoint /contact/fxa/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
@@ -425,14 +429,14 @@ Feature: Getting the test user's information works
       """
 
   Scenario Outline: Unknown contacts IDs are not found
-    Given the contact_id cad092ec-a71a-4df5-aa92-517959caeecb
-    And the desired endpoint /<endpoint_prefix>/(contact_id)
+    Given the email_id cad092ec-a71a-4df5-aa92-517959caeecb
+    And the desired endpoint /<endpoint_prefix>/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 404
     And the response JSON is
     """
     {
-      "detail": "Unknown contact_id"
+      "detail": "Unknown email_id"
     }
     """
 

--- a/tests/behave/steps/app.py
+++ b/tests/behave/steps/app.py
@@ -14,26 +14,26 @@ from ctms.sample_data import SAMPLE_CONTACTS
 def setup_test_client(context):
     context.test_client = TestClient(app=app)
     context.post_body = None
-    context.contact_id = None
+    context.email_id = None
 
 
-@given("the test contact {contact_id} is setup")
-def setup_test_contact(context, contact_id):
+@given("the test contact {email_id} is setup")
+def setup_test_contact(context, email_id):
     """TODO: Setup the test contact with a POST to /ctms"""
-    assert UUID(contact_id) in SAMPLE_CONTACTS
-    context.contact_id = contact_id
+    assert UUID(email_id) in SAMPLE_CONTACTS
+    context.email_id = email_id
 
 
-@given("the contact_id {contact_id}")
-def set_contact_id(context, contact_id):
-    context.contact_id = contact_id
+@given("the email_id {email_id}")
+def set_email_id(context, email_id):
+    context.email_id = email_id
 
 
 @given("the desired endpoint {endpoint}")
 def endpoint_setup(context, endpoint):
-    if "(contact_id)" in endpoint:
-        assert context.contact_id
-        endpoint = endpoint.replace("(contact_id)", context.contact_id)
+    if "(email_id)" in endpoint:
+        assert context.email_id
+        endpoint = endpoint.replace("(email_id)", context.email_id)
     context.test_endpoint = endpoint
 
 


### PR DESCRIPTION
## Proposed changes

The API is moving toward storing emails and related data, rather than contacts and related data. Reflect this by changing the API primary key from ``contact_id`` to ``email_id``, and move it into the ``contact`` group, which will be renamed to ``email`` next.

## Types of changes

What types of changes does your code introduce?

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Update (if none of the other choices apply)

## Checklist

- I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- Lint and tests pass both locally and on the cicd with my changes
- I have added tests that prove my fix is effective or that my feature works
- I have added necessary documentation (if appropriate)
