### PR TITLE
Add OAuth2 authentication (57)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "poetry.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-09T23:46:49Z",
+  "generated_at": "2021-03-10T00:27:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,7 +58,17 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
+  "results": {
+    "guides/developer_setup.md": [
+      {
+        "hashed_secret": "5089246737bcae6ebd14c2548a8360bc548cf0db",
+        "is_secret": true,
+        "is_verified": false,
+        "line_number": 215,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
   "version": "0.14.3",
   "word_list": {
     "file": null,

--- a/ctms/auth.py
+++ b/ctms/auth.py
@@ -1,0 +1,144 @@
+"""
+Implement OAuth2 client credentials.
+
+A backend client POSTs to the /token endpoint, sending client_id and
+client_secret, either as form fields in the body, or in the Authentication
+header. A JWT token is returned that expires after a short time. To renew,
+the client POSTs to /token again.
+"""
+import warnings
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+from fastapi.exceptions import HTTPException
+from fastapi.param_functions import Form
+from fastapi.security.oauth2 import OAuth2, OAuthFlowsModel
+from fastapi.security.utils import get_authorization_scheme_param
+from passlib.context import CryptContext
+from starlette.requests import Request
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+with warnings.catch_warnings():
+    # TODO: remove when fixed: https://github.com/mpdavis/python-jose/issues/208
+    warnings.filterwarnings("ignore", message="int_from_bytes is deprecated")
+    from jose import JWTError, jwt
+
+# Argon2 is the winner of the 2015 password hashing competion.
+# It is supported by passlib with the recommended argon2_cffi library.
+pwd_context = CryptContext(schemes=["argon2"], deprecated=["auto"])
+
+
+def verify_password(plain_password, hashed_password):
+    """Verify the password, using a constant time equality check."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def hash_password(plain_password):
+    """Hash the password, using the pre-configured CryptContext."""
+    return pwd_context.hash(plain_password)
+
+
+def create_access_token(
+    data: dict,
+    expires_delta: timedelta,
+    secret_key: str,
+    now: Optional[datetime] = None,
+) -> str:
+    """Create a JWT string to act as an OAuth2 access token."""
+    to_encode = data.copy()
+    expire = (now or datetime.utcnow()) + expires_delta
+    to_encode["exp"] = expire
+    encoded_jwt = jwt.encode(to_encode, secret_key, algorithm="HS256")
+    return encoded_jwt
+
+
+def get_subject_from_token(token: str, secret_key: str):
+    """Get the parts of a valid token subject.
+
+    Returns (namespace, identity) if the token is valid
+    Returns (None, None) if the token is expired or invalid, or the payload is invalid.
+    """
+    try:
+        payload = jwt.decode(token, secret_key, algorithms=["HS256"])
+    except JWTError:
+        return None, None
+    sub = payload["sub"]
+    if ":" not in sub:
+        return None, None
+    else:
+        return sub.split(":", 1)
+
+
+class OAuth2ClientCredentialsRequestForm:
+    """
+    Expect OAuth2 client credentials as form request parameters
+
+    This is a dependency class, modeled after OAuth2PasswordRequestForm and similar.
+    Use it like:
+
+        @app.post("/login")
+        def login(form_data: OAuth2ClientCredentialsRequestForm = Depends()):
+            data = form_data.parse()
+            print(data.client_id)
+            for scope in data.scopes:
+                print(scope)
+            return data
+
+    It creates the following Form request parameters in your endpoint:
+    grant_type: the OAuth2 spec says it is required and MUST be the fixed string "client_credentials".
+        Nevertheless, this dependency class is permissive and allows not passing it.
+    scope: Optional string. Several scopes (each one a string) separated by spaces. Currently unused.
+    client_id: optional string. OAuth2 recommends sending the client_id and client_secret (if any)
+        using HTTP Basic auth, as: client_id:client_secret
+    client_secret: optional string. OAuth2 recommends sending the client_id and client_secret (if any)
+        using HTTP Basic auth, as: client_id:client_secret
+    """
+
+    def __init__(
+        self,
+        grant_type: str = Form(None, regex="client_credentials"),
+        scope: str = Form(""),
+        client_id: Optional[str] = Form(None),
+        client_secret: Optional[str] = Form(None),
+    ):
+        self.grant_type = grant_type
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
+class OAuth2ClientCredentials(OAuth2):
+    """
+    Implement OAuth2 client_credentials workflow.
+
+    This is modeled after the OAuth2PasswordBearer and OAuth2AuthorizationCodeBearer
+    classes from FastAPI, but sets auto_error to True to avoid uncovered branches.
+    See https://github.com/tiangolo/fastapi/issues/774 for original implementation,
+    and to check if FastAPI added a similar class.
+
+    See RFC 6749 for details of the client credentials authorization grant.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: str,
+        scheme_name: Optional[str] = None,
+        scopes: Optional[Dict[str, str]] = None,
+    ):
+        if not scopes:
+            scopes = {}
+        flows = OAuthFlowsModel(
+            clientCredentials={"tokenUrl": tokenUrl, "scopes": scopes}
+        )
+        super().__init__(flows=flows, scheme_name=scheme_name, auto_error=True)
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization: str = request.headers.get("Authorization")
+        scheme, param = get_authorization_scheme_param(authorization)
+        if not authorization or scheme.lower() != "bearer":
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Not authenticated",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        return param

--- a/ctms/bin/client_credentials.py
+++ b/ctms/bin/client_credentials.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Generate OAuth2 client credentials."""
+
+import argparse
+import re
+from secrets import token_urlsafe
+
+from ctms import config
+from ctms.auth import hash_password
+from ctms.crud import create_api_client, get_api_client_by_id
+from ctms.database import get_db_engine
+from ctms.schemas import ApiClientSchema
+
+
+def create_secret():
+    """Generate a new secret."""
+    return "secret_" + token_urlsafe(32)
+
+
+def create_client(db, client_id, email, enabled=True):
+    """Return a new OAuth2 client_id and client_secret."""
+    api_client = ApiClientSchema(client_id=client_id, email=email, enabled=enabled)
+    secret = create_secret()
+    create_api_client(db, api_client, secret)
+    db.flush()
+    return (client_id, secret)
+
+
+def update_client(db, client, email=None, enabled=None, new_secret=None):
+    """Update an existing OAuth2 client."""
+    assert not (email is None and enabled is None and new_secret is None)
+    secret = None
+    if email is not None:
+        client.email = email
+    if enabled is not None:
+        client.enabled = enabled
+    if new_secret:
+        client.hashed_secret = hash_password(new_secret)
+    db.flush()
+
+
+def print_new_credentials(
+    client_id,
+    client_secret,
+    settings,
+    sample_email="contact@example.com",
+    sample_token="a_very_long_base64_string",
+    enabled=True,
+):
+
+    print(
+        f"""\
+Your OAuth2 client credentials are:
+
+      client_id: {client_id}
+  client_secret: {client_secret}
+"""
+    )
+
+    if enabled:
+        print(
+            f"""\
+You can generate a token with an Authentication header:
+
+  curl --user {client_id}:{client_secret} -F grant_type=client_credentials {settings.server_prefix}/token
+
+or passing credentials in the form body:
+
+  curl -v -F client_id={client_id} -F client_secret={client_secret} -F grant_type=client_credentials {settings.server_prefix}/token
+
+The JSON response will have an access token, such as:
+
+  {{
+    "access_token": "{sample_token}",
+    "token_type": "bearer",
+    "expires_in": {int(settings.token_expiration.total_seconds())}
+  }}
+
+This can be used to access the API, such as:
+
+  curl --oauth2-bearer {sample_token} {settings.server_prefix}/ctms?primary_email={sample_email}
+
+"""
+        )
+    else:
+        print(
+            "These credentials are currently disabled, and can not be used to get an OAuth2 access token."
+        )
+
+
+def main(db, settings, test_args=None):
+    """
+    Process the command line and create or update client credentials
+
+    db - the database session
+    settings - the application settings
+    test_args - command line arguments for testing, or None to read from sys.argv
+
+    Return is 0 for success, 1 for failure, appropriate for sys.exit()
+    """
+    parser = argparse.ArgumentParser(description="Create or update client credentials.")
+    parser.add_argument("name", help="short name of the client")
+    parser.add_argument("-e", "--email", help="contact email for the client")
+    parser.add_argument(
+        "--enable", action="store_true", help="enable a disabled client"
+    )
+    parser.add_argument(
+        "--disable", action="store_true", help="disable a new or enabled client"
+    )
+    parser.add_argument(
+        "--rotate-secret", action="store_true", help="generate a new secret key"
+    )
+
+    args = parser.parse_args(args=test_args)
+    name = args.name
+    email = args.email
+    enable = args.enable
+    disable = args.disable
+    rotate = args.rotate_secret
+
+    if not re.match(r"^[-_.a-zA-Z0-9]*$", name):
+        print(
+            f"name '{name}' should have only alphanumeric characters, '-', '_', or '.'"
+        )
+        return 1
+
+    if enable and disable:
+        print(f"Can only pick one of --enable and --disable")
+        return 1
+
+    if name.startswith("id_"):
+        client_id = name
+    else:
+        client_id = f"id_{name}"
+    existing = get_api_client_by_id(db, client_id)
+    if existing:
+        if disable and existing.enabled:
+            enabled = False
+        elif enable and not existing.enabled:
+            enabled = True
+        else:
+            enabled = None
+
+        if rotate:
+            new_secret = create_secret()
+        else:
+            new_secret = None
+
+        if new_secret is None and enabled is None and email in (None, existing.email):
+            print(f"Nothing to change for existing credentials for {name}.")
+            return 0
+
+        update_client(db, existing, email=email, enabled=enabled, new_secret=new_secret)
+        db.commit()
+        if new_secret:
+            print_new_credentials(
+                existing.client_id,
+                new_secret,
+                settings,
+                sample_email=email,
+                enabled=enabled,
+            )
+        else:
+            print(f"Credentials for {name} are updated.")
+    else:
+        if email is None:
+            print("email is required for new credentials.")
+            return 1
+
+        enabled = not disable
+        client_id, client_secret = create_client(db, client_id, email, enabled)
+        db.commit()
+        print_new_credentials(
+            client_id, client_secret, settings, sample_email=email, enabled=enabled
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    # Get the database
+    settings = config.Settings()
+    engine, session_factory = get_db_engine(settings)
+    db = session_factory()
+
+    try:
+        ret = main(db, settings)
+    finally:
+        db.close()
+
+    sys.exit(ret)

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     db_url: PostgresDsn
     secret_key: str
     token_expiration: timedelta = timedelta(minutes=60)
+    server_prefix: str = "http://localhost:8000"
 
     class Config:
         env_prefix = "ctms_"

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -1,8 +1,12 @@
+from datetime import timedelta
+
 from pydantic import BaseSettings, PostgresDsn
 
 
 class Settings(BaseSettings):
     db_url: PostgresDsn
+    secret_key: str
+    token_expiration: timedelta = timedelta(minutes=60)
 
     class Config:
         env_prefix = "ctms_"

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -3,10 +3,19 @@ from typing import Dict, List, Optional
 from pydantic import UUID4, EmailStr
 from sqlalchemy.orm import Session
 
-from .models import AmoAccount, Email, FirefoxAccount, Newsletter, VpnWaitlist
+from .auth import hash_password
+from .models import (
+    AmoAccount,
+    ApiClient,
+    Email,
+    FirefoxAccount,
+    Newsletter,
+    VpnWaitlist,
+)
 from .schemas import (
     AddOnsInSchema,
     AddOnsSchema,
+    ApiClientSchema,
     ContactInSchema,
     ContactSchema,
     EmailInSchema,
@@ -173,3 +182,13 @@ def create_contact(db: Session, email_id: UUID4, contact: ContactInSchema):
         create_vpn_waitlist(db, email_id, contact.vpn_waitlist)
     for newsletter in contact.newsletters:
         create_newsletter(db, email_id, newsletter)
+
+
+def create_api_client(db: Session, api_client: ApiClientSchema, secret):
+    hashed_secret = hash_password(secret)
+    db_api_client = ApiClient(hashed_secret=hashed_secret, **api_client.dict())
+    db.add(db_api_client)
+
+
+def get_api_client_by_id(db: Session, client_id: str):
+    return db.query(ApiClient).filter(ApiClient.client_id == client_id).one_or_none()

--- a/ctms/models.py
+++ b/ctms/models.py
@@ -156,3 +156,24 @@ class VpnWaitlist(Base):
     )
 
     email = relationship("Email", back_populates="vpn_waitlist", uselist=False)
+
+
+class ApiClient(Base):
+    """An OAuth2 Client"""
+
+    __tablename__ = "api_client"
+
+    client_id = Column(String(255), primary_key=True)
+    email = Column(String(255), nullable=False)
+    enabled = Column(Boolean, default=True)
+    hashed_secret = Column(String, nullable=False)
+
+    create_timestamp = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=now()
+    )
+    update_timestamp = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=now(),
+        server_onupdate=now(),
+    )

--- a/ctms/schemas/__init__.py
+++ b/ctms/schemas/__init__.py
@@ -1,7 +1,13 @@
 from .addons import AddOnsInSchema, AddOnsSchema
+from .api_client import ApiClientSchema
 from .contact import ContactInSchema, ContactSchema, CTMSResponse, IdentityResponse
 from .email import EmailInSchema, EmailSchema
 from .fxa import FirefoxAccountsInSchema, FirefoxAccountsSchema
 from .newsletter import NewsletterInSchema, NewsletterSchema
 from .vpn import VpnWaitlistInSchema, VpnWaitlistSchema
-from .web import BadRequestResponse, NotFoundResponse
+from .web import (
+    BadRequestResponse,
+    NotFoundResponse,
+    TokenResponse,
+    UnauthorizedResponse,
+)

--- a/ctms/schemas/api_client.py
+++ b/ctms/schemas/api_client.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, EmailStr
+
+
+class ApiClientSchema(BaseModel):
+    """An OAuth2 Client"""
+
+    client_id: str
+    email: EmailStr
+    enabled: bool

--- a/ctms/schemas/web.py
+++ b/ctms/schemas/web.py
@@ -22,3 +22,21 @@ class NotFoundResponse(BaseModel):
         description="A human-readable summary of the issue.",
         example="Unknown contact_id",
     )
+
+
+class TokenResponse(BaseModel):
+    """An OAuth2 Token response."""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+
+
+class UnauthorizedResponse(BaseModel):
+    """Client authorization failed."""
+
+    detail: str = Field(
+        ...,
+        description="A vague description of the authentication issue.",
+        example="Not authenticated",
+    )

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -5,3 +5,6 @@ CTMS_DB_URL=postgresql://postgres@postgres/postgres
 
 # Encryption key for OAuth2 and other hashes
 CTMS_SECRET_KEY=dev_only_secret_key_not_for_production
+
+# Webserver protocol and domain
+CTMS_SERVER_PREFIX=http://localhost:8000

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -2,3 +2,6 @@
 
 # Database
 CTMS_DB_URL=postgresql://postgres@postgres/postgres
+
+# Encryption key for OAuth2 and other hashes
+CTMS_SECRET_KEY=dev_only_secret_key_not_for_production

--- a/guides/developer_setup.md
+++ b/guides/developer_setup.md
@@ -195,6 +195,31 @@ exit
 ```
 
 ---
+## OAuth2 Client Credentials
+
+The API uses [OAuth 2 Client Credentials](https://oauth.net/2/grant-types/client-credentials/)
+for authentication. To generate credentials for your development environment:
+
+```sh
+make shell  # Enter the web container
+poetry install
+ctms/bin/client_credentials.py test --email test@example.com
+```
+
+This will print out new client credentials, such as:
+
+```
+Your OAuth2 client credentials are:
+
+      client_id: id_test
+  client_secret: secret_dGhpcyBpcyBubyBzZWNyZXQu
+
+...
+```
+
+You can use these on the interactive Swagger docs by clicking the "**Authorize**" button.
+
+---
 ## Next Steps
 
 ### Git Strategy

--- a/migrations/versions/20210309_435d9701a9a4_add_api_client_table.py
+++ b/migrations/versions/20210309_435d9701a9a4_add_api_client_table.py
@@ -1,0 +1,42 @@
+"""Add api_client table
+
+Revision ID: 435d9701a9a4
+Revises: 20f05b0d3dc8
+Create Date: 2021-03-09 21:28:16.818488
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "435d9701a9a4"  # pragma: allowlist secret
+down_revision = "20f05b0d3dc8"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "api_client",
+        sa.Column("client_id", sa.String(length=255), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=True),
+        sa.Column("hashed_secret", sa.String(), nullable=False),
+        sa.Column(
+            "create_timestamp",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "update_timestamp",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("client_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("api_client")

--- a/poetry.lock
+++ b/poetry.lock
@@ -17,8 +17,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 [package.dependencies]
 Mako = "*"
 python-dateutil = "*"
-SQLAlchemy = ">=1.3.0"
 python-editor = ">=0.3"
+SQLAlchemy = ">=1.3.0"
 
 [[package]]
 name = "appdirs"
@@ -27,6 +27,23 @@ description = "A small Python module for determining appropriate platform-specif
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "argon2-cffi"
+version = "20.1.0"
+description = "The secure Argon2 password hashing algorithm."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+cffi = ">=1.0.0"
+six = "*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest", "sphinx", "wheel", "pre-commit"]
+docs = ["sphinx"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
 name = "atomicwrites"
@@ -45,10 +62,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 
 [[package]]
 name = "babel"
@@ -70,11 +87,11 @@ optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-stevedore = ">=1.20.0"
-PyYAML = ">=5.3.1"
-six = ">=1.10.0"
 colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
 GitPython = ">=1.0.1"
+PyYAML = ">=5.3.1"
+six = ">=1.10.0"
+stevedore = ">=1.20.0"
 
 [[package]]
 name = "black"
@@ -85,14 +102,14 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-regex = ">=2020.1.8"
-mypy-extensions = ">=0.4.3"
-typed-ast = ">=1.4.0"
-toml = ">=0.10.1"
-typing-extensions = ">=3.7.4"
-pathspec = ">=0.6,<1"
-click = ">=7.1.2"
 appdirs = "*"
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.6,<1"
+regex = ">=2020.1.8"
+toml = ">=0.10.1"
+typed-ast = ">=1.4.0"
+typing-extensions = ">=3.7.4"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -105,6 +122,17 @@ description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "cffi"
+version = "1.14.5"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "cfgv"
@@ -153,6 +181,25 @@ toml = {version = "*", optional = true, markers = "extra == \"toml\""}
 toml = ["toml"]
 
 [[package]]
+name = "cryptography"
+version = "3.4.6"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.12"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
+docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+sdist = ["setuptools-rust (>=0.11.4)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+
+[[package]]
 name = "detect-secrets"
 version = "0.14.3"
 description = "Tool for detecting secrets in the codebase"
@@ -184,11 +231,11 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-doh = ["requests", "requests-toolbelt"]
-curio = ["curio (>=1.2)", "sniffio (>=1.1)"]
-idna = ["idna (>=2.1)"]
-trio = ["trio (>=0.14.0)", "sniffio (>=1.1)"]
 dnssec = ["cryptography (>=2.6)"]
+doh = ["requests", "requests-toolbelt"]
+idna = ["idna (>=2.1)"]
+curio = ["curio (>=1.2)", "sniffio (>=1.1)"]
+trio = ["trio (>=0.14.0)", "sniffio (>=1.1)"]
 
 [[package]]
 name = "docutils"
@@ -197,6 +244,17 @@ description = "Docutils -- Python Documentation Utilities"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "ecdsa"
+version = "0.14.1"
+description = "ECDSA cryptographic signature library (pure python)"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 name = "email-validator"
@@ -223,10 +281,10 @@ pydantic = ">=1.0.0,<2.0.0"
 starlette = "0.13.6"
 
 [package.extras]
-test = ["pytest (==5.4.3)", "pytest-cov (==2.10.0)", "pytest-asyncio (>=0.14.0,<0.15.0)", "mypy (==0.782)", "flake8 (>=3.8.3,<4.0.0)", "black (==19.10b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.15.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<2.0.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.4.0)", "orjson (>=3.2.1,<4.0.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "aiofiles (>=0.5.0,<0.6.0)", "flask (>=1.1.2,<2.0.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.5.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.2.0)", "typer (>=0.3.0,<0.4.0)", "typer-cli (>=0.0.9,<0.0.10)", "pyyaml (>=5.3.1,<6.0.0)"]
 all = ["requests (>=2.24.0,<3.0.0)", "aiofiles (>=0.5.0,<0.6.0)", "jinja2 (>=2.11.2,<3.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<2.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "graphene (>=2.1.8,<3.0.0)", "ujson (>=3.0.0,<4.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn (>=0.11.5,<0.12.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)"]
 dev = ["python-jose[cryptography] (>=3.1.0,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "uvicorn (>=0.11.5,<0.12.0)", "graphene (>=2.1.8,<3.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.5.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.2.0)", "typer (>=0.3.0,<0.4.0)", "typer-cli (>=0.0.9,<0.0.10)", "pyyaml (>=5.3.1,<6.0.0)"]
+test = ["pytest (==5.4.3)", "pytest-cov (==2.10.0)", "pytest-asyncio (>=0.14.0,<0.15.0)", "mypy (==0.782)", "flake8 (>=3.8.3,<4.0.0)", "black (==19.10b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.15.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<2.0.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.4.0)", "orjson (>=3.2.1,<4.0.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "aiofiles (>=0.5.0,<0.6.0)", "flask (>=1.1.2,<2.0.0)"]
 
 [[package]]
 name = "filelock"
@@ -267,10 +325,10 @@ optional = false
 python-versions = ">=3.4"
 
 [package.extras]
-tornado = ["tornado (>=0.2)"]
+eventlet = ["eventlet (>=0.9.7)"]
 gevent = ["gevent (>=0.13)"]
 setproctitle = ["setproctitle"]
-eventlet = ["eventlet (>=0.9.7)"]
+tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "h11"
@@ -343,8 +401,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 toml = {version = "*", optional = true, markers = "extra == \"pyproject\""}
 
 [package.extras]
-pyproject = ["toml"]
 pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
 requirements = ["pipreqs", "pip-api"]
 xdg_home = ["appdirs (>=1.4.0)"]
 
@@ -429,6 +487,23 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 pyparsing = ">=2.0.2"
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+description = "comprehensive password hashing framework supporting over 30 schemes"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+argon2-cffi = {version = ">=18.2.0", optional = true, markers = "extra == \"argon2\""}
+
+[package.extras]
+argon2 = ["argon2-cffi (>=18.2.0)"]
+bcrypt = ["bcrypt (>=3.1.0)"]
+build_docs = ["sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)", "cloud-sptheme (>=1.10.1)"]
+totp = ["cryptography"]
+
+[[package]]
 name = "pathspec"
 version = "0.8.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -467,13 +542,13 @@ optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
-virtualenv = ">=20.0.8"
-pyyaml = ">=5.1"
 cfgv = ">=2.0.0"
-nodeenv = ">=0.11.1"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
 toml = "*"
+virtualenv = ">=20.0.8"
 
 [[package]]
 name = "psycopg2-binary"
@@ -492,6 +567,22 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pyasn1"
+version = "0.4.8"
+description = "ASN.1 types and codecs"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pycparser"
+version = "2.20"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pydantic"
 version = "1.8.1"
 description = "Data validation and settings management using python 3.6 type hinting"
@@ -500,8 +591,8 @@ optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
-typing-extensions = ">=3.7.4.3"
 email-validator = {version = ">=1.0.3", optional = true, markers = "extra == \"email\""}
+typing-extensions = ">=3.7.4.3"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -532,15 +623,15 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-packaging = "*"
-py = ">=1.8.2"
-iniconfig = "*"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-attrs = ">=19.2.0"
-toml = "*"
-pluggy = ">=0.12,<1.0.0a1"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
@@ -563,6 +654,37 @@ description = "Programmatically open an editor, capture the result."
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "python-jose"
+version = "3.2.0"
+description = "JOSE implementation in Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+cryptography = {version = "*", optional = true, markers = "extra == \"cryptography\""}
+ecdsa = "<0.15"
+pyasn1 = "*"
+rsa = "*"
+six = "<2.0"
+
+[package.extras]
+cryptography = ["cryptography"]
+pycrypto = ["pycrypto (>=2.6.0,<2.7.0)", "pyasn1"]
+pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)", "pyasn1"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.5"
+description = "A streaming multipart parser for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.4.0"
 
 [[package]]
 name = "pytz"
@@ -597,14 +719,25 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-idna = ">=2.5,<3"
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "rsa"
+version = "4.7.2"
+description = "Pure-Python RSA implementation"
+category = "main"
+optional = false
+python-versions = ">=3.5, <4"
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "six"
@@ -639,27 +772,27 @@ optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-sphinxcontrib-qthelp = "*"
-imagesize = "*"
-sphinxcontrib-devhelp = "*"
-snowballstemmer = ">=1.1"
-babel = ">=1.3"
 alabaster = ">=0.7,<0.8"
-sphinxcontrib-serializinghtml = "*"
-packaging = "*"
-docutils = ">=0.12"
-Pygments = ">=2.0"
-Jinja2 = ">=2.3"
+babel = ">=1.3"
 colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
+docutils = ">=0.12"
+imagesize = "*"
+Jinja2 = ">=2.3"
+packaging = "*"
+Pygments = ">=2.0"
 requests = ">=2.5.0"
+snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
+sphinxcontrib-devhelp = "*"
 sphinxcontrib-htmlhelp = "*"
 sphinxcontrib-jsmath = "*"
+sphinxcontrib-qthelp = "*"
+sphinxcontrib-serializinghtml = "*"
 
 [package.extras]
-test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 docs = ["sphinxcontrib-websupport"]
 lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.800)", "docutils-stubs"]
+test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -670,8 +803,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-test = ["pytest"]
 lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-devhelp"
@@ -682,8 +815,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-test = ["pytest"]
 lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
@@ -694,8 +827,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-test = ["pytest", "html5lib"]
 lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest", "html5lib"]
 
 [[package]]
 name = "sphinxcontrib-jsmath"
@@ -717,8 +850,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-test = ["pytest"]
 lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-serializinghtml"
@@ -729,8 +862,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-test = ["pytest"]
 lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 name = "sqlalchemy"
@@ -741,16 +874,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-postgresql_pg8000 = ["pg8000 (<1.16.6)"]
-postgresql = ["psycopg2"]
-postgresql_psycopg2cffi = ["psycopg2cffi"]
-pymysql = ["pymysql (<1)", "pymysql"]
+mssql = ["pyodbc"]
 mssql_pymssql = ["pymssql"]
-postgresql_psycopg2binary = ["psycopg2-binary"]
+mssql_pyodbc = ["pyodbc"]
 mysql = ["mysqlclient"]
 oracle = ["cx-oracle"]
-mssql = ["pyodbc"]
-mssql_pyodbc = ["pyodbc"]
+postgresql = ["psycopg2"]
+postgresql_pg8000 = ["pg8000 (<1.16.6)"]
+postgresql_psycopg2binary = ["psycopg2-binary"]
+postgresql_psycopg2cffi = ["psycopg2cffi"]
+pymysql = ["pymysql (<1)", "pymysql"]
 
 [[package]]
 name = "sqlalchemy-utils"
@@ -761,23 +894,23 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-SQLAlchemy = ">=1.0"
 six = "*"
+SQLAlchemy = ">=1.0"
 
 [package.extras]
-test_all = ["anyjson (>=0.3.3)", "arrow (>=0.3.4)", "Babel (>=1.3)", "colour (>=0.0.4)", "cryptography (>=0.6)", "intervals (>=0.7.1)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "phonenumbers (>=5.9.2)", "pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "mock (==2.0.0)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc", "python-dateutil", "furl (>=0.4.1)"]
 anyjson = ["anyjson (>=0.3.3)"]
-pendulum = ["pendulum (>=2.0.5)"]
-color = ["colour (>=0.0.4)"]
-babel = ["Babel (>=1.3)"]
-phone = ["phonenumbers (>=5.9.2)"]
-intervals = ["intervals (>=0.7.1)"]
-url = ["furl (>=0.4.1)"]
 arrow = ["arrow (>=0.3.4)"]
+babel = ["Babel (>=1.3)"]
+color = ["colour (>=0.0.4)"]
 encrypted = ["cryptography (>=0.6)"]
-test = ["pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "mock (==2.0.0)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc"]
-timezone = ["python-dateutil"]
+intervals = ["intervals (>=0.7.1)"]
 password = ["passlib (>=1.6,<2.0)"]
+pendulum = ["pendulum (>=2.0.5)"]
+phone = ["phonenumbers (>=5.9.2)"]
+test = ["pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "mock (==2.0.0)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc"]
+test_all = ["anyjson (>=0.3.3)", "arrow (>=0.3.4)", "Babel (>=1.3)", "colour (>=0.0.4)", "cryptography (>=0.6)", "intervals (>=0.7.1)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "phonenumbers (>=5.9.2)", "pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "mock (==2.0.0)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc", "python-dateutil", "furl (>=0.4.1)"]
+timezone = ["python-dateutil"]
+url = ["furl (>=0.4.1)"]
 
 [[package]]
 name = "starlette"
@@ -848,8 +981,8 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-h11 = ">=0.8"
 click = ">=7.0.0,<8.0.0"
+h11 = ">=0.8"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
@@ -864,11 +997,11 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 six = ">=1.9.0,<2"
-appdirs = ">=1.4.3,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
@@ -889,7 +1022,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <4"
-content-hash = "145b538d62cca80cc889e605b806ce4c7275e8ce27c7b1901dd2b29b93ad3fdb"
+content-hash = "c3965aee8088ad97793cd6764ef2d910ed5a6f017a0dfb41f7a0aa3d7b2d9f5d"
 
 [metadata.files]
 alabaster = [
@@ -903,6 +1036,26 @@ alembic = [
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+argon2-cffi = [
+    {file = "argon2-cffi-20.1.0.tar.gz", hash = "sha256:d8029b2d3e4b4cea770e9e5a0104dd8fa185c1724a0f01528ae4826a6d25f97d"},
+    {file = "argon2_cffi-20.1.0-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:6ea92c980586931a816d61e4faf6c192b4abce89aa767ff6581e6ddc985ed003"},
+    {file = "argon2_cffi-20.1.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:05a8ac07c7026542377e38389638a8a1e9b78f1cd8439cd7493b39f08dd75fbf"},
+    {file = "argon2_cffi-20.1.0-cp27-cp27m-win32.whl", hash = "sha256:0bf066bc049332489bb2d75f69216416329d9dc65deee127152caeb16e5ce7d5"},
+    {file = "argon2_cffi-20.1.0-cp27-cp27m-win_amd64.whl", hash = "sha256:57358570592c46c420300ec94f2ff3b32cbccd10d38bdc12dc6979c4a8484fbc"},
+    {file = "argon2_cffi-20.1.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:7d455c802727710e9dfa69b74ccaab04568386ca17b0ad36350b622cd34606fe"},
+    {file = "argon2_cffi-20.1.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:b160416adc0f012fb1f12588a5e6954889510f82f698e23ed4f4fa57f12a0647"},
+    {file = "argon2_cffi-20.1.0-cp35-cp35m-win32.whl", hash = "sha256:9bee3212ba4f560af397b6d7146848c32a800652301843df06b9e8f68f0f7361"},
+    {file = "argon2_cffi-20.1.0-cp35-cp35m-win_amd64.whl", hash = "sha256:392c3c2ef91d12da510cfb6f9bae52512a4552573a9e27600bdb800e05905d2b"},
+    {file = "argon2_cffi-20.1.0-cp36-cp36m-win32.whl", hash = "sha256:ba7209b608945b889457f949cc04c8e762bed4fe3fec88ae9a6b7765ae82e496"},
+    {file = "argon2_cffi-20.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:da7f0445b71db6d3a72462e04f36544b0de871289b0bc8a7cc87c0f5ec7079fa"},
+    {file = "argon2_cffi-20.1.0-cp37-abi3-macosx_10_6_intel.whl", hash = "sha256:cc0e028b209a5483b6846053d5fd7165f460a1f14774d79e632e75e7ae64b82b"},
+    {file = "argon2_cffi-20.1.0-cp37-cp37m-win32.whl", hash = "sha256:18dee20e25e4be86680b178b35ccfc5d495ebd5792cd00781548d50880fee5c5"},
+    {file = "argon2_cffi-20.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:6678bb047373f52bcff02db8afab0d2a77d83bde61cfecea7c5c62e2335cb203"},
+    {file = "argon2_cffi-20.1.0-cp38-cp38-win32.whl", hash = "sha256:77e909cc756ef81d6abb60524d259d959bab384832f0c651ed7dcb6e5ccdbb78"},
+    {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
+    {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
+    {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -926,6 +1079,45 @@ black = [
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
     {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+]
+cffi = [
+    {file = "cffi-1.14.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991"},
+    {file = "cffi-1.14.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1"},
+    {file = "cffi-1.14.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:99cd03ae7988a93dd00bcd9d0b75e1f6c426063d6f03d2f90b89e29b25b82dfa"},
+    {file = "cffi-1.14.5-cp27-cp27m-win32.whl", hash = "sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3"},
+    {file = "cffi-1.14.5-cp27-cp27m-win_amd64.whl", hash = "sha256:51182f8927c5af975fece87b1b369f722c570fe169f9880764b1ee3bca8347b5"},
+    {file = "cffi-1.14.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482"},
+    {file = "cffi-1.14.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6"},
+    {file = "cffi-1.14.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045"},
+    {file = "cffi-1.14.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a465da611f6fa124963b91bf432d960a555563efe4ed1cc403ba5077b15370aa"},
+    {file = "cffi-1.14.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406"},
+    {file = "cffi-1.14.5-cp35-cp35m-win32.whl", hash = "sha256:72d8d3ef52c208ee1c7b2e341f7d71c6fd3157138abf1a95166e6165dd5d4369"},
+    {file = "cffi-1.14.5-cp35-cp35m-win_amd64.whl", hash = "sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315"},
+    {file = "cffi-1.14.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
+    {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
+    {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
+    {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
+    {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
+    {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
+    {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
+    {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
+    {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
+    {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
+    {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
+    {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
+    {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
 ]
 cfgv = [
     {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
@@ -997,6 +1189,20 @@ coverage = [
     {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
+cryptography = [
+    {file = "cryptography-3.4.6-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:57ad77d32917bc55299b16d3b996ffa42a1c73c6cfa829b14043c561288d2799"},
+    {file = "cryptography-3.4.6-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:4169a27b818de4a1860720108b55a2801f32b6ae79e7f99c00d79f2a2822eeb7"},
+    {file = "cryptography-3.4.6-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:93cfe5b7ff006de13e1e89830810ecbd014791b042cbe5eec253be11ac2b28f3"},
+    {file = "cryptography-3.4.6-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:5ecf2bcb34d17415e89b546dbb44e73080f747e504273e4d4987630493cded1b"},
+    {file = "cryptography-3.4.6-cp36-abi3-manylinux2014_x86_64.whl", hash = "sha256:fec7fb46b10da10d9e1d078d1ff8ed9e05ae14f431fdbd11145edd0550b9a964"},
+    {file = "cryptography-3.4.6-cp36-abi3-win32.whl", hash = "sha256:df186fcbf86dc1ce56305becb8434e4b6b7504bc724b71ad7a3239e0c9d14ef2"},
+    {file = "cryptography-3.4.6-cp36-abi3-win_amd64.whl", hash = "sha256:66b57a9ca4b3221d51b237094b0303843b914b7d5afd4349970bb26518e350b0"},
+    {file = "cryptography-3.4.6-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:066bc53f052dfeda2f2d7c195cf16fb3e5ff13e1b6b7415b468514b40b381a5b"},
+    {file = "cryptography-3.4.6-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:600cf9bfe75e96d965509a4c0b2b183f74a4fa6f5331dcb40fb7b77b7c2484df"},
+    {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:0923ba600d00718d63a3976f23cab19aef10c1765038945628cd9be047ad0336"},
+    {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:9e98b452132963678e3ac6c73f7010fe53adf72209a32854d55690acac3f6724"},
+    {file = "cryptography-3.4.6.tar.gz", hash = "sha256:2d32223e5b0ee02943f32b19245b61a62db83a882f0e76cc564e1cec60d48f87"},
+]
 detect-secrets = [
     {file = "detect_secrets-0.14.3-py2.py3-none-any.whl", hash = "sha256:dc56fb75ddc221eed4e998127230b59154024910121778bf38100a29da04c5cd"},
     {file = "detect_secrets-0.14.3.tar.gz", hash = "sha256:953466e6e4a698cd6ee5bce060173889d7383a7ebf7a2cf3774ab7718bf826a3"},
@@ -1012,6 +1218,10 @@ dnspython = [
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
+]
+ecdsa = [
+    {file = "ecdsa-0.14.1-py2.py3-none-any.whl", hash = "sha256:e108a5fe92c67639abae3260e43561af914e7fd0d27bae6d2ec1312ae7934dfe"},
+    {file = "ecdsa-0.14.1.tar.gz", hash = "sha256:64c613005f13efec6541bb0a33290d0d03c27abab5f15fbab20fb0ee162bdd8e"},
 ]
 email-validator = [
     {file = "email-validator-1.1.2.tar.gz", hash = "sha256:1a13bd6050d1db4475f13e444e169b6fe872434922d38968c67cea9568cce2f0"},
@@ -1135,6 +1345,10 @@ packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
+passlib = [
+    {file = "passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1"},
+    {file = "passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"},
+]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
@@ -1182,12 +1396,34 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win32.whl", hash = "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win_amd64.whl", hash = "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-macosx_10_9_x86_64.macosx_10_9_intel.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win32.whl", hash = "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pycparser = [
+    {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
+    {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
 pydantic = [
     {file = "pydantic-1.8.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0c40162796fc8d0aa744875b60e4dc36834db9f2a25dbf9ba9664b1915a23850"},
@@ -1235,6 +1471,13 @@ python-editor = [
     {file = "python_editor-1.0.4-py2.7.egg", hash = "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522"},
     {file = "python_editor-1.0.4-py3-none-any.whl", hash = "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d"},
     {file = "python_editor-1.0.4-py3.5.egg", hash = "sha256:c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77"},
+]
+python-jose = [
+    {file = "python-jose-3.2.0.tar.gz", hash = "sha256:4e4192402e100b5fb09de5a8ea6bcc39c36ad4526341c123d401e2561720335b"},
+    {file = "python_jose-3.2.0-py2.py3-none-any.whl", hash = "sha256:67d7dfff599df676b04a996520d9be90d6cdb7e6dd10b4c7cacc0c3e2e92f2be"},
+]
+python-multipart = [
+    {file = "python-multipart-0.0.5.tar.gz", hash = "sha256:f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
@@ -1309,6 +1552,10 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+rsa = [
+    {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
+    {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ pydantic = {extras = ["email"], version = "^1.7.3"}
 psycopg2-binary = "^2.8.6"
 SQLAlchemy = "^1.3.23"
 alembic = "^1.5.4"
+python-multipart = "^0.0.5"
+python-jose = {extras = ["cryptography"], version = "^3.2.0"}
+passlib = {extras = ["argon2"], version = "^1.7.4"}
+
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.7.1"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,17 +9,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 
-from ctms.app import app, get_db
+from ctms.app import app, get_api_client, get_db
 from ctms.config import Settings
 from ctms.crud import create_contact, get_contacts_by_any_id
 from ctms.models import Base
 from ctms.sample_data import SAMPLE_CONTACTS
-from ctms.schemas import ContactInSchema, ContactSchema
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
+from ctms.schemas import ApiClientSchema, ContactInSchema, ContactSchema
 
 
 @pytest.fixture(scope="session")
@@ -127,3 +122,23 @@ def sample_contacts(minimal_contact, maximal_contact, example_contact):
         "maximal": (maximal_contact.email.email_id, maximal_contact),
         "example": (example_contact.email.email_id, example_contact),
     }
+
+
+@pytest.fixture
+def anon_client():
+    """A test client with no authorization."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def client(anon_client):
+    """A test client that passed a valid OAuth2 token."""
+
+    def test_api_client():
+        return ApiClientSchema(
+            client_id="test_client", email="test_client@example.com", enabled=True
+        )
+
+    app.dependency_overrides[get_api_client] = test_api_client
+    yield anon_client
+    del app.dependency_overrides[get_api_client]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,9 +1,9 @@
 """pytest tests for basic app functionality"""
 
 
-def test_read_root(client):
+def test_read_root(anon_client):
     """The site root redirects to the Swagger docs"""
-    resp = client.get("/")
+    resp = anon_client.get("/")
     assert resp.status_code == 200
     assert len(resp.history) == 1
     prev_resp = resp.history[0]
@@ -11,8 +11,8 @@ def test_read_root(client):
     assert prev_resp.headers["location"] == "./docs"
 
 
-def test_read_health(client):
+def test_read_health(anon_client):
     """The platform calls /health to check app readiness."""
-    resp = client.get("/health")
+    resp = anon_client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == [{"health": "OK"}, 200]

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,251 @@
+"""Test authentication"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from jose import jwt
+from requests.auth import HTTPBasicAuth
+
+from ctms.app import app, token_settings
+from ctms.auth import create_access_token, hash_password, verify_password
+from ctms.crud import create_api_client, get_api_client_by_id
+from ctms.models import ApiClient
+from ctms.schemas import ApiClientSchema
+
+
+@pytest.fixture
+def client_id_and_secret(dbsession):
+    """Return valid OAuth2 client_id and client_secret."""
+    api_client = ApiClientSchema(
+        client_id="id_db_api_client", email="db_api_client@example.com", enabled=True
+    )
+    secret = "secret_what_a_weird_random_string"  # pragma: allowlist secret
+    create_api_client(dbsession, api_client, secret)
+    dbsession.flush()
+    return (api_client.client_id, secret)
+
+
+@pytest.fixture
+def test_token_settings():
+    """Set token settings for tests."""
+
+    settings = {
+        "expires_delta": timedelta(minutes=5),
+        "secret_key": "AN_AWESOME_RANDOM_SECRET_KEY",
+    }
+
+    app.dependency_overrides[token_settings] = lambda: settings
+    yield settings
+    del app.dependency_overrides[token_settings]
+
+
+def test_post_token_header(anon_client, test_token_settings, client_id_and_secret):
+    """A backend client can post crendentials in the header"""
+    client_id, client_secret = client_id_and_secret
+    resp = anon_client.post(
+        "/token",
+        {"grant_type": "client_credentials"},
+        auth=HTTPBasicAuth(client_id, client_secret),
+    )
+    assert resp.status_code == 200
+    content = resp.json()
+    assert content["token_type"] == "bearer"
+    assert content["expires_in"] == 5 * 60
+    payload = jwt.decode(
+        content["access_token"],
+        test_token_settings["secret_key"],
+    )
+    assert payload["sub"] == f"api_client:{client_id}"
+    expected_expires = (
+        datetime.utcnow() + test_token_settings["expires_delta"]
+    ).timestamp()
+    assert -2.0 < (expected_expires - payload["exp"]) < 2.0
+
+
+def test_post_token_form_data(anon_client, test_token_settings, client_id_and_secret):
+    """A backend client can post crendentials in body as form data"""
+
+    client_id, client_secret = client_id_and_secret
+    resp = anon_client.post(
+        "/token",
+        {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+    )
+    assert resp.status_code == 200
+    content = resp.json()
+    assert content["token_type"] == "bearer"
+    payload = jwt.decode(
+        content["access_token"],
+        test_token_settings["secret_key"],
+    )
+    assert payload["sub"] == f"api_client:{client_id}"
+    expected_expires = (
+        datetime.utcnow() + test_token_settings["expires_delta"]
+    ).timestamp()
+    assert -2.0 < (expected_expires - payload["exp"]) < 2.0
+
+
+def test_post_token_succeeds_no_grant(anon_client, client_id_and_secret):
+    """If grant_type is omitted, client_credentials is assumed."""
+    resp = anon_client.post(
+        "/token",
+        auth=HTTPBasicAuth(*client_id_and_secret),
+    )
+    assert resp.status_code == 200
+
+
+def test_post_token_fails_wrong_grant(anon_client, client_id_and_secret):
+    """If grant_type is omitted, getting a token fails."""
+    resp = anon_client.post(
+        "/token",
+        {"grant_type": "password"},
+        auth=HTTPBasicAuth(*client_id_and_secret),
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0] == {
+        "ctx": {"pattern": "client_credentials"},
+        "loc": ["body", "grant_type"],
+        "msg": 'string does not match regex "client_credentials"',
+        "type": "value_error.str.regex",
+    }
+
+
+def test_post_token_fails_no_credentials(anon_client, dbsession):
+    """If no credentials are passed, token generation fails."""
+    resp = anon_client.post("/token", {"grant_type": "client_credentials"})
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "Incorrect username or password"}
+
+
+def test_post_token_fails_bad_credentials(anon_client, client_id_and_secret):
+    """Authentication fails on bad credentials."""
+    good_id, good_secret = client_id_and_secret
+    resp = anon_client.post("/token", auth=HTTPBasicAuth(good_id, good_secret + "x"))
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "Incorrect username or password"}
+
+
+def test_post_token_fails_disabled_client(dbsession, anon_client, client_id_and_secret):
+    """Authentication fails when the client is disabled."""
+    client_id, client_secret = client_id_and_secret
+    api_client = get_api_client_by_id(dbsession, client_id)
+    api_client.enabled = False
+    dbsession.commit()
+    resp = anon_client.post("/token", auth=HTTPBasicAuth(client_id, client_secret))
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "Incorrect username or password"}
+
+
+def test_get_ctms_with_token(
+    example_contact, anon_client, test_token_settings, client_id_and_secret
+):
+    """An authenticated API can be fetched with a valid token"""
+    client_id, client_secret = client_id_and_secret
+    token = create_access_token(
+        {"sub": f"api_client:{client_id}"}, **test_token_settings
+    )
+    resp = anon_client.get(
+        f"/ctms/{example_contact.email.email_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_get_ctms_with_invalid_token_fails(
+    example_contact, anon_client, test_token_settings, client_id_and_secret
+):
+    """Calling an authenticated API with an invalid token is an error"""
+    client_id, client_secret = client_id_and_secret
+    token = create_access_token(
+        {"sub": f"api_client:{client_id}"},
+        secret_key="secret_key_from_other_deploy",
+        expires_delta=test_token_settings["expires_delta"],
+    )
+    resp = anon_client.get(
+        f"/ctms/{example_contact.email.email_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Could not validate credentials"}
+
+
+def test_get_ctms_with_invalid_namespace_fails(
+    example_contact, anon_client, test_token_settings, client_id_and_secret
+):
+    """Calling an authenticated API with an unexpected namespace is an error"""
+    client_id, client_secret = client_id_and_secret
+    token = create_access_token({"sub": f"unknown:{client_id}"}, **test_token_settings)
+    resp = anon_client.get(
+        f"/ctms/{example_contact.email.email_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Could not validate credentials"}
+
+
+def test_get_ctms_with_unknown_client_fails(
+    example_contact, anon_client, test_token_settings, client_id_and_secret
+):
+    """A token with an unknown (deleted?) API client name is an error"""
+    client_id, client_secret = client_id_and_secret
+    token = create_access_token(
+        {"sub": f"api_client:not_{client_id}"}, **test_token_settings
+    )
+    resp = anon_client.get(
+        f"/ctms/{example_contact.email.email_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Could not validate credentials"}
+
+
+def test_get_ctms_with_expired_token_fails(
+    example_contact, anon_client, test_token_settings, client_id_and_secret
+):
+    """Calling an authenticated API with an expired token is an error"""
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    client_id, client_secret = client_id_and_secret
+    token = create_access_token(
+        {"sub": f"api_client:{client_id}"}, **test_token_settings, now=yesterday
+    )
+    resp = anon_client.get(
+        f"/ctms/{example_contact.email.email_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Could not validate credentials"}
+
+
+def test_get_ctms_with_disabled_client_fails(
+    dbsession, example_contact, anon_client, test_token_settings, client_id_and_secret
+):
+    """Calling an authenticated API with a valid token for an expired client is an error."""
+    client_id, client_secret = client_id_and_secret
+    token = create_access_token(
+        {"sub": f"api_client:{client_id}"}, **test_token_settings
+    )
+    api_client = get_api_client_by_id(dbsession, client_id)
+    api_client.enabled = False
+    dbsession.commit()
+
+    resp = anon_client.get(
+        f"/ctms/{example_contact.email.email_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "API Client has been disabled"}
+
+
+def test_hashed_passwords():
+    """Hashed passwords have unique salts"""
+    hashed1 = hash_password("password")
+    assert hashed1 != "password"
+    assert verify_password("password", hashed1)
+    assert not verify_password("xpassword", hashed1)
+
+    hashed2 = hash_password("password")
+    assert verify_password("password", hashed1)
+    assert hashed1 != hashed2

--- a/tests/unit/test_bin_client_credentials.py
+++ b/tests/unit/test_bin_client_credentials.py
@@ -1,0 +1,148 @@
+"""Tests for ctms/bin/client_credentials.py"""
+
+import pytest
+
+from ctms.bin.client_credentials import main
+from ctms.config import Settings
+from ctms.models import ApiClient
+
+
+@pytest.fixture
+def settings():
+    return Settings()
+
+
+@pytest.fixture
+def existing_client(dbsession):
+    client = ApiClient(
+        client_id="id_existing", email="existing@example.com", hashed_secret="password"
+    )
+    dbsession.add(client)
+    dbsession.flush()
+    return client
+
+
+def test_create(dbsession, settings):
+    """New client credentials can be generated, with id_ prefixed to the client_id."""
+    ret = main(dbsession, settings, ["test", "--email", "test@example.com"])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.client_id == "id_test"
+    assert client.email == "test@example.com"
+    assert client.enabled == True
+
+
+def test_create_explicit_id(dbsession, settings):
+    """A id_ prefix is not added if it is already there."""
+    ret = main(dbsession, settings, ["id_tst", "--email", "test@example.com"])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.client_id == "id_tst"
+    assert client.email == "test@example.com"
+    assert client.enabled == True
+
+
+def test_create_disabled(dbsession, settings):
+    """New client credentials can be generated as disabled."""
+    ret = main(
+        dbsession, settings, ["test2", "--email", "test@example.com", "--disable"]
+    )
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.client_id == "id_test2"
+    assert client.email == "test@example.com"
+    assert client.enabled == False
+
+
+def test_create_email_required(dbsession, settings):
+    """The email is required when generating new client credentials."""
+    ret = main(dbsession, settings, ["test"])
+    assert ret == 1
+
+    assert dbsession.query(ApiClient).first() is None
+
+
+@pytest.mark.parametrize(
+    "client_id", ("service.mozilla.com", "1-800-Contacts", "under_score.js")
+)
+def test_create_valid_client_id(dbsession, settings, client_id):
+    """Some punctuation is allowed."""
+    ret = main(dbsession, settings, [client_id, "--email", "test@example.com"])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.client_id == f"id_{client_id}"
+    assert client.email == "test@example.com"
+    assert client.enabled == True
+
+
+@pytest.mark.parametrize("client_id", ("test@example.com", "Résumé", "💩.la"))
+def test_create_bad_client_id_fails(dbsession, settings, client_id):
+    """A client_id must be alphanume New client credentials can be generated."""
+    ret = main(dbsession, settings, [client_id, "--email", "test@example.com"])
+    assert ret == 1
+    assert dbsession.query(ApiClient).first() is None
+
+
+def test_update_email(dbsession, settings, existing_client):
+    """The email of an existing client can be changed."""
+    new_email = "new@example.com"
+    assert existing_client.email != new_email
+    ret = main(dbsession, settings, [existing_client.client_id, "--email", new_email])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.email == new_email
+
+
+def test_update_disable(dbsession, settings, existing_client):
+    """A client can be disabled."""
+    assert existing_client.enabled
+    ret = main(dbsession, settings, [existing_client.client_id, "--disable"])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert not client.enabled
+
+
+def test_update_enable(dbsession, settings, existing_client):
+    """A disabled client can be enabled."""
+    existing_client.enabled = False
+    dbsession.flush()
+    ret = main(dbsession, settings, [existing_client.client_id, "--enable"])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.enabled
+
+
+def test_update_enable_and_disable_fails(dbsession, settings, existing_client):
+    """Picking enable and disable is an error."""
+    ret = main(
+        dbsession, settings, [existing_client.client_id, "--disable", "--enable"]
+    )
+    assert ret == 1
+    client = dbsession.query(ApiClient).one()
+    assert client.enabled
+
+
+def test_update_secret(dbsession, settings, existing_client):
+    """A client can get new credentials."""
+    old_secret = existing_client.hashed_secret
+    ret = main(dbsession, settings, [existing_client.client_id, "--rotate-secret"])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.hashed_secret != old_secret
+
+
+def test_update_nothing(dbsession, settings, existing_client):
+    """It is valid to do nothing to an existing client."""
+    ret = main(dbsession, settings, [existing_client.client_id])
+    assert ret == 0
+
+    client = dbsession.query(ApiClient).one()
+    assert client.client_id == existing_client.client_id

--- a/tests/unit/test_private_api.py
+++ b/tests/unit/test_private_api.py
@@ -1,6 +1,31 @@
 """Tests for the private APIs that may be removed."""
+from typing import Any, Tuple
 
 import pytest
+
+API_TEST_CASES: Tuple[Tuple[str, Any], ...] = (
+    ("/identities", {"basket_token": "c4a7d759-bb52-457b-896b-90f1d3ef8433"}),
+    ("/identity/332de237-cab7-4461-bcc3-48e68f42bd5c", {}),
+    ("/contact/email/332de237-cab7-4461-bcc3-48e68f42bd5c", {}),
+    ("/contact/amo/332de237-cab7-4461-bcc3-48e68f42bd5c", {}),
+    ("/contact/vpn_waitlist/332de237-cab7-4461-bcc3-48e68f42bd5c", {}),
+    ("/contact/fxa/332de237-cab7-4461-bcc3-48e68f42bd5c", {}),
+)
+
+
+@pytest.mark.parametrize("path,params", API_TEST_CASES)
+def test_unauthorized_api_call_fails(anon_client, example_contact, path, params):
+    """Calling the API without credentials fails."""
+    resp = anon_client.get(path, params=params)
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Not authenticated"}
+
+
+@pytest.mark.parametrize("path,params", API_TEST_CASES)
+def test_authorized_api_call_succeeds(client, example_contact, path, params):
+    """Calling the API without credentials fails."""
+    resp = client.get(path, params=params)
+    assert resp.status_code == 200
 
 
 def identity_response_for_contact(contact):


### PR DESCRIPTION
## Proposed changes

To fix issue #57, add [OAuth2 authentication](https://tools.ietf.org/html/rfc6749) using [client credentials](https://oauth.net/2/grant-types/client-credentials/).

A new endpoint `/token` implements the OAuth2 client credentials grant process. A caller passes a ``client_id`` and a ``client_secret``, either in the form body or a header, and gets an OAuth2 token that expires. The token is implemented as a [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) or JWT, signed by the server (HMAC with SHA-256). When the token expires (default of 60 minutes), the client calls ``/token`` again.
    
All API endpoints now require a bearer token. The Swagger API docs already include a mechanism for authenticating in the browser.

There's a new database table ``api_client`` that stores the details for the API clients, along with an alembic migration. A script ``ctms/bin/client_credentials.py`` can create these. See below for an example.



There are new application settings:
    
 * ``CTMS_SECRET_KEY ``- A long string used in JWT signing. There is a default for development, and it should be unique for each deployment.
 * ``CTMS_TOKEN_EXPIRATION`` - How long, in seconds, that access tokens are valid. Default is 60 minutes.
 * ``CTMS_SERVER_PREFIX`` - The prefix of the server URL, defaults to the dev value of ``http://localhost:8000``. Currently used in the output of ``client_credentials.py``, but it may be handy for CSP or other uses.

## Types of changes

What types of changes does your code introduce?
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- [x] I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- [x] Lint and tests pass both locally and on the cicd with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules

## Further comments

Sorry for the size of this PR. It is hard to do just a part of a security feature.

Here's how to use ``client_credentials.py`` in a local development environment:

```sh
make shell             # Enter a docker shell
poetry install         # Get ctms into Python path
alembic upgrade head   # Add the api_client table
ctms/bin/client_credentials.py test --email test@example.com
``` 

This will print something like:
```
Your OAuth2 client credentials are:

      client_id: id_test
  client_secret: secret_gPwcXQLSOXSYfpKxzjA5DBSQLDNL__MMkBBm2auWyxI

You can generate a token with an Authentication header:

  curl --user id_test:secret_gPwcXQLSOXSYfpKxzjA5DBSQLDNL__MMkBBm2auWyxI -F grant_type=client_credentials http://localhost:8000/token

or passing credentials in the form body:

  curl -v -F client_id=id_test -F client_secret=secret_gPwcXQLSOXSYfpKxzjA5DBSQLDNL__MMkBBm2auWyxI -F grant_type=client_credentials http://localhost:8000/token

The JSON response will have an access token, such as:

  {
    "access_token": "a_very_long_base64_string",
    "token_type": "bearer",
    "expires_in": 3600
  }

This can be used to access the API, such as:

  curl --oauth2-bearer a_very_long_base64_string http://localhost:8000/ctms?primary_email=test@example.com
```

You can then start the webserver (``make start`` in a different terminal) and enter the credentials into http://localhost:8000/docs.  The "Authorize" button in the Swagger docs is over by the right side:

![CTMS authorize](https://user-images.githubusercontent.com/286017/110559312-976b1c00-8109-11eb-9844-688d00c7204b.png)

You need to authorize before you can use the API endpoints, as hinted by the lock icons.