### PR TITLE
Changing Dockerfile to listen on port 8000

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,4 +95,4 @@ ENTRYPOINT /docker-entrypoint.sh $0 $@
 
 EXPOSE 80
 
-CMD ["uvicorn", "ctms.app:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "ctms.app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Will be worked on in more depth in https://github.com/mozilla-it/ctms-api/issues/89
but, our helm chart exports port 8000 at the moment, and since that's where we are planning on ending up
making this quick change now.