### PR TITLE
Fix mypy yelling about auto_error

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -51,7 +51,7 @@ app = FastAPI(
 )
 SessionLocal = None
 oauth2_scheme = OAuth2ClientCredentials(tokenUrl="token")
-token_scheme = HTTPBasic(auto_error=None)
+token_scheme = HTTPBasic(auto_error=False)
 
 
 @lru_cache()


### PR DESCRIPTION
## Proposed changes

Without this it yells

```
Argument "auto_error" to "HTTPBasic" has incompatible type "None"; expected "bool"mypy(error)
```

@jwhitlock, does this change make sense?

## Types of changes

What types of changes does your code introduce?
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- [ ] I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- [ ] Lint and tests pass both locally and on the cicd with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

_Use this space for additional comments, complications, learnings, alternatives,..._
