### PR TITLE
Convert ``.first()`` to ``.one_or_none()`` or ``.all()

### DIFF
--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -24,15 +24,19 @@ from .schemas import (
 
 
 def get_email_by_email_id(db: Session, email_id: UUID4):
-    return db.query(Email).filter(Email.email_id == email_id).first()
+    return db.query(Email).filter(Email.email_id == email_id).one_or_none()
 
 
 def get_amo_by_email_id(db: Session, email_id: UUID4):
-    return db.query(AmoAccount).filter(AmoAccount.email_id == email_id).first()
+    return db.query(AmoAccount).filter(AmoAccount.email_id == email_id).one_or_none()
 
 
 def get_fxa_by_email_id(db: Session, email_id: UUID4):
-    return db.query(FirefoxAccount).filter(FirefoxAccount.email_id == email_id).first()
+    return (
+        db.query(FirefoxAccount)
+        .filter(FirefoxAccount.email_id == email_id)
+        .one_or_none()
+    )
 
 
 def get_newsletters_by_email_id(db: Session, email_id: UUID4):
@@ -40,7 +44,7 @@ def get_newsletters_by_email_id(db: Session, email_id: UUID4):
 
 
 def get_vpn_by_email_id(db: Session, email_id: UUID4):
-    return db.query(VpnWaitlist).filter(VpnWaitlist.email_id == email_id).first()
+    return db.query(VpnWaitlist).filter(VpnWaitlist.email_id == email_id).one_or_none()
 
 
 def _contact_base_query(db):

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -40,7 +40,7 @@ def get_fxa_by_email_id(db: Session, email_id: UUID4):
 
 
 def get_newsletters_by_email_id(db: Session, email_id: UUID4):
-    return db.query(Newsletter).filter(Newsletter.email_id == email_id).first()
+    return db.query(Newsletter).filter(Newsletter.email_id == email_id).all()
 
 
 def get_vpn_by_email_id(db: Session, email_id: UUID4):

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -23,10 +23,6 @@ from .schemas import (
 )
 
 
-def get_email_by_email_id(db: Session, email_id: UUID4):
-    return db.query(Email).filter(Email.email_id == email_id).one_or_none()
-
-
 def get_amo_by_email_id(db: Session, email_id: UUID4):
     return db.query(AmoAccount).filter(AmoAccount.email_id == email_id).one_or_none()
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -416,7 +416,7 @@ def add_contact(request, client, dbsession):
         assert len(saved) == stored_contacts
 
         # Now make sure that we skip writing default models
-        def _check_written(field, getter):
+        def _check_written(field, getter, result_list=False):
             # We delete this field in one test case so we have to check
             # to see if it is even there
             if hasattr(sample.email, "email_id") and sample.email.email_id is not None:
@@ -426,22 +426,32 @@ def add_contact(request, client, dbsession):
             results = getter(dbsession, written_id)
             if sample.dict()[field] and code == 303:
                 if field in fields_not_written:
-                    assert (
-                        results is None
-                    ), f"{email_id} has field `{field}` but it is _default_ and it should _not_ have been written to db"
+                    if result_list:
+                        assert (
+                            results == []
+                        ), f"{email_id} has field `{field}` but it is _default_ and it should _not_ have been written to db"
+                    else:
+                        assert (
+                            results is None
+                        ), f"{email_id} has field `{field}` but it is _default_ and it should _not_ have been written to db"
                 else:
                     assert (
                         results
                     ), f"{email_id} has field `{field}` and it should have been written to db"
             else:
-                assert (
-                    results is None
-                ), f"{email_id} does not have field `{field}` and it should _not_ have been written to db"
+                if result_list:
+                    assert (
+                        results == []
+                    ), f"{email_id} does not have field `{field}` and it should _not_ have been written to db"
+                else:
+                    assert (
+                        results is None
+                    ), f"{email_id} does not have field `{field}` and it should _not_ have been written to db"
 
         if check_written:
             _check_written("amo", get_amo_by_email_id)
             _check_written("fxa", get_fxa_by_email_id)
-            _check_written("newsletters", get_newsletters_by_email_id)
+            _check_written("newsletters", get_newsletters_by_email_id, result_list=True)
             _check_written("vpn_waitlist", get_vpn_by_email_id)
 
         return saved, sample, email_id


### PR DESCRIPTION
Fix #50 by converting ``get_amo_by_email_id``, ``get_fxa_by_email_id``, and ``get_vpn_by_email_id`` from ``.first()`` to ``.one_or_none()``, to detect early if there are multiple records for one ``email_id``.

Convert ``get_newsletters_by_email_id`` from ``.first()`` to ``.all()``, which mostly affected how to test if none were written.

Remove ``get_email_by_email_id``, which was unused and untested.
