### PR TITLE
Move alembic to prod container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ gunicorn = "^20.0.4"
 pydantic = {extras = ["email"], version = "^1.7.3"}
 psycopg2-binary = "^2.8.6"
 SQLAlchemy = "^1.3.23"
-
+alembic = "^1.5.4"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.7.1"
@@ -39,7 +39,7 @@ mypy = "^0.782"
 detect-secrets = "^0.14.3"
 bandit = "^1.7.0"
 SQLAlchemy-Utils = "^0.36.8"
-alembic = "^1.5.4"
+
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ detect-secrets = "^0.14.3"
 bandit = "^1.7.0"
 SQLAlchemy-Utils = "^0.36.8"
 
-
 [tool.pytest.ini_options]
 testpaths = [
     "tests/unit",


### PR DESCRIPTION
To get migrations working in prod we need the prod container to have alembic
Rather than running a different container for migrating the db
moving the dependency to the prod container