### PR TITLE
Change fpn to vpn_waitlist, sync with schema

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -10,13 +10,13 @@ from pydantic import EmailStr
 from .sample_data import SAMPLE_CONTACTS
 from .schemas import (
     AddOnsSchema,
-    ContactFirefoxPrivateNetworkSchema,
     ContactSchema,
     CTMSResponse,
     EmailSchema,
     FirefoxAccountsSchema,
     IdentityResponse,
     NotFoundResponse,
+    VpnWaitlistSchema,
 )
 
 app = FastAPI(
@@ -63,9 +63,9 @@ def read_ctms(email_id: UUID = Path(..., title="The Email ID")):
     return CTMSResponse(
         amo=contact.amo or AddOnsSchema(),
         email=contact.email or EmailSchema(),
-        fpn=contact.fpn or ContactFirefoxPrivateNetworkSchema(),
         fxa=contact.fxa or FirefoxAccountsSchema(),
         newsletters=contact.newsletters or [],
+        vpn_waitlist=contact.vpn_waitlist or VpnWaitlistSchema(),
         status="ok",
     )
 
@@ -107,15 +107,15 @@ def read_contact_amo(email_id: UUID = Path(..., title="The email ID")):
 
 
 @app.get(
-    "/contact/fpn/{email_id}",
-    summary="Get contact's Firefox Private Network details",
-    response_model=ContactFirefoxPrivateNetworkSchema,
+    "/contact/vpn_waitlist/{email_id}",
+    summary="Get contact's Mozilla VPN Waitlist details",
+    response_model=VpnWaitlistSchema,
     responses={404: {"model": NotFoundResponse}},
     tags=["Private"],
 )
 def read_contact_fpn(email_id: UUID = Path(..., title="The email ID")):
     contact = get_contact_or_404(email_id)
-    return contact.fpn or ContactFirefoxPrivateNetworkSchema()
+    return contact.vpn_waitlist or VpnWaitlistSchema()
 
 
 @app.get(

--- a/ctms/sample_data.py
+++ b/ctms/sample_data.py
@@ -3,10 +3,10 @@ from uuid import UUID
 
 from .schemas import (
     AddOnsSchema,
-    ContactFirefoxPrivateNetworkSchema,
     ContactSchema,
     EmailSchema,
     FirefoxAccountsSchema,
+    VpnWaitlistSchema,
 )
 
 # A contact that has just some of the fields entered
@@ -58,10 +58,6 @@ SAMPLE_MAXIMAL = ContactSchema(
         unsubscribe_reason="done with this mailing list",
         create_timestamp="2010-01-01T08:04:00+00:00",
         update_timestamp="2020-01-28T14:50:00.000+0000",
-    ),
-    fpn=ContactFirefoxPrivateNetworkSchema(
-        country="Canada",
-        platform="Windows",
     ),
     fxa=FirefoxAccountsSchema(
         created_date="2019-05-22T08:29:31.906094+00:00",
@@ -120,6 +116,10 @@ SAMPLE_MAXIMAL = ContactSchema(
         "view-source-conference-north-america",
         "webmaker",
     ],
+    vpn_waitlist=VpnWaitlistSchema(
+        geo="ca",
+        platform="windows,android",
+    ),
 )
 
 
@@ -136,10 +136,8 @@ def _gather_examples(schema_class) -> Dict[str, str]:
 SAMPLE_EXAMPLE = ContactSchema(
     amo=AddOnsSchema(**_gather_examples(AddOnsSchema)),
     email=EmailSchema(**_gather_examples(EmailSchema)),
-    fpn=ContactFirefoxPrivateNetworkSchema(
-        **ContactFirefoxPrivateNetworkSchema.Config.schema_extra["example"]
-    ),
     fxa=FirefoxAccountsSchema(**_gather_examples(FirefoxAccountsSchema)),
+    vpn_waitlist=VpnWaitlistSchema(**_gather_examples(VpnWaitlistSchema)),
 )
 
 

--- a/ctms/schemas.py
+++ b/ctms/schemas.py
@@ -10,9 +10,9 @@ class ContactSchema(BaseModel):
 
     amo: Optional["AddOnsSchema"] = None
     email: Optional["EmailSchema"] = None
-    fpn: Optional["ContactFirefoxPrivateNetworkSchema"] = None
     fxa: Optional["FirefoxAccountsSchema"] = None
     newsletters: List[str] = []
+    vpn_waitlist: Optional["VpnWaitlistSchema"] = None
 
     def as_identity_response(self) -> "IdentityResponse":
         """Return the identities of a contact"""
@@ -188,32 +188,29 @@ class EmailSchema(BaseModel):
     )
 
 
-class ContactFirefoxPrivateNetworkSchema(BaseModel):
+class VpnWaitlistSchema(BaseModel):
     """
-    The Firefox Private Network schema.
+    The Mozilla VPN Waitlist schema.
 
-    These fields are present in Basket but might not be in SFDC.
-    Requested in https://github.com/mozmeao/basket/issues/384
+    This was previously the Firefox Private Network (fpn) waitlist data,
+    with a similar purpose.
     """
 
-    country: Optional[str] = Field(
+    geo: Optional[str] = Field(
         default=None,
-        max_length=120,
-        description="FPN waitlist country, FPN_Waitlist_Geo__c in Salesforce",
+        max_length=100,
+        description="VPN waitlist country, FPN_Waitlist_Geo__c in Salesforce",
+        example="fr",
     )
     platform: Optional[str] = Field(
         default=None,
-        max_length=120,
-        description="FPRM waitlist, FPN_Waitlist_Platform__c in Salesforce",
+        max_length=100,
+        description=(
+            "VPN waitlist platforms as comma-separated list,"
+            " FPN_Waitlist_Platform__c in Salesforce"
+        ),
+        example="ios,mac",
     )
-
-    class Config:
-        schema_extra = {
-            "example": {
-                "country": "France",
-                "platform": "Chrome",
-            }
-        }
 
 
 class FirefoxAccountsSchema(BaseModel):
@@ -264,7 +261,6 @@ class CTMSResponse(BaseModel):
 
     amo: AddOnsSchema
     email: EmailSchema
-    fpn: ContactFirefoxPrivateNetworkSchema
     fxa: FirefoxAccountsSchema
     newsletters: List[str] = Field(
         default=[],
@@ -274,6 +270,7 @@ class CTMSResponse(BaseModel):
     status: Literal["ok"] = Field(
         default="ok", description="Request was successful", example="ok"
     )
+    vpn_waitlist: VpnWaitlistSchema
 
 
 class IdentityResponse(BaseModel):

--- a/tests/behave/get_test_contact.feature
+++ b/tests/behave/get_test_contact.feature
@@ -47,10 +47,6 @@ Feature: Getting the test user's information works
           "unsubscribe_reason": null,
           "update_timestamp": "2020-01-22T15:24:00+00:00"
         },
-        "fpn": {
-          "country": null,
-          "platform": null
-        },
         "fxa": {
           "created_date": null,
           "deleted": false,
@@ -65,7 +61,11 @@ Feature: Getting the test user's information works
             "mozilla-foundation",
             "mozilla-learning-network"
         ],
-        "status": "ok"
+        "status": "ok",
+        "vpn_waitlist": {
+          "geo": null,
+          "platform": null
+        }
       }
       """
 
@@ -109,10 +109,6 @@ Feature: Getting the test user's information works
           "unengaged": false,
           "unsubscribe_reason": "done with this mailing list",
           "update_timestamp": "2020-01-28T14:50:00+00:00"
-        },
-        "fpn": {
-          "country": "Canada",
-          "platform": "Windows"
         },
         "fxa": {
           "created_date": "2019-05-22T08:29:31.906094+00:00",
@@ -172,7 +168,11 @@ Feature: Getting the test user's information works
             "view-source-conference-north-america",
             "webmaker"
         ],
-        "status": "ok"
+        "status": "ok",
+        "vpn_waitlist": {
+          "geo": "ca",
+          "platform": "windows,android"
+        }
       }
       """
 
@@ -217,10 +217,6 @@ Feature: Getting the test user's information works
           "unsubscribe_reason": null,
           "update_timestamp": "2021-01-28T21:26:57.511000+00:00"
         },
