### PR TITLE
Add /identities endpoint, query by alt ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Next features for v0.5:
   * [ ] ``location``: What does a valid valid look like? On site, they are "Potsdam, Germany"
   * [ ] ``profile_url``: What does a valid value look like? Why this and not homepage?
   * [ ] ``user_id``: Is this a string version of an int? Can we make int?
-* [ ] Implement the ``/identity`` APIs with alternate IDs
+* [x] Implement the ``/identities`` APIs with alternate IDs
 * [ ] Implement ``/ctms`` lookup with alternate IDs
 * [x] Add a database backend
 * [ ] Add ``acoustic_sync`` model

--- a/ctms/schemas.py
+++ b/ctms/schemas.py
@@ -318,10 +318,21 @@ class IdentityResponse(BaseModel):
     fxa_primary_email: Optional[EmailStr] = None
 
 
+class BadRequestResponse(BaseModel):
+    """The client called the endpoint incorrectly."""
+
+    detail: str = Field(
+        ...,
+        description="A human-readable summary of the client error.",
+        example="No identifiers provided, at least one is needed.",
+    )
+
+
 class NotFoundResponse(BaseModel):
-    """The content of the 404 Not Found message."""
+    """No existing record was found for the indentifier."""
 
-    detail: str
-
-    class Config:
-        schema_extra = {"example": {"detail": "Unknown contact_id"}}
+    detail: str = Field(
+        ...,
+        description="A human-readable summary of the issue.",
+        example="Unknown contact_id",
+    )

--- a/tests/behave/get_test_contact.feature
+++ b/tests/behave/get_test_contact.feature
@@ -321,6 +321,206 @@ Feature: Getting the test user's information works
       }
       """
 
+  Scenario: User wants to find an identity by email_id
+        Given the desired endpoint /identities?email_id=332de237-cab7-4461-bcc3-48e68f42bd5c
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "332de237-cab7-4461-bcc3-48e68f42bd5c",
+          "primary_email": "contact@example.com",
+          "amo_user_id": "98765",
+          "basket_token": "c4a7d759-bb52-457b-896b-90f1d3ef8433",
+          "fxa_id": "6eb6ed6a-c3b6-4259-968a-a490c6c0b9df",
+          "fxa_primary_email": "my-fxa-acct@example.com",
+          "sfdc_id": "001A000023aABcDEFG"
+        }
+      ]
+      """
+
+  Scenario: User wants to find an identity by primary email
+    Given the desired endpoint /identities?primary_email=ctms-user@example.com
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
+          "primary_email": "ctms-user@example.com",
+          "basket_token": "142e20b6-1ef5-43d8-b5f4-597430e956d7",
+          "sfdc_id": "001A000001aABcDEFG",
+          "amo_user_id": null,
+          "fxa_id": null,
+          "fxa_primary_email": null
+        }
+      ]
+      """
+
+  Scenario: User wants to find an identity by basket token
+    Given the desired endpoint /identities?basket_token=d9ba6182-f5dd-4728-a477-2cc11bf62b69
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
+          "primary_email": "mozilla-fan@example.com",
+          "amo_user_id": "123",
+          "basket_token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+          "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+          "fxa_primary_email": "fxa-firefox-fan@example.com",
+          "sfdc_id": "001A000001aMozFan"
+        }
+      ]
+      """
+
+  Scenario: User wants to find an identity by legacy Salesforce ID
+    Given the desired endpoint /identities?sfdc_id=001A000001aABcDEFG
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "93db83d4-4119-4e0c-af87-a713786fa81d",
+          "primary_email": "ctms-user@example.com",
+          "basket_token": "142e20b6-1ef5-43d8-b5f4-597430e956d7",
+          "sfdc_id": "001A000001aABcDEFG",
+          "amo_user_id": null,
+          "fxa_id": null,
+          "fxa_primary_email": null
+        }
+      ]
+      """
+  Scenario: User wants to find an identity by ID on addons.mozilla.org
+    Given the desired endpoint /identities?amo_user_id=123
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
+          "primary_email": "mozilla-fan@example.com",
+          "amo_user_id": "123",
+          "basket_token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+          "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+          "fxa_primary_email": "fxa-firefox-fan@example.com",
+          "sfdc_id": "001A000001aMozFan"
+        }
+      ]
+      """
+
+  Scenario: User wants to find an identity by Firefox Accounts ID
+    Given the desired endpoint /identities?fxa_id=611b6788-2bba-42a6-98c9-9ce6eb9cbd34
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
+          "primary_email": "mozilla-fan@example.com",
+          "amo_user_id": "123",
+          "basket_token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+          "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+          "fxa_primary_email": "fxa-firefox-fan@example.com",
+          "sfdc_id": "001A000001aMozFan"
+        }
+      ]
+      """
+
+  Scenario: User wants to find an identity by Firefox Accounts primary email
+    Given the desired endpoint /identities?fxa_primary_email=fxa-firefox-fan@example.com
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
+          "primary_email": "mozilla-fan@example.com",
+          "amo_user_id": "123",
+          "basket_token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+          "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+          "fxa_primary_email": "fxa-firefox-fan@example.com",
+          "sfdc_id": "001A000001aMozFan"
+        }
+      ]
+      """
+
+  Scenario: User wants to find an identity by two alternate IDs
+    Given the desired endpoint /identities?sfdc_id=001A000001aMozFan&fxa_primary_email=fxa-firefox-fan@example.com
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      [
+        {
+          "email_id": "67e52c77-950f-4f28-accb-bb3ea1a2c51a",
+          "primary_email": "mozilla-fan@example.com",
+          "amo_user_id": "123",
+          "basket_token": "d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+          "fxa_id": "611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+          "fxa_primary_email": "fxa-firefox-fan@example.com",
+          "sfdc_id": "001A000001aMozFan"
+        }
+      ]
+      """
+
+  Scenario: User wants to find an identity by two alternate IDs, but one does not match
+    Given the desired endpoint /identities?primary_email=ctms-user@example.com&amo_user_id=404
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      []
+      """
+
+  Scenario: User wants to find an identity by two alternate IDs, but one is empty
+    Given the desired endpoint /identities?primary_email=ctms-user@example.com&fxa_id=
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+      """
+      []
+      """
+
+  Scenario: User receives a bad request error when finding identities with no alternate IDs
+    Given the desired endpoint /identities
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 400
+    And the response JSON is
+      """
+      {
+        "detail": "No identifiers provided, at least one is needed: email_id, primary_email, basket_token, sfdc_id, amo_user_id, fxa_id, fxa_primary_email"
+      }
+      """
+
+  Scenario Outline: Unknown alternate IDs are not found
+    Given the email_id cad092ec-a71a-4df5-aa92-517959caeecb
+    And the desired endpoint /identities?<alt_id>=<alt_value>
+    When the user invokes the client via GET
+    Then the user expects the response to have a status of 200
+    And the response JSON is
+    """
+    []
+    """
+
+    Examples: Alternate IDs
+      | alt_id            | alt_value                            |
+      | email_id          | cad092ec-a71a-4df5-aa92-517959caeecb |
+      | primary_email     | unknown-user@example.com             |
+      | amo_user_id       | 404                                  |
+      | basket_token      | cad092ec-a71a-4df5-aa92-517959caeecb |
+      | fxa_id            | cad092ec-a71a-4df5-aa92-517959caeecb |
+      | fxa_primary_email | unknown-user@example.com             |
+      | sfdc_id           | 001A000404aUnknown                   |
+
   Scenario: User wants to read the main email data for the minimal contact
     Given the email_id 93db83d4-4119-4e0c-af87-a713786fa81d
     And the desired endpoint /contact/email/(email_id)


### PR DESCRIPTION
## Proposed changes

The private /identities endpoint allows querying by the alternate IDs:
 * ``primary_email``
 * ``amo_user_id``
 * ``basket_token``
 * ``fxa_id``
 * ``fxa_primary_email``
 * ``sfdc_id``

Because some alternate IDs are not unique, the return is a list of ``IdentityResponse``s. If none are found, an empty list is returned rather than a 404. My reasoning is that a client would process the list, with special cases for 0, 1, or many responses and the logic would be clearer if 0 responses was an empty list. I'm curious if others have opinions in the other direction.

For completeness, ``email_id`` is also allowed, and may be useful when querying by multiple IDs. If multiple IDs are passed, then all must match to return the contact.

If no IDs are passed, a 400 (Bad Request) is returned.

It is currently implemented against the built-in sample contacts. In the future, it can be transitioned to query the database.

## Types of changes

What types of changes does your code introduce?
- New feature (non-breaking change which adds functionality)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- ✓ I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules

## Further comments

Tests added as well. I am missing unit tests and pytest. Testing and linting is a bit more awkward with the new docker-compose setup, I'm thinking of ways to make it easier.

Some of this is overkill for this PR, but the next action is a ``/ctms`` endpoint that takes alternate IDs, and will reuse a lot of this code and the design decisions.