### PR TITLE
Refactor complete contact queries

### DIFF
--- a/ctms/models.py
+++ b/ctms/models.py
@@ -44,7 +44,9 @@ class Email(Base):
         server_onupdate=now(),
     )
 
-    newsletters = relationship("Newsletter", back_populates="email")
+    newsletters = relationship(
+        "Newsletter", back_populates="email", order_by="Newsletter.name"
+    )
     fxa = relationship("FirefoxAccount", back_populates="email", uselist=False)
     amo = relationship("AmoAccount", back_populates="email", uselist=False)
     vpn_waitlist = relationship("VpnWaitlist", back_populates="email", uselist=False)

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -1,0 +1,149 @@
+"""Test database operations"""
+
+from uuid import uuid4
+
+import pytest
+import sqlalchemy.event
+
+from ctms.crud import (
+    create_amo,
+    create_email,
+    create_fxa,
+    create_newsletter,
+    get_contact_by_email_id,
+    get_contacts_by_any_id,
+)
+from ctms.schemas import (
+    AddOnsInSchema,
+    EmailInSchema,
+    FirefoxAccountsInSchema,
+    NewsletterInSchema,
+)
+
+
+class StatementWatcher:
+    """
+    Capture SQL statements emitted by code.
+
+    Based on https://stackoverflow.com/a/33691585/10612
+
+    Use as a context manager to count the number of execute()'s performed
+    against the given session / connection.
+
+    Usage:
+        with StatementWatcher(dbsession.connection()) as sw:
+            dbsession.query(Email).all()
+        assert sw.count == 1
+    """
+
+    def __init__(self, connection):
+        self.connection = connection
+        self.statements = []
+
+    def __enter__(self):
+        sqlalchemy.event.listen(self.connection, "before_cursor_execute", self.callback)
+        return self
+
+    def __exit__(self, *args):
+        sqlalchemy.event.remove(self.connection, "before_cursor_execute", self.callback)
+
+    def callback(self, conn, cursor, statement, parameters, context, execute_many):
+        self.statements.append((statement, parameters, execute_many))
+
+    @property
+    def count(self):
+        return len(self.statements)
+
+
+def test_get_contact_by_email_id_found(dbsession, example_contact):
+    """A contact is retrived in two queries, and newsletters are sorted by name."""
+    email_id = example_contact.email.email_id
+    with StatementWatcher(dbsession.connection()) as sw:
+        contact = get_contact_by_email_id(dbsession, email_id)
+    assert sw.count == 2
+    assert contact["email"].email_id == email_id
+    newsletter_names = [nl.name for nl in contact["newsletters"]]
+    assert newsletter_names == ["firefox-welcome", "mozilla-welcome"]
+    assert sorted(newsletter_names) == newsletter_names
+
+
+def test_get_contact_by_email_id_miss(dbsession):
+    """A missed contact is 1 query."""
+    with StatementWatcher(dbsession.connection()) as sw:
+        contact = get_contact_by_email_id(dbsession, str(uuid4()))
+    assert sw.count == 1
+    assert contact is None
+
+
+@pytest.mark.parametrize(
+    "alt_id_name,alt_id_value",
+    [
+        ("email_id", "67e52c77-950f-4f28-accb-bb3ea1a2c51a"),
+        ("primary_email", "mozilla-fan@example.com"),
+        ("amo_user_id", "123"),
+        ("basket_token", "d9ba6182-f5dd-4728-a477-2cc11bf62b69"),
+        ("fxa_id", "611b6788-2bba-42a6-98c9-9ce6eb9cbd34"),
+        ("fxa_primary_email", "fxa-firefox-fan@example.com"),
+        ("sfdc_id", "001A000001aMozFan"),
+        ("mofo_id", "195207d2-63f2-4c9f-b149-80e9c408477a"),
+    ],
+)
+def test_get_contact_by_any_id(dbsession, sample_contacts, alt_id_name, alt_id_value):
+    """A contacts is fetched by alternate id in two queries."""
+    with StatementWatcher(dbsession.connection()) as sw:
+        contacts = get_contacts_by_any_id(dbsession, **{alt_id_name: alt_id_value})
+    assert sw.count == 2
+    assert len(contacts) == 1
+    newsletter_names = [nl.name for nl in contacts[0]["newsletters"]]
+    assert sorted(newsletter_names) == newsletter_names
+
+
+def test_get_contact_by_any_id_missing(dbsession, sample_contacts):
+    """A contacts is fetched by alternate id in two queries."""
+    with StatementWatcher(dbsession.connection()) as sw:
+        contact = get_contacts_by_any_id(dbsession, basket_token=str(uuid4()))
+    assert sw.count == 1
+    assert len(contact) == 0
+
+
+@pytest.mark.parametrize(
+    "alt_id_name,alt_id_value",
+    [
+        ("amo_user_id", "123"),
+        ("fxa_primary_email", "fxa-firefox-fan@example.com"),
+        ("sfdc_id", "001A000001aMozFan"),
+        ("mofo_id", "195207d2-63f2-4c9f-b149-80e9c408477a"),
+    ],
+)
+def test_get_multiple_contacts_by_any_id(
+    dbsession, sample_contacts, alt_id_name, alt_id_value
+):
+    """N contacts are retrieved in N+1 queries."""
+
+    dupe_id = str(uuid4())
+    create_email(
+        dbsession,
+        EmailInSchema(
+            email_id=dupe_id,
+            primary_email="dupe@example.com",
+            basket_token=str(uuid4()),
+            sfdc_id=alt_id_value
+            if alt_id_name == "sfdc_id"
+            else "other_sdfc_alt_id_value",
+            mofo_id=alt_id_value if alt_id_name == "mofo_id" else str(uuid4()),
+        ),
+    )
+    if alt_id_name == "amo_user_id":
+        create_amo(dbsession, dupe_id, AddOnsInSchema(user_id=alt_id_value))
+    if alt_id_name == "fxa_primary_email":
+        create_fxa(
+            dbsession, dupe_id, FirefoxAccountsInSchema(primary_email=alt_id_value)
+        )
+    create_newsletter(dbsession, dupe_id, NewsletterInSchema(name="zzz_sleepy_news"))
+    create_newsletter(dbsession, dupe_id, NewsletterInSchema(name="aaa_game_news"))
+    dbsession.flush()
+
+    with StatementWatcher(dbsession.connection()) as sw:
+        contacts = get_contacts_by_any_id(dbsession, **{alt_id_name: alt_id_value})
+    assert sw.count == 3
+    assert len(contacts) == 2

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -118,7 +118,7 @@ def test_get_contact_by_any_id_missing(dbsession, sample_contacts):
 def test_get_multiple_contacts_by_any_id(
     dbsession, sample_contacts, alt_id_name, alt_id_value
 ):
-    """N contacts are retrieved in N+1 queries."""
+    """2 contacts are retrieved in 2 queries."""
 
     dupe_id = str(uuid4())
     create_email(
@@ -145,5 +145,5 @@ def test_get_multiple_contacts_by_any_id(
 
     with StatementWatcher(dbsession.connection()) as sw:
         contacts = get_contacts_by_any_id(dbsession, **{alt_id_name: alt_id_value})
-    assert sw.count == 3
+    assert sw.count == 2
     assert len(contacts) == 2

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -147,3 +147,6 @@ def test_get_multiple_contacts_by_any_id(
         contacts = get_contacts_by_any_id(dbsession, **{alt_id_name: alt_id_value})
     assert sw.count == 2
     assert len(contacts) == 2
+    for contact in contacts:
+        newsletter_names = [nl.name for nl in contacts[0]["newsletters"]]
+        assert sorted(newsletter_names) == newsletter_names


### PR DESCRIPTION
## Proposed changes

To fix issue #51:

* Refactor the main query from ``get_contact_by_email_id`` and ``get_contacts_by_any_id`` into ``_contact_base_query``, and use some SQLAlchemy [relationship loading techniques](https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html) to load related data directly onto the ``Email`` object. This increases efficiency when multiple contacts are loaded for an alternate ID, changing from N+1 queries to 2, up to N=500 contacts.
* Return newsletters ordered by name, for consistent output.
* Add direct tests of CRUD methods, including a ``StatementWatcher`` for counting SQL queries and debugging issues.

Future work I talked myself out of for this round:

* Change ``get_contact_by_email_id`` to ``get_email_by_email_id``, and just return the ORM ``Email`` instance. This would change the application and some tests.
* Test all the CRUD methods and get 100% coverage.