### PR TITLE
Sync Firefox Accounts (fxa) group with DB schema

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -10,11 +10,11 @@ from pydantic import EmailStr
 from .sample_data import SAMPLE_CONTACTS
 from .schemas import (
     AddOnsSchema,
-    ContactFirefoxAccountsSchema,
     ContactFirefoxPrivateNetworkSchema,
     ContactSchema,
     CTMSResponse,
     EmailSchema,
+    FirefoxAccountsSchema,
     IdentityResponse,
     NotFoundResponse,
 )
@@ -64,7 +64,7 @@ def read_ctms(email_id: UUID = Path(..., title="The Email ID")):
         amo=contact.amo or AddOnsSchema(),
         email=contact.email or EmailSchema(),
         fpn=contact.fpn or ContactFirefoxPrivateNetworkSchema(),
-        fxa=contact.fxa or ContactFirefoxAccountsSchema(),
+        fxa=contact.fxa or FirefoxAccountsSchema(),
         newsletters=contact.newsletters or [],
         status="ok",
     )
@@ -121,13 +121,13 @@ def read_contact_fpn(email_id: UUID = Path(..., title="The email ID")):
 @app.get(
     "/contact/fxa/{email_id}",
     summary="Get contact's Firefox Account details",
-    response_model=ContactFirefoxAccountsSchema,
+    response_model=FirefoxAccountsSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
 def read_contact_fxa(email_id: UUID = Path(..., title="The email ID")):
     contact = get_contact_or_404(email_id)
-    return contact.fxa or ContactFirefoxAccountsSchema()
+    return contact.fxa or FirefoxAccountsSchema()
 
 
 # NOTE:  This endpoint should provide a better proxy of "health".  It presently is a

--- a/ctms/sample_data.py
+++ b/ctms/sample_data.py
@@ -3,10 +3,10 @@ from uuid import UUID
 
 from .schemas import (
     AddOnsSchema,
-    ContactFirefoxAccountsSchema,
     ContactFirefoxPrivateNetworkSchema,
     ContactSchema,
     EmailSchema,
+    FirefoxAccountsSchema,
 )
 
 # A contact that has just some of the fields entered
@@ -63,12 +63,12 @@ SAMPLE_MAXIMAL = ContactSchema(
         country="Canada",
         platform="Windows",
     ),
-    fxa=ContactFirefoxAccountsSchema(
-        create_date="2019-05-22T08:29:31.906094+00:00",
-        id="611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+    fxa=FirefoxAccountsSchema(
+        created_date="2019-05-22T08:29:31.906094+00:00",
+        fxa_id="611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
         lang="fr,fr-CA",
         primary_email="fxa-firefox-fan@example.com",
-        service="monitor",
+        first_service="monitor",
     ),
     newsletters=[
         "about-addons",
@@ -139,9 +139,7 @@ SAMPLE_EXAMPLE = ContactSchema(
     fpn=ContactFirefoxPrivateNetworkSchema(
         **ContactFirefoxPrivateNetworkSchema.Config.schema_extra["example"]
     ),
-    fxa=ContactFirefoxAccountsSchema(
-        **ContactFirefoxAccountsSchema.Config.schema_extra["example"]
-    ),
+    fxa=FirefoxAccountsSchema(**_gather_examples(FirefoxAccountsSchema)),
 )
 
 

--- a/ctms/schemas.py
+++ b/ctms/schemas.py
@@ -11,7 +11,7 @@ class ContactSchema(BaseModel):
     amo: Optional["AddOnsSchema"] = None
     email: Optional["EmailSchema"] = None
     fpn: Optional["ContactFirefoxPrivateNetworkSchema"] = None
-    fxa: Optional["ContactFirefoxAccountsSchema"] = None
+    fxa: Optional["FirefoxAccountsSchema"] = None
     newsletters: List[str] = []
 
     def as_identity_response(self) -> "IdentityResponse":
@@ -20,7 +20,7 @@ class ContactSchema(BaseModel):
             amo_user_id=getattr(self.amo, "user_id", None),
             basket_token=getattr(self.email, "basket_token", None),
             email_id=self.email.email_id,
-            fxa_id=getattr(self.fxa, "id", None),
+            fxa_id=getattr(self.fxa, "fxa_id", None),
             fxa_primary_email=getattr(self.fxa, "primary_email", None),
             primary_email=getattr(self.email, "primary_email", None),
         )
@@ -216,47 +216,44 @@ class ContactFirefoxPrivateNetworkSchema(BaseModel):
         }
 
 
-class ContactFirefoxAccountsSchema(BaseModel):
+class FirefoxAccountsSchema(BaseModel):
     """The Firefox Account schema."""
 
-    create_date: Optional[datetime] = Field(
+    fxa_id: Optional[str] = Field(
+        default=None,
+        description="Firefox Accounts foreign ID, FxA_Id__c in Salesforce",
+        max_length=50,
+        example="6eb6ed6a-c3b6-4259-968a-a490c6c0b9df",
+    )
+    primary_email: Optional[EmailStr] = Field(
+        default=None,
+        description="FxA Email, can be foreign ID, FxA_Primary_Email__c in Salesforce",
+        example="my-fxa-acct@example.com",
+    )
+    created_date: Optional[str] = Field(
         default=None,
         description="Source is unix timestamp, FxA_Created_Date__c in Salesforce",
+        example="2021-01-29T18:43:49.082375+00:00",
     )
-    deleted: Optional[bool] = Field(
+    lang: Optional[str] = Field(
         default=None,
+        max_length=10,
+        description="FxA Locale, FxA_Language__c in Salesforce",
+        example="en,en-US",
+    )
+    first_service: Optional[str] = Field(
+        default=None,
+        max_length=50,
+        description="First service that an FxA user used, FirstService__c in Salesforce",
+        example="sync",
+    )
+    deleted: bool = Field(
+        default=False,
         description=(
             "Set to True when FxA account deleted or dupe,"
             " FxA_Account_Deleted__c in Salesforce"
         ),
     )
-    id: Optional[str] = Field(
-        default=None, description="Firefox Accounts foreign ID, FxA_Id__c in Salesforce"
-    )
-    lang: Optional[str] = Field(
-        default=None,
-        description="FxA Locale like 'en,en-US', FxA_Language__c in Salesforce",
-    )
-    primary_email: Optional[str] = Field(
-        default=None,
-        description="FxA Email, can be foreign ID, FxA_Primary_Email__c in Salesforce",
-    )
-    service: Optional[str] = Field(
-        default=None,
-        description="First service that an FxA user used, FirstService__c in Salesforce",
-    )
-
-    class Config:
-        schema_extra = {
-            "example": {
-                "create_date": "2021-01-29T18:43:49.082375+00:00",
-                "deleted": None,
-                "id": "6eb6ed6a-c3b6-4259-968a-a490c6c0b9df",
-                "lang": "en,en-US",
-                "primary_email": "my-fxa-acct@example.com",
-                "service": "sync",
-            }
-        }
 
 
 ContactSchema.update_forward_refs()
@@ -268,7 +265,7 @@ class CTMSResponse(BaseModel):
     amo: AddOnsSchema
     email: EmailSchema
     fpn: ContactFirefoxPrivateNetworkSchema
-    fxa: ContactFirefoxAccountsSchema
+    fxa: FirefoxAccountsSchema
     newsletters: List[str] = Field(
         default=[],
         description="List of identifiers for newsletters for which the contact is subscribed",

--- a/tests/behave/get_test_contact.feature
+++ b/tests/behave/get_test_contact.feature
@@ -52,12 +52,12 @@ Feature: Getting the test user's information works
           "platform": null
         },
         "fxa": {
-          "create_date": null,
-          "deleted": null,
-          "id": null,
+          "created_date": null,
+          "deleted": false,
+          "first_service": null,
+          "fxa_id": null,
           "lang": null,
-          "primary_email": null,
-          "service": null
+          "primary_email": null
         },
         "newsletters": [
             "app-dev",
@@ -115,12 +115,12 @@ Feature: Getting the test user's information works
           "platform": "Windows"
         },
         "fxa": {
-          "create_date": "2019-05-22T08:29:31.906094+00:00",
-          "deleted": null,
-          "id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+          "created_date": "2019-05-22T08:29:31.906094+00:00",
+          "deleted": false,
+          "first_service": "monitor",
+          "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
           "lang": "fr,fr-CA",
-          "primary_email": "fxa-firefox-fan@example.com",
-          "service": "monitor"
+          "primary_email": "fxa-firefox-fan@example.com"
         },
         "newsletters": [
             "about-addons",
@@ -222,12 +222,12 @@ Feature: Getting the test user's information works
           "platform": "Chrome"
         },
         "fxa": {
-          "create_date": "2021-01-29T18:43:49.082375+00:00",
-          "deleted": null,
-          "id": "6eb6ed6a-c3b6-4259-968a-a490c6c0b9df",
+          "created_date": "2021-01-29T18:43:49.082375+00:00",
+          "deleted": false,
+          "first_service": "sync",
+          "fxa_id": "6eb6ed6a-c3b6-4259-968a-a490c6c0b9df",
           "lang": "en,en-US",
-          "primary_email": "my-fxa-acct@example.com",
-          "service": "sync"
+          "primary_email": "my-fxa-acct@example.com"
         },
         "newsletters": [],
         "status": "ok"
@@ -357,12 +357,12 @@ Feature: Getting the test user's information works
     And the response JSON is
       """
       {
-        "create_date": null,
-        "deleted": null,
-        "id": null,
+        "created_date": null,
+        "deleted": false,
+        "first_service": null,
+        "fxa_id": null,
         "lang": null,
-        "primary_email": null,
-        "service": null
+        "primary_email": null
       }
       """
 


### PR DESCRIPTION

## Proposed changes

In the ``fxa`` group, tune most fields:
  * ``id``to ``fxa_id``, max length 50
  * ``create_date`` to ``created_date``, datetime to string of length 50
  * ``lang``: max length 10
  * ``service`` to ``first_service``: max length 50
  * ``deleted`` to ``account_deleted``, changed to non-null boolean

No changes to ``primary_email``, and no additions or deletions.

## Types of changes

What types of changes does your code introduce?
- ✓ Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- ✓ I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules
