### PR TITLE
Fix email_format: empty string, not space

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Next features for v0.5:
   * [ ] Should we have a separate ``email_id`` and ``basket_token``, or merge?
   * [ ] Should ``basket_token`` be required?
   * [ ] ``mailing_country``: Was 2-letter lowercase ISO, now 255-character string. Can we constrain?
-  * [X] ``email_format``: Was "H" or "T", now 2-char. Can we constrain? (existing data includes 'N' and ' ')
+  * [X] ``email_format``: Was "H" or "T", now 2-char. Can we constrain? (existing data includes 'N' and '')
   * [x] ``email_lang``: Was 2-letter lowercase code, now 3-char string. Can we constrain? *Back to 2 char*
   * [x] ``browser_locale``: What kind of data is this?
   * [ ] ``subscriber``: What does this signify?

--- a/ctms/schemas.py
+++ b/ctms/schemas.py
@@ -143,9 +143,9 @@ class EmailSchema(BaseModel):
         description="Mailing country code, 2 lowercase letters, MailingCountryCode in Salesforce",
         example="us",
     )
-    email_format: Literal["H", "T", "N", " "] = Field(
+    email_format: Literal["H", "T", "N", ""] = Field(
         default="H",
-        description="Email format, H=HTML, T=Plain Text, N and Space=No selection, Email_Format__c in Salesforce",
+        description="Email format, H=HTML, T=Plain Text, N and Empty=No selection, Email_Format__c in Salesforce",
     )
     email_lang: Optional[str] = Field(
         default="en",


### PR DESCRIPTION
## Proposed changes

When the email format option was added, legacy records were empty, not a single space.

Fixes #28 as mentioned here: https://github.com/mozilla-it/ctms-api/pull/27#discussion_r574091543

## Types of changes

What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- *N/A* I have added tests that prove my fix is effective or that my feature works
- *N/A* I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules
