### PR TITLE
Email field changes

### DIFF
--- a/ctms/models.py
+++ b/ctms/models.py
@@ -19,7 +19,6 @@ class Email(Base):
     email_lang = Column(String(2))
     mofo_relevant = Column(Boolean)
     has_opted_out_of_email = Column(Boolean)
-    subscriber = Column(Boolean)
     unsubscribe_reason = Column(Text)
 
     # TODO: not null, default now(), update on update

--- a/ctms/sample_data.py
+++ b/ctms/sample_data.py
@@ -56,7 +56,6 @@ SAMPLE_MAXIMAL = ContactSchema(
         email_lang="fr",
         mofo_relevant=True,
         sfdc_id="001A000001aMozFan",
-        subscriber=True,
         unsubscribe_reason="done with this mailing list",
         create_timestamp="2010-01-01T08:04:00+00:00",
         update_timestamp="2020-01-28T14:50:00.000+0000",

--- a/ctms/schemas.py
+++ b/ctms/schemas.py
@@ -169,9 +169,6 @@ class EmailSchema(BaseModel):
         default=False,
         description="User has opted-out, HasOptedOutOfEmail in Salesforce",
     )
-    subscriber: bool = Field(
-        default=False, description="TODO: add description. Subscriber__c in Salesforce"
-    )
     unsubscribe_reason: Optional[str] = Field(
         default=None,
         description="Reason for unsubscribing, in basket IGNORE_USER_FIELDS, Unsubscribe_Reason__c in Salesforce",

--- a/tests/behave/get_test_contact.feature
+++ b/tests/behave/get_test_contact.feature
@@ -41,7 +41,6 @@ Feature: Getting the test user's information works
           "mofo_relevant": false,
           "primary_email": "ctms-user@example.com",
           "sfdc_id": "001A000001aABcDEFG",
-          "subscriber": false,
           "unsubscribe_reason": null,
           "update_timestamp": "2020-01-22T15:24:00+00:00"
         },
@@ -130,7 +129,6 @@ Feature: Getting the test user's information works
           "mofo_relevant": true,
           "primary_email": "mozilla-fan@example.com",
           "sfdc_id": "001A000001aMozFan",
-          "subscriber": true,
           "unsubscribe_reason": "done with this mailing list",
           "update_timestamp": "2020-01-28T14:50:00+00:00"
         },
@@ -243,7 +241,6 @@ Feature: Getting the test user's information works
           "mofo_relevant": false,
           "primary_email": "contact@example.com",
           "sfdc_id": "001A000023aABcDEFG",
-          "subscriber": false,
           "unsubscribe_reason": null,
           "update_timestamp": "2021-01-28T21:26:57.511000+00:00"
         },
@@ -316,7 +313,6 @@ Feature: Getting the test user's information works
           "mofo_relevant": false,
           "primary_email": "contact@example.com",
           "sfdc_id": "001A000023aABcDEFG",
-          "subscriber": false,
           "unsubscribe_reason": null,
           "update_timestamp": "2021-01-28T21:26:57.511000+00:00"
         },
@@ -639,7 +635,6 @@ Feature: Getting the test user's information works
         "mofo_relevant": false,
         "primary_email": "ctms-user@example.com",
         "sfdc_id": "001A000001aABcDEFG",
-        "subscriber": false,
         "unsubscribe_reason": null,
         "update_timestamp": "2020-01-22T15:24:00+00:00"
       }


### PR DESCRIPTION
## Proposed changes

Change the ``email`` schema to reflect the latest Acoustic schema:

* ``name`` is back to ``first_name`` (40 to 255 chars) and ``last_name`` (80 to 255 chars)
* drop ``signup_source`` (but keep ``newsletter.source``)
* drop ``pmt_cust_id`` (tracked in MoFo)
* drop ``subscriber``

## Types of changes

What types of changes does your code introduce?
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- ✓ I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules
