### PR TITLE
Allow testing outside of docker

### DIFF
--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,6 +1,6 @@
 """Test authentication"""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from jose import jwt
@@ -56,8 +56,10 @@ def test_post_token_header(anon_client, test_token_settings, client_id_and_secre
     )
     assert payload["sub"] == f"api_client:{client_id}"
     expected_expires = (
-        datetime.utcnow() + test_token_settings["expires_delta"]
-    ).timestamp()
+        (datetime.utcnow() + test_token_settings["expires_delta"])
+        .replace(tzinfo=timezone.utc)
+        .timestamp()
+    )
     assert -2.0 < (expected_expires - payload["exp"]) < 2.0
 
 
@@ -82,8 +84,10 @@ def test_post_token_form_data(anon_client, test_token_settings, client_id_and_se
     )
     assert payload["sub"] == f"api_client:{client_id}"
     expected_expires = (
-        datetime.utcnow() + test_token_settings["expires_delta"]
-    ).timestamp()
+        (datetime.utcnow() + test_token_settings["expires_delta"])
+        .replace(tzinfo=timezone.utc)
+        .timestamp()
+    )
     assert -2.0 < (expected_expires - payload["exp"]) < 2.0
 
 


### PR DESCRIPTION

## Proposed changes

The docker container is in UTC so the timestamps it generates are in
that timezone. The `datetime.utcnow()...timestamp()` in tests is kinda
funny. The note in
https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp
explains a bit more. Basically when I tried running pytest on my machine
(which is in PST currently), the result of that call was 7 hours in the
past instead of correctly in UTC.

Happy to be told this is wrong if I'm misundersanding something. I _think_ this
is right but timezones are hard!

## Types of changes

What types of changes does your code introduce?
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- [ ] I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- [ ] Lint and tests pass both locally and on the cicd with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

_Use this space for additional comments, complications, learnings, alternatives,..._