-        "fpn": {
-          "country": "France",
-          "platform": "Chrome"
-        },
         "fxa": {
           "created_date": "2021-01-29T18:43:49.082375+00:00",
           "deleted": false,
@@ -230,7 +226,11 @@ Feature: Getting the test user's information works
           "primary_email": "my-fxa-acct@example.com"
         },
         "newsletters": [],
-        "status": "ok"
+        "status": "ok",
+        "vpn_waitlist": {
+          "geo": "fr",
+          "platform": "ios,mac"
+        }
       }
       """
 
@@ -336,15 +336,15 @@ Feature: Getting the test user's information works
       }
       """
 
-  Scenario: User wants to read the FPN data for the minimal contact
+  Scenario: User wants to read the VPN waitlist data for the minimal contact
     Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
-    And the desired endpoint /contact/fpn/(email_id)
+    And the desired endpoint /contact/vpn_waitlist/(email_id)
     When the user invokes the client via GET
     Then the user expects the response to have a status of 200
     And the response JSON is
       """
       {
-        "country": null,
+        "geo": null,
         "platform": null
       }
       """
@@ -384,5 +384,5 @@ Feature: Getting the test user's information works
       | identity        |
       | contact/amo     |
       | contact/email   |
-      | contact/fpn     |
       | contact/fxa     |
+      | contact/vpn_waitlist |


### PR DESCRIPTION
## Proposed changes

* The ``fpn`` group is renamed to ``vpn_waitlist``, to reflect the product from Firefox Private Network to Mozilla VPN, and to clarify that these are the emails added to the waitlist for when their country and/or platform is supported.
* The ``vpn_waitlist`` fields are updated:
  * Rename ``country`` to ``geo``, reduce from 120 to 100 characters
  * Reduce ``platform`` from 120 to 100 characters
* Update examples to reflect the [in-progress forms](https://github.com/mozilla/bedrock/blob/e9307baa3f9ed464b3b3c6edabd031514b3da878/bedrock/products/forms.py#L10) on Bedrock (draft PR 9876)

## Types of changes

What types of changes does your code introduce?
- ✓ Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- *N/A* I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules
