### PR TITLE
Convert docker-compose to use environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ reports/
 htmlcov/
 .isort.cfg
 docs/_build
+.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,8 +14,9 @@ services:
     # Let the init system handle signals for us.
     # among other things this helps shutdown be fast
     init: true
-    environment:
-      CTMS_DB_URL: postgresql://postgres@postgres/postgres
+    env_file:
+      - docker/config/local_dev.env
+      - .env
     depends_on:
       - postgres
   postgres:

--- a/docker/config/env.dist
+++ b/docker/config/env.dist
@@ -1,0 +1,9 @@
+# This file is for settings that are specific to your docker local development
+# environment. Since these are specific to your local development environment,
+# don't check them in.
+
+# Set this to always call docker-compose run with --service-ports in the Makefile
+# MK_WITH_SERVICE_PORTS=--service-ports
+
+# Set this to skip calling "docker-compose down" after "make tests"
+# MK_KEEP_DOCKER_UP=1

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -1,0 +1,4 @@
+# Environment variables for the local development environment
+
+# Database
+CTMS_DB_URL=postgresql://postgres@postgres/postgres

--- a/tests/docker-compose.test.yaml
+++ b/tests/docker-compose.test.yaml
@@ -12,7 +12,8 @@ services:
     # Let the init system handle signals for us.
     # among other things this helps shutdown be fast
     init: true
-    environment:
-      CTMS_DB_URL: postgresql://postgres@postgres/postgres
+    env_file:
+      - docker/config/local_dev.env
+      - .env
     depends_on:
       - postgres


### PR DESCRIPTION
Environment files like [.env](https://docs.docker.com/compose/environment-variables/#the-env-file) are considered after the environment settings in``docker-compose.yml`` and the shell. The ``docker/config/local_dev.env`` file has settings for the local development environment, such as the database URL. The ``.env`` file has developer-specific settings, is created when a ``make`` command is used, and is ignored by ``git``.

To demonstrate  possibilities, I've added a few override for ``Makefile`` behavior:

* ``MK_WITH_SERVICE_PORTS=--service-ports`` - Add ``--service-ports`` to calls to ``docker-compose run``, to make it more likely that postgres ports will stay open
* ``MK_KEEP_DOCKER_UP=1`` - Avoid calling ``docker-compose down`` after ``make test``

The real use cases are in the future - adding a dev value for the per-deployment ``CTMS_SECRET_KEY`` for crypto operations, adding a switch for development vs live servers, etc. If it doesn't make sense to do it now, I can make the change as part of the OAuth2 stuff, when it will make more sense.

This is based on [similar functionality in MLS](https://github.com/mozilla/ichnaea/tree/main/docker/config), which doesn't use ``docker-compose`` for deployment. I have no experience with that use case, so I'm not sure if this helps or hurts.
