### PR TITLE
Convert contact group to email, sync with schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,15 @@ The API is read-only with some sample test contacts with fake data:
 * [93db83d4-4119-4e0c-af87-a713786fa81d](http://ctms-api.api.data.allizom.org/ctms/93db83d4-4119-4e0c-af87-a713786fa81d):
   sample contact with minimal data:
   - email ``ctms-user@example.com``
-  - SalesForce ID ``001A000001aABcDEFG``
   - Basket token ``142e20b6-1ef5-43d8-b5f4-597430e956d7``
 * [67e52c77-950f-4f28-accb-bb3ea1a2c51a](http://ctms-api.api.data.allizom.org/ctms/67e52c77-950f-4f28-accb-bb3ea1a2c51a):
   sample contact with all data:
   - email ``mozilla-fan@example.com``
-  - SalesForce ID ``001A000001aMozFan``
   - Basket token ``d9ba6182-f5dd-4728-a477-2cc11bf62b69``
   - AMO ID: 123
   - Payee ID: ``cust_012345``
 * [332de237-cab7-4461-bcc3-48e68f42bd5c](http://ctms-api.api.data.allizom.org/ctms/332de237-cab7-4461-bcc3-48e68f42bd5c):
   - email ``contact@example.com``
-  - SalesForce ID ``001A000023aABcDEFG``
   - Basket token ``c4a7d759-bb52-457b-896b-90f1d3ef8433``
   - AMO ID: 98765
 

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -13,9 +13,9 @@ from .models import (
     ContactFirefoxAccountsSchema,
     ContactFirefoxPrivateNetworkSchema,
     ContactFirefoxStudentAmbassadorSchema,
-    ContactMainSchema,
     ContactSchema,
     CTMSResponse,
+    EmailSchema,
     IdentityResponse,
     NotFoundResponse,
 )
@@ -64,7 +64,7 @@ async def read_ctms(email_id: UUID = Path(..., title="The Email ID")):
     contact = await get_contact_or_404(email_id)
     return CTMSResponse(
         amo=contact.amo or ContactAddonsSchema(),
-        email=contact.email or ContactMainSchema(),
+        email=contact.email or EmailSchema(),
         cv=contact.cv or ContactCommonVoiceSchema(),
         fpn=contact.fpn or ContactFirefoxPrivateNetworkSchema(),
         fsa=contact.fsa or ContactFirefoxStudentAmbassadorSchema(),
@@ -87,15 +87,15 @@ async def read_identity(email_id: UUID = Path(..., title="The email ID")):
 
 
 @app.get(
-    "/contact/main/{email_id}",
+    "/contact/email/{email_id}",
     summary="Get contact's main details",
-    response_model=ContactMainSchema,
+    response_model=EmailSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
 async def read_contact_main(email_id: UUID = Path(..., title="The email ID")):
     contact = await get_contact_or_404(email_id)
-    return contact.email or ContactMainSchema()
+    return contact.email or EmailSchema()
 
 
 @app.get(

--- a/ctms/sample_data.py
+++ b/ctms/sample_data.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from uuid import UUID
 
 from .models import (
@@ -6,25 +7,19 @@ from .models import (
     ContactFirefoxAccountsSchema,
     ContactFirefoxPrivateNetworkSchema,
     ContactFirefoxStudentAmbassadorSchema,
-    ContactMainSchema,
     ContactSchema,
+    EmailSchema,
 )
 
 # A contact that has just some of the fields entered
 SAMPLE_MINIMAL = ContactSchema(
-    email=ContactMainSchema(
+    email=EmailSchema(
+        basket_token="142e20b6-1ef5-43d8-b5f4-597430e956d7",
+        create_timestamp="2014-01-22T15:24:00+00:00",
         email_id=UUID("93db83d4-4119-4e0c-af87-a713786fa81d"),
-        id="001A000001aABcDEFG",
-        country="us",
-        created_date="2014-01-22T15:24:00+00:00",
-        email="ctms-user@example.com",
-        lang="en",
-        last_modified_date="2020-01-22T15:24:00.000+0000",
-        optin=True,
-        optout=False,
-        postal_code="666",
-        record_type="0124A0000001aABCDE",
-        token="142e20b6-1ef5-43d8-b5f4-597430e956d7",
+        mailing_country="us",
+        primary_email="ctms-user@example.com",
+        update_timestamp="2020-01-22T15:24:00.000+0000",
     ),
     newsletters=[
         "app-dev",
@@ -52,25 +47,21 @@ SAMPLE_MAXIMAL = ContactSchema(
         last_active_date="2021-1-10T11:15:19.008Z",
         two_day_streak=True,
     ),
-    email=ContactMainSchema(
-        country="ca",
-        created_date="2010-01-01T08:04:00+00:00",
-        email="mozilla-fan@example.com",
+    email=EmailSchema(
         email_id=UUID("67e52c77-950f-4f28-accb-bb3ea1a2c51a"),
-        first_name="Fan of",
-        format="H",
-        id="001A000001aMozFan",
-        lang="fr",
-        last_modified_date="2020-01-28T14:50:00.000+0000",
-        last_name="Mozilla",
-        optin=True,
-        optout=False,
-        payee_id="cust_012345",
-        postal_code="H2L",
-        reason="done with this mailing list",
-        record_type="0124A0000001aABCDE",
-        source_url="https://developer.mozilla.org/fr/",
-        token="d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+        primary_email="mozilla-fan@example.com",
+        basket_token="d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+        name="Fan of Mozilla",
+        mailing_country="ca",
+        email_lang="fr",
+        browser_locale="fr-CA",
+        mofo_relevant=True,
+        signup_source="https://developer.mozilla.org/fr/",
+        pmt_cust_id="cust_012345",
+        subscriber=True,
+        unsubscribe_reason="done with this mailing list",
+        create_timestamp="2010-01-01T08:04:00+00:00",
+        update_timestamp="2020-01-28T14:50:00.000+0000",
     ),
     fpn=ContactFirefoxPrivateNetworkSchema(
         country="Canada",
@@ -143,13 +134,23 @@ SAMPLE_MAXIMAL = ContactSchema(
     ],
 )
 
+
+def _gather_examples(schema_class) -> Dict[str, str]:
+    """Gather the examples from a schema definition"""
+    examples = dict()
+    for key, props in schema_class.schema()["properties"].items():
+        if "example" in props:
+            examples[key] = props["example"]
+    return examples
+
+
 # A sample user that has the OpenAPI schema examples
 SAMPLE_EXAMPLE = ContactSchema(
     amo=ContactAddonsSchema(**ContactAddonsSchema.Config.schema_extra["example"]),
     cv=ContactCommonVoiceSchema(
         **ContactCommonVoiceSchema.Config.schema_extra["example"]
     ),
-    email=ContactMainSchema(**ContactMainSchema.Config.schema_extra["example"]),
+    email=EmailSchema(**_gather_examples(EmailSchema)),
     fpn=ContactFirefoxPrivateNetworkSchema(
         **ContactFirefoxPrivateNetworkSchema.Config.schema_extra["example"]
     ),

--- a/tests/behave/get_test_contact.feature
+++ b/tests/behave/get_test_contact.feature
@@ -31,24 +31,23 @@ Feature: Getting the test user's information works
           "two_day_streak": null
         },
         "email": {
-          "country": "us",
-          "created_date": "2014-01-22T15:24:00+00:00",
-          "email": "ctms-user@example.com",
+          "basket_token": "142e20b6-1ef5-43d8-b5f4-597430e956d7",
+          "browser_locale": null,
+          "create_timestamp": "2014-01-22T15:24:00+00:00",
+          "email_format": "H",
           "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
-          "first_name": null,
-          "format": "H",
-          "id": "001A000001aABcDEFG",
-          "lang": "en",
-          "last_modified_date": "2020-01-22T15:24:00+00:00",
-          "last_name": "_",
-          "optin": true,
-          "optout": false,
-          "payee_id": null,
-          "postal_code": "666",
-          "reason": null,
-          "record_type": "0124A0000001aABCDE",
-          "token": "142e20b6-1ef5-43d8-b5f4-597430e956d7",
-          "source_url": null
+          "email_lang": "en",
+          "has_opted_out_of_email": false,
+          "mailing_country": "us",
+          "mofo_relevant": false,
+          "name": null,
+          "pmt_cust_id": null,
+          "primary_email": "ctms-user@example.com",
+          "signup_source": null,
+          "subscriber": false,
+          "unengaged": false,
+          "unsubscribe_reason": null,
+          "update_timestamp": "2020-01-22T15:24:00+00:00"
         },
         "fpn": {
           "country": null,
@@ -105,24 +104,23 @@ Feature: Getting the test user's information works
           "two_day_streak": true
         },
         "email": {
-          "country": "ca",
-          "created_date": "2010-01-01T08:04:00+00:00",
-          "email": "mozilla-fan@example.com",
+          "basket_token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+          "browser_locale": "fr-CA",
+          "create_timestamp": "2010-01-01T08:04:00+00:00",
+          "email_format": "H",
           "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
-          "first_name": "Fan of",
-          "format": "H",
-          "id": "001A000001aMozFan",
-          "lang": "fr",
-          "last_modified_date": "2020-01-28T14:50:00+00:00",
-          "last_name": "Mozilla",
-          "optin": true,
-          "optout": false,
-          "payee_id": "cust_012345",
-          "postal_code": "H2L",
-          "reason": "done with this mailing list",
-          "record_type": "0124A0000001aABCDE",
-          "source_url": "https://developer.mozilla.org/fr/",
-          "token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69"
+          "email_lang": "fr",
+          "has_opted_out_of_email": false,
+          "mailing_country": "ca",
+          "mofo_relevant": true,
+          "name": "Fan of Mozilla",
+          "pmt_cust_id": "cust_012345",
+          "primary_email": "mozilla-fan@example.com",
+          "signup_source": "https://developer.mozilla.org/fr/",
+          "subscriber": true,
+          "unengaged": false,
+          "unsubscribe_reason": "done with this mailing list",
+          "update_timestamp": "2020-01-28T14:50:00+00:00"
         },
         "fpn": {
           "country": "Canada",
@@ -223,24 +221,23 @@ Feature: Getting the test user's information works
           "two_day_streak": true
         },
         "email": {
-          "country": "us",
-          "created_date": "2020-03-28T15:41:00+00:00",
-          "email": "contact@example.com",
+          "basket_token": "c4a7d759-bb52-457b-896b-90f1d3ef8433",
+          "browser_locale": null,
+          "create_timestamp": "2020-03-28T15:41:00+00:00",
+          "email_format": "H",
           "email_id": "332de237-cab7-4461-bcc3-48e68f42bd5c",
-          "first_name": null,
-          "format": "H",
-          "id": "001A000023aABcDEFG",
-          "lang": "en",
-          "last_modified_date": "2021-01-28T21:26:57.511000+00:00",
-          "last_name": "_",
-          "optin": true,
-          "optout": false,
-          "payee_id": null,
-          "postal_code": "94041",
-          "reason": null,
-          "record_type": "0124A0000001aABCDE",
-          "source_url": "https://www.mozilla.org/en-US/",
-          "token": "c4a7d759-bb52-457b-896b-90f1d3ef8433"
+          "email_lang": "en",
+          "has_opted_out_of_email": false,
+          "mailing_country": "us",
+          "mofo_relevant": false,
+          "name": "Mozilla Subscriber",
+          "pmt_cust_id": null,
+          "primary_email": "contact@example.com",
+          "signup_source": "https://www.mozilla.org/en-US/",
+          "subscriber": false,
+          "unengaged": false,
+          "unsubscribe_reason": null,
+          "update_timestamp": "2021-01-28T21:26:57.511000+00:00"
         },
         "fpn": {
           "country": "France",
@@ -275,12 +272,12 @@ Feature: Getting the test user's information works
     And the response JSON is
       """
       {
-        "amo_id": null,
         "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
+        "primary_email": "ctms-user@example.com",
+        "basket_token": "142e20b6-1ef5-43d8-b5f4-597430e956d7",
+        "amo_id": null,
         "fxa_id": null,
-        "fxa_primary_email": null,
-        "id": "001A000001aABcDEFG",
-        "token": "142e20b6-1ef5-43d8-b5f4-597430e956d7"
+        "fxa_primary_email": null
       }
       """
 
@@ -292,12 +289,12 @@ Feature: Getting the test user's information works
     And the response JSON is
       """
       {
-        "amo_id": 123,
         "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
+        "primary_email": "mozilla-fan@example.com",
+        "amo_id": 123,
+        "basket_token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69",
         "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
-        "fxa_primary_email": "fxa-firefox-fan@example.com",
-        "id": "001A000001aMozFan",
-        "token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69"
+        "fxa_primary_email": "fxa-firefox-fan@example.com"
       }
       """
 
@@ -309,41 +306,40 @@ Feature: Getting the test user's information works
     And the response JSON is
       """
       {
-        "amo_id": 98765,
         "email_id": "332de237-cab7-4461-bcc3-48e68f42bd5c",
+        "primary_email": "contact@example.com",
+        "amo_id": 98765,
+        "basket_token": "c4a7d759-bb52-457b-896b-90f1d3ef8433",
         "fxa_id": "6eb6ed6a-c3b6-4259-968a-a490c6c0b9df",
-        "fxa_primary_email": "my-fxa-acct@example.com",
-        "id": "001A000023aABcDEFG",
-        "token": "c4a7d759-bb52-457b-896b-90f1d3ef8433"
+        "fxa_primary_email": "my-fxa-acct@example.com"
       }
       """
 
-  Scenario: User wants to read the main contact data for the minimal contact
+  Scenario: User wants to read the main email data for the minimal contact
     Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/main/(email_id)
+    And the desired endpoint /contact/email/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
-        "country": "us",
-        "created_date": "2014-01-22T15:24:00+00:00",
-        "email": "ctms-user@example.com",
+        "basket_token": "142e20b6-1ef5-43d8-b5f4-597430e956d7",
+        "browser_locale": null,
+        "create_timestamp": "2014-01-22T15:24:00+00:00",
+        "email_format": "H",
         "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
-        "first_name": null,
-        "format": "H",
-        "id": "001A000001aABcDEFG",
-        "lang": "en",
-        "last_modified_date": "2020-01-22T15:24:00+00:00",
-        "last_name": "_",
-        "optin": true,
-        "optout": false,
-        "payee_id": null,
-        "postal_code": "666",
-        "reason": null,
-        "record_type": "0124A0000001aABCDE",
-        "source_url": null,
-        "token": "142e20b6-1ef5-43d8-b5f4-597430e956d7"
+        "email_lang": "en",
+        "has_opted_out_of_email": false,
+        "mailing_country": "us",
+        "mofo_relevant": false,
+        "name": null,
+        "pmt_cust_id": null,
+        "primary_email": "ctms-user@example.com",
+        "signup_source": null,
+        "subscriber": false,
+        "unengaged": false,
+        "unsubscribe_reason": null,
+        "update_timestamp": "2020-01-22T15:24:00+00:00"
       }
       """
 
@@ -444,9 +440,9 @@ Feature: Getting the test user's information works
       | endpoint_prefix |
       | ctms            |
       | identity        |
-      | contact/main    |
       | contact/amo     |
       | contact/cv      |
+      | contact/email   |
       | contact/fpn     |
       | contact/fsa     |
       | contact/fxa     |


### PR DESCRIPTION
## Proposed changes

Implement the API changes for the email table:

* In ``/ctms`` response, rename ``contact`` group to ``email``
* Rename endpoint ``/contact/main`` to ``/contact/email``
* Rename ``ContactMainSchema`` class to ``EmailSchema``, change fields:
  * ``email_id``: was the ``contact_id`` at the top level
  * ``email`` to ``primary_email``: now required
  * ``token`` to ``basket_token``: now required
  * ``name``: combined ``first_name`` and ``last_name``, increase to 255 characters
  * ``country`` to ``mailing_country``, from exactly 2 to max 255 chars
  * ``format`` to ``email_format``, from "H" or "T" to max 2 chars
  * ``lang`` to ``email_lang``, from exactly 2 to max 3 chars
  * ``browser_locale``: new field, 5 characters
  * ``mofo_relevant``: new field, true if tracked by Mozilla Foundation
  * ``source_url`` to ``signup_source``: removed length restriction
  * ``optout`` to ``has_opted_out_of_email``
  * ``payee_id`` to ``pmt_cust_id``: max 50 chars
  * ``subscriber``: new field
  * ``unengaged``: new field
  * ``reason`` to ``unsubscribe_reason``, limit removed
  * ``created_date`` to ``create_timestamp``
  * ``last_modified_date`` to ``update_timestamp``
  * ``id``: dropped
  * ``optin``: dropped
  * ``postal_code``: dropped
  * ``record_type``: dropped
* Change fields in ``IdentifyResponse``:
  * Drop ``id`` (Salesforce ID)
  * Rename ``token`` to ``basket_token``, make required
  * Add ``primary_email``, make required
* Reimplement examples in ``EmailSchema``

## Types of changes

What types of changes does your code introduce?
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- ✓ I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules
