### PR TITLE
Scan only git-tracked files for secrets

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,7 +6,11 @@ CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 BASE_DIR="$(dirname "$CURRENT_DIR")"
 
 bandit -lll --recursive "${BASE_DIR}" --exclude "${BASE_DIR}/poetry.lock,${BASE_DIR}/.venv,${BASE_DIR}/.mypy,${BASE_DIR}/build"
-detect-secrets-hook {./*,**/**} --baseline .secrets.baseline
+
+# Scan only files checked into the repo, omit poetry.lock
+SECRETS_TO_SCAN=`git ls-tree --full-tree -r --name-only HEAD | grep -v poetry.lock`
+detect-secrets-hook $SECRETS_TO_SCAN --baseline .secrets.baseline
+
 mypy --no-strict-optional --ignore-missing-imports "${BASE_DIR}"
 black --config "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
 isort --recursive --settings-path "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"


### PR DESCRIPTION
## Proposed changes

When running ``scripts/lint.sh``, run ``detect-secrets-hook`` on only git-tracked files, except for ``poetry.lock``. This makes it run more like the pre-commit hook, and avoids checking ``htmlcov/status.json``, generated by ``scripts/test.sh``, which has hashes that look like secrets and is not checked in.

## Types of changes

What types of changes does your code introduce?
- New feature (non-breaking change which adds functionality)

## Checklist

- I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- Lint and tests pass both locally and on the cicd with my changes
- *N/A* I have added tests that prove my fix is effective or that my feature works
- *N/A* I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules
