### PR TITLE
Adopt Dockerflow, other changes

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -31,7 +31,7 @@ jobs:
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
           echo "Building an image with the following tag:"
-          echo $IMAGE_TAG 
+          echo $IMAGE_TAG
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,6 +57,12 @@ jobs:
           ECR_REPOSITORY: ctms-api
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
+          printf '{\n    "commit": "%s",\n    "version": "%s",\n    "image_tag": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
+            "$GITHUB_SHA" \
+            "$GITHUB_REF" \
+            "$IMAGE_TAG" \
+            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
           docker build --file docker/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker image tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "poetry.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-10T00:27:59Z",
+  "generated_at": "2021-03-13T00:51:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -64,7 +64,7 @@
         "hashed_secret": "5089246737bcae6ebd14c2548a8360bc548cf0db",
         "is_secret": true,
         "is_verified": false,
-        "line_number": 215,
+        "line_number": 214,
         "type": "Secret Keyword"
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "poetry.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-13T00:51:18Z",
+  "generated_at": "2021-03-13T04:14:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -64,7 +64,7 @@
         "hashed_secret": "5089246737bcae6ebd14c2548a8360bc548cf0db",
         "is_secret": true,
         "is_verified": false,
-        "line_number": 214,
+        "line_number": 237,
         "type": "Secret Keyword"
       }
     ]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 include .env
 export
 
+# Set these in the environment to override them. This is helpful for
+# development if you have file ownership problems because the user
+# in the container doesn't match the user on your host.
+CTMS_UID ?= 10001
+CTMS_GID ?= 10001
 
 .PHONY: help
 help:
@@ -31,7 +36,8 @@ help:
 
 .PHONY: build
 build: .env
-	docker-compose -f ./docker-compose.yaml -f ./tests/docker-compose.test.yaml build
+	docker-compose -f ./docker-compose.yaml -f ./tests/docker-compose.test.yaml build \
+		--build-arg userid=${CTMS_UID} --build-arg groupid=${CTMS_GID}
 
 .PHONY: db-only
 db-only: .env

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ setup: .env
 	docker-compose exec postgres bash -c 'while !</dev/tcp/postgres/5432; do sleep 1; done'
 	docker-compose exec postgres dropdb postgres --user postgres
 	docker-compose exec postgres createdb postgres --user postgres
-	docker-compose run --rm ${MK_WITH_SERVICE_PORTS} web python -m alembic upgrade head
+	docker-compose run --rm ${MK_WITH_SERVICE_PORTS} web alembic upgrade head
 
 .PHONY: shell
 shell: .env

--- a/ctms/monitor.py
+++ b/ctms/monitor.py
@@ -1,0 +1,38 @@
+"""Application monitoring and health utilities"""
+
+import json
+import os.path
+import time
+from functools import lru_cache
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.sql import func, select
+
+
+def check_database(db_session):
+    """Check database availability and migration state."""
+    start_time = time.monotonic()
+    try:
+        db_session.execute(select([func.now()])).first()
+    except SQLAlchemyError:
+        success = False
+    else:
+        success = True
+    duration_s = time.monotonic() - start_time
+    return {"up": success, "time_ms": int(round(1000 * duration_s))}
+
+
+@lru_cache()
+def get_version():
+    """
+    Return contents of version.json.
+
+    This has generic data in repo, but gets the build details in CI.
+    """
+    ctms_root = os.path.dirname(os.path.dirname(__file__))
+    version_path = os.path.join(ctms_root, "version.json")
+    info = {}
+    if os.path.exists(version_path):
+        with open(version_path, "r") as version_file:
+            info = json.load(version_file)
+    return info

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         source: .
         target: /app
     ports:
-      - 8000:8000
+      - ${PORT:-8000}:${PORT:-8000}
     # Let the init system handle signals for us.
     # among other things this helps shutdown be fast
     init: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,8 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     POETRY_NO_INTERACTION=1 \
     PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv"
