### PR TITLE
Drop Common Voice, Firefox Student Ambassador data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Next features for the read-only version:
 * [ ] Review rounds
 * [ ] Flesh out the rest of the read-only API
 * [ ] Implement the ``/identity`` APIs with alternate IDs
-* [ ] Add more sample contacts
 
 Future features:
 

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -11,7 +11,6 @@ from .models import (
     ContactAddonsSchema,
     ContactFirefoxAccountsSchema,
     ContactFirefoxPrivateNetworkSchema,
-    ContactFirefoxStudentAmbassadorSchema,
     ContactSchema,
     CTMSResponse,
     EmailSchema,
@@ -65,7 +64,6 @@ async def read_ctms(email_id: UUID = Path(..., title="The Email ID")):
         amo=contact.amo or ContactAddonsSchema(),
         email=contact.email or EmailSchema(),
         fpn=contact.fpn or ContactFirefoxPrivateNetworkSchema(),
-        fsa=contact.fsa or ContactFirefoxStudentAmbassadorSchema(),
         fxa=contact.fxa or ContactFirefoxAccountsSchema(),
         newsletters=contact.newsletters or [],
         status="ok",
@@ -118,18 +116,6 @@ async def read_contact_amo(email_id: UUID = Path(..., title="The email ID")):
 async def read_contact_fpn(email_id: UUID = Path(..., title="The email ID")):
     contact = await get_contact_or_404(email_id)
     return contact.fpn or ContactFirefoxPrivateNetworkSchema()
-
-
-@app.get(
-    "/contact/fsa/{email_id}",
-    summary="Get contact's FSA details",
-    response_model=ContactFirefoxStudentAmbassadorSchema,
-    responses={404: {"model": NotFoundResponse}},
-    tags=["Private"],
-)
-async def read_contact_fsa(email_id: UUID = Path(..., title="The email ID")):
-    contact = await get_contact_or_404(email_id)
-    return contact.fsa or ContactFirefoxStudentAmbassadorSchema()
 
 
 @app.get(

--- a/ctms/models.py
+++ b/ctms/models.py
@@ -11,7 +11,6 @@ class ContactSchema(BaseModel):
     amo: Optional["ContactAddonsSchema"] = None
     email: Optional["EmailSchema"] = None
     fpn: Optional["ContactFirefoxPrivateNetworkSchema"] = None
-    fsa: Optional["ContactFirefoxStudentAmbassadorSchema"] = None
     fxa: Optional["ContactFirefoxAccountsSchema"] = None
     newsletters: List[str] = []
 
@@ -189,49 +188,6 @@ class ContactFirefoxPrivateNetworkSchema(BaseModel):
         }
 
 
-class ContactFirefoxStudentAmbassadorSchema(BaseModel):
-    """
-    The Firefox Student Ambassador program schema
-
-    This is now at https://community.mozilla.org/en/, may not be used.
-    All fields are on basket's IGNORE_USER_FIELDS list, and are
-    not planned to migrate to Acoustic.
-    """
-
-    allow_share: Optional[bool] = Field(
-        default=None, description="FSA_Allow_Info_Shared__c in Salesforce"
-    )
-    city: Optional[str] = Field(
-        default=None,
-        max_length=100,
-        description="MailingCity or maybe FSA_City__c in Salesforce",
-    )
-    current_status: Optional[str] = Field(
-        default=None, description="FSA_Current_Status__c in Salesforce"
-    )
-    grad_year: Optional[int] = Field(
-        default=None, description="FSA_Grad_Year__c in Salesforce"
-    )
-    major: Optional[str] = Field(
-        default=None, max_length=100, description="FSA_Major__c in Salesforce"
-    )
-    school: Optional[str] = Field(
-        default=None, max_length=100, description="FSA_School__c in Salesforce"
-    )
-
-    class Config:
-        schema_extra = {
-            "example": {
-                "allow_share": True,
-                "city": "Dehradun",
-                "current_status": "Student",
-                "grad_year": 2012,
-                "major": "Computer Science",
-                "school": "DIT University, Makkawala, Salon gaon, Dehradun",
-            }
-        }
-
-
 class ContactFirefoxAccountsSchema(BaseModel):
     """The Firefox Account schema."""
 
@@ -284,7 +240,6 @@ class CTMSResponse(BaseModel):
     amo: ContactAddonsSchema
     email: EmailSchema
     fpn: ContactFirefoxPrivateNetworkSchema
-    fsa: ContactFirefoxStudentAmbassadorSchema
     fxa: ContactFirefoxAccountsSchema
     newsletters: List[str] = Field(
         default=[],

--- a/ctms/sample_data.py
+++ b/ctms/sample_data.py
@@ -5,7 +5,6 @@ from .models import (
     ContactAddonsSchema,
     ContactFirefoxAccountsSchema,
     ContactFirefoxPrivateNetworkSchema,
-    ContactFirefoxStudentAmbassadorSchema,
     ContactSchema,
     EmailSchema,
 )
@@ -57,14 +56,6 @@ SAMPLE_MAXIMAL = ContactSchema(
     fpn=ContactFirefoxPrivateNetworkSchema(
         country="Canada",
         platform="Windows",
-    ),
-    fsa=ContactFirefoxStudentAmbassadorSchema(
-        allow_share=False,
-        city="Montreal",
-        current_status="Graduate",
-        grad_year=2011,
-        major="Library & Information Management",
-        school="McGill University",
     ),
     fxa=ContactFirefoxAccountsSchema(
         create_date="2019-05-22T08:29:31.906094+00:00",
@@ -141,9 +132,6 @@ SAMPLE_EXAMPLE = ContactSchema(
     email=EmailSchema(**_gather_examples(EmailSchema)),
     fpn=ContactFirefoxPrivateNetworkSchema(
         **ContactFirefoxPrivateNetworkSchema.Config.schema_extra["example"]
-    ),
-    fsa=ContactFirefoxStudentAmbassadorSchema(
-        **ContactFirefoxStudentAmbassadorSchema.Config.schema_extra["example"]
     ),
     fxa=ContactFirefoxAccountsSchema(
         **ContactFirefoxAccountsSchema.Config.schema_extra["example"]

--- a/tests/behave/get_test_contact.feature
+++ b/tests/behave/get_test_contact.feature
@@ -45,14 +45,6 @@ Feature: Getting the test user's information works
           "country": null,
           "platform": null
         },
-        "fsa": {
-          "allow_share": null,
-          "city": null,
-          "current_status": null,
-          "grad_year": null,
-          "major": null,
-          "school": null
-        },
         "fxa": {
           "create_date": null,
           "deleted": null,
@@ -109,14 +101,6 @@ Feature: Getting the test user's information works
         "fpn": {
           "country": "Canada",
           "platform": "Windows"
-        },
-        "fsa": {
-          "allow_share": false,
-          "city": "Montreal",
-          "current_status": "Graduate",
-          "grad_year": 2011,
-          "major": "Library & Information Management",
-          "school": "McGill University"
         },
         "fxa": {
           "create_date": "2019-05-22T08:29:31.906094+00:00",
@@ -218,14 +202,6 @@ Feature: Getting the test user's information works
         "fpn": {
           "country": "France",
           "platform": "Chrome"
-        },
-        "fsa": {
-          "allow_share": true,
-          "city": "Dehradun",
-          "current_status": "Student",
-          "grad_year": 2012,
-          "major": "Computer Science",
-          "school": "DIT University, Makkawala, Salon gaon, Dehradun"
         },
         "fxa": {
           "create_date": "2021-01-29T18:43:49.082375+00:00",
@@ -349,23 +325,6 @@ Feature: Getting the test user's information works
       }
       """
 
-  Scenario: User wants to read the FSA data for the minimal contact
-    Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/fsa/(email_id)
-    When the user invokes the client via GET
-    Then the user expects the response to have a status of 200
-    And the response JSON is
-      """
-      {
-        "allow_share": null,
-        "city": null,
-        "current_status": null,
-        "grad_year": null,
-        "major": null,
-        "school": null
-      }
-      """
-
   Scenario: User wants to read the FXA data for the minimal contact
     Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
     And the desired endpoint /contact/fxa/(email_id)
@@ -402,5 +361,4 @@ Feature: Getting the test user's information works
       | contact/amo     |
       | contact/email   |
       | contact/fpn     |
-      | contact/fsa     |
       | contact/fxa     |


### PR DESCRIPTION
## Proposed changes

Common Voice will move from the Mozilla Corporation to the Mozilla Foundation, so CTMS will not track it:

* Remove ``cv`` group from the ``/ctms`` response
* Remove the private ``/contact/cv`` API endpoint
* Remove the ``ContactCommonVoiceSchema`` class

The Firefox Student Ambassador data is stale and will not be migrated:

* Remove ``fsa`` group from the ``/ctms`` response
* Remove the private ``/contact/fsa`` API endpoint
* Remove the ``ContactFirefoxStudentAmbassadorSchema`` class

## Types of changes

What types of changes does your code introduce?
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- ✓ I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules

Oops