### PR TITLE
Clear .secrets.baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,10 +1,10 @@
 {
   "custom_plugin_paths": [],
   "exclude": {
-    "files": "poetry.lock,htmlcov/status.json",
+    "files": "poetry.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-02-03T22:52:09Z",
+  "generated_at": "2021-03-09T23:46:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,48 +58,7 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {
-    "./poetry.lock": [
-      {
-        "hashed_secret": "cd1bc7a5bbe95901771a567a4a2416f3a857ef8e",
-        "is_verified": false,
-        "line_number": 830,
-        "type": "Hex High Entropy String"
-      }
-    ],
-    "htmlcov/status.json": [
-      {
-        "hashed_secret": "076d9e6fa6160f7b9554d015c277ddf57248b134",
-        "is_verified": false,
-        "line_number": 1,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "3c094a79eeefd8a8ae21e764a570d67cf49cd1ad",
-        "is_verified": false,
-        "line_number": 1,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "5a91acd844aa5eef09da31696ef009267433f6fd",
-        "is_verified": false,
-        "line_number": 1,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "9cfe778e486602b4a7bdb7c5ac5174abf3533deb",
-        "is_verified": false,
-        "line_number": 1,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "f0f29316ef8ec7d975a8aa9ca71b0c49b74e290e",
-        "is_verified": false,
-        "line_number": 1,
-        "type": "Hex High Entropy String"
-      }
-    ]
-  },
+  "results": {},
   "version": "0.14.3",
   "word_list": {
     "file": null,


### PR DESCRIPTION
With ignored files applied, there are no detected secrets. My upcoming changes _will_ add a secret, so I wanted a clean baseline before it was added.

To update the file, I ran:

```
poetry shell
detect-secrets scan --update .secrets.baseline --exclude-files poetry.lock
```