+    VENV_PATH="/opt/pysetup/.venv" \
+    PORT=8000
 
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
 
@@ -56,9 +57,9 @@ RUN poetry install
 WORKDIR /app
 COPY . .
 
-EXPOSE 8000
-ENTRYPOINT /docker-entrypoint.sh $0 $@
-CMD ["uvicorn", "--reload", "--host=0.0.0.0", "--port=8000", "ctms.app:app"]
+EXPOSE $PORT
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD uvicorn ctms.app:app --reload --host=0.0.0.0 --port=$PORT
 
 
 # 'lint' stage runs black and isort
@@ -91,8 +92,6 @@ RUN chmod +x /docker-entrypoint.sh
 COPY . /app
 WORKDIR /app
 
-ENTRYPOINT /docker-entrypoint.sh $0 $@
-
-EXPOSE 80
-
-CMD ["uvicorn", "ctms.app:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE $PORT
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD uvicorn ctms.app:app --host=0.0.0.0 --port=${PORT}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,8 @@
 
 # Creating a python base with shared environment variables
 FROM python:3.8.2-slim as python-base
-ENV PYTHONUNBUFFERED=1 \
+ENV PYTHONPATH=/app \
+    PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,19 @@ ENV PYTHONPATH=/app \
 
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
 
+# Set up user and group
+ARG userid=10001
+ARG groupid=10001
+WORKDIR /app
+RUN groupadd --gid $groupid app && \
+    useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app
+
+RUN mkdir -p $POETRY_HOME && \
+    chown app:app /opt/poetry && \
+    mkdir -p $PYSETUP_PATH && \
+    chown app:app $PYSETUP_PATH && \
+    mkdir -p /app && \
+    chown app:app /app
 
 # builder-base is used to build dependencies
 FROM python-base as builder-base
@@ -28,14 +41,15 @@ RUN apt-get update \
     build-essential
 
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
+USER app
 ENV POETRY_VERSION=1.1.5
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 
 # We copy our Python requirements here to cache them
 # and install only runtime deps using poetry
 WORKDIR $PYSETUP_PATH
-COPY ./poetry.lock ./pyproject.toml ./
-RUN poetry install --no-dev
+COPY --chown=app:app ./poetry.lock ./pyproject.toml ./
+RUN poetry install --no-dev --no-root
 
 
 # 'development' stage installs all dev deps and can be used to develop code.
@@ -44,19 +58,20 @@ FROM python-base as development
 ENV FASTAPI_ENV=development
 
 # Copying poetry and venv into image
+USER app
 COPY --from=builder-base $POETRY_HOME $POETRY_HOME
 COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
 
 # Copying in our entrypoint
-COPY ./docker/docker-entrypoint.sh /docker-entrypoint.sh
+COPY --chown=app:app ./docker/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 # venv already has runtime deps installed we get a quicker install
 WORKDIR $PYSETUP_PATH
-RUN poetry install
+RUN poetry install --no-root
 
 WORKDIR /app
-COPY . .
+COPY --chown=app:app . .
 
 EXPOSE $PORT
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Creating a python base with shared environment variables
-FROM python:3.8.1-slim as python-base
+FROM python:3.8.2-slim as python-base
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=off \
@@ -26,7 +26,7 @@ RUN apt-get update \
     build-essential
 
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
-ENV POETRY_VERSION=1.1.4
+ENV POETRY_VERSION=1.1.5
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 
 # We copy our Python requirements here to cache them

--- a/docker/config/env.dist
+++ b/docker/config/env.dist
@@ -7,3 +7,6 @@
 
 # Set this to skip calling "docker-compose down" after "make tests"
 # MK_KEEP_DOCKER_UP=1
+
+# Change the webserver port
+# PORT=8000

--- a/docker/config/env.dist
+++ b/docker/config/env.dist
@@ -2,6 +2,13 @@
 # environment. Since these are specific to your local development environment,
 # don't check them in.
 
+# Linux users may want to set these to their own UID and GID
+# so that files created in the container will have the same permissions
+# id -u and id -g may return the proper values
+# This is unnecessary for Docker Desktop for Mac or Windows
+# CTMS_UID=
+# CTMS_GID=
+
 # Set this to always call docker-compose run with --service-ports in the Makefile
 # MK_WITH_SERVICE_PORTS=--service-ports
 

--- a/guides/deployment_guide.md
+++ b/guides/deployment_guide.md
@@ -22,10 +22,10 @@ Acknowledgments to [michael0liver's example](https://github.com/michael0liver/py
 We use a variety of technologies to get this code into production.  Starting from this repo and going outwards:
 
 1. github actions builds and deploys a docker container to ecr
-    1. prs and pushes to this repo will build and push a 'short-sha' container to AWS' ECR
+    1. prs and pushes to this repo will build and push a 'short-sha' container to AWS' ECR. The build details are written to ``/app/version.json``.
     1. Code merged to main will trigger a build that prefixes the short sha with literal 'stg-'
     1. Code released with a good version tag should get released to prod (this is to be determined, does not work, but is plan of record)
-1. A helm release is configured in ctms-infra 
+1. A helm release is configured in ctms-infra
     1. https://github.com/mozilla-it/ctms-infra/tree/main/k8s
     1. We can trigger a release by updating the correct files there (For helm chart or helm chart value changes)
     1. by default we will also configure new images in the ECR to trigger a build

--- a/guides/developer_setup.md
+++ b/guides/developer_setup.md
@@ -172,7 +172,7 @@ To create a new migration file based on updated SQLAlchemy models:
 
 ```sh
 make shell  # To enter the web container
-python -m alembic revision -m "A short description of the change"
+alembic revision -m "A short description of the change"
 exit
 ```
 
@@ -190,7 +190,7 @@ To run this and other migrations on an existing database:
 
 ```sh
 make shell  # Enter the web container
-python -m alembic upgrade head
+alembic upgrade head
 exit
 ```
 
@@ -202,7 +202,6 @@ for authentication. To generate credentials for your development environment:
 
 ```sh
 make shell  # Enter the web container
-poetry install
 ctms/bin/client_credentials.py test --email test@example.com
 ```
 

--- a/guides/developer_setup.md
+++ b/guides/developer_setup.md
@@ -101,6 +101,29 @@ The option `--no-verify` should allow a committer to bypass the hooks.
 ### Installation
 Install Docker here: https://docs.docker.com/get-docker/
 
+### Linux Users
+Linux users will want to set the user ID and group ID used in the container.
+User of Docker Desktop for Mac or Windows and skip this step.
+
+Create a ``.env`` environment file, if it isn't already created:
+
+```sh
+make .env
+```
+
+Edit this file, and set these variables:
+```sh
+CTMS_UID=1000
+CTMS_GID=1000
+```
+
+Set these to your user ID and group ID. These commands might return them:
+
+```sh
+id -u # Your user ID
+id -g # Your group ID
+```
+
 ### Building
 Build images with:
 ```sh

--- a/guides/testing_strategy.md
+++ b/guides/testing_strategy.md
@@ -32,11 +32,10 @@ with the database.
 You can run the suite by first entering the web container:
 > make test-shell
 
-And then running the installed ``pytest`` through ``python``, which adds the
-current ``app`` folder to the system path first:
-> python -m pytest
+And then run the installed ``pytest``:
+> pytest
 
 To stop on the first failure and drop into [pdb][pdb]:
-> python -m pytest -sx --pdb
+> pytest -sx --pdb
 
 [pdb]: <https://docs.python.org/3/library/pdb.html> "pdb - The Python Debugger"

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,5 +1,27 @@
 """pytest tests for basic app functionality"""
 
+import json
+import os.path
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy.exc import TimeoutError
+
+from ctms.app import app, get_db
+
+
+@pytest.fixture
+def mock_db():
+    """Mock the database session."""
+    mock_db = Mock()
+
+    def mock_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = mock_get_db
+    yield mock_db
+    del app.dependency_overrides[get_db]
+
 
 def test_read_root(anon_client):
     """The site root redirects to the Swagger docs"""
@@ -11,8 +33,39 @@ def test_read_root(anon_client):
     assert prev_resp.headers["location"] == "./docs"
 
 
-def test_read_health(anon_client):
-    """The platform calls /health to check app readiness."""
-    resp = anon_client.get("/health")
+def test_read_version(anon_client):
+    """__version__ returns the contents of version.json."""
+    here = os.path.dirname(__file__)
+    root_dir = os.path.dirname(os.path.dirname(here))
+    version_path = os.path.join(root_dir, "version.json")
+    version_contents = open(version_path, "r").read()
+    expected = json.loads(version_contents)
+    resp = anon_client.get("/__version__")
     assert resp.status_code == 200
-    assert resp.json() == [{"health": "OK"}, 200]
+    assert resp.json() == expected
+
+
+def test_read_heartbeat(anon_client, dbsession):
+    """The platform calls /__heartbeat__ to check backing services."""
+    resp = anon_client.get("/__heartbeat__")
+    assert resp.status_code == 200
+    data = resp.json()
+    expected = {"database": {"up": True, "time_ms": data["database"]["time_ms"]}}
+    assert data == expected
+
+
+def test_read_heartbeat_no_db_fails(anon_client, mock_db):
+    """/__heartbeat__ returns 503 when the database is unavailable."""
+    mock_db.execute.side_effect = TimeoutError()
+    resp = anon_client.get("/__heartbeat__")
+    assert resp.status_code == 503
+    data = resp.json()
+    expected = {"database": {"up": False, "time_ms": data["database"]["time_ms"]}}
+    assert data == expected
+
+
+def test_read_health(anon_client):
+    """The platform calls /__lbheartbeat__ to see when the app is running."""
+    resp = anon_client.get("/__lbheartbeat__")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "OK"}

--- a/version.json
+++ b/version.json
@@ -1,0 +1,7 @@
+{
+    "commit": "HEAD",
+    "version": null,
+    "image_tag": null,
+    "source": "https://github.com/mozilla-it/ctms-api",
+    "build": null
+}


### PR DESCRIPTION
## Proposed changes

For issue #89, adjust ``Dockerfile`` for [dockerflow](https://github.com/mozilla-services/dockerflow):

* Add an environment variable ``PORT``, default 8000, to control the port that the application is served from.
   - This required changing to ``ENTRYPOINT ["/docker-entrypoint.sh"]``, so that ``CMD`` could use shell expansion to get the value of ``$PORT``
* Add a user ``app``, default to user id 10001 and group id 10001, give it ownership of the application files, and run the application as the ``app`` user.
   - The ``app`` user can cause problems for Linux users, if it creates files owned by user 10001 that the development account can't read or delete. If this happens, there are ``.env`` overrides ``CTMS_UID`` and ``CTMS_GID`` to set these for local development.
* Add a generic ``version.json``, and populate it with build details when building the Docker image with a Github action.
* Add ``/__version__``, which returns the contents of ``version.json``
* Replace ``/health`` with ``/__lbheartbeat``, which returns that the application is up and running.
* Add ``/_heartbeat``, which checks backing services (currently just the database.
  - I think it should also return the alembic version, but I need to fix #68 first. 


Other changes not related to dockerflow:

* Update the Python image from 3.8.1 to 3.8.2
* Update poetry from 1.1.4 to 1.1.5
* Add ``PYTHONPATH=/app`` so that Python code can import from ``ctms``, and tools no longer require ``python -m`` to run.
