### PR TITLE
Convert utcnow() to now(utc)

### DIFF
--- a/ctms/auth.py
+++ b/ctms/auth.py
@@ -7,7 +7,7 @@ header. A JWT token is returned that expires after a short time. To renew,
 the client POSTs to /token again.
 """
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
 from fastapi.exceptions import HTTPException
@@ -46,7 +46,7 @@ def create_access_token(
 ) -> str:
     """Create a JWT string to act as an OAuth2 access token."""
     to_encode = data.copy()
-    expire = (now or datetime.utcnow()) + expires_delta
+    expire = (now or datetime.now(timezone.utc)) + expires_delta
     to_encode["exp"] = expire
     encoded_jwt = jwt.encode(to_encode, secret_key, algorithm="HS256")
     return encoded_jwt

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -56,10 +56,8 @@ def test_post_token_header(anon_client, test_token_settings, client_id_and_secre
     )
     assert payload["sub"] == f"api_client:{client_id}"
     expected_expires = (
-        (datetime.utcnow() + test_token_settings["expires_delta"])
-        .replace(tzinfo=timezone.utc)
-        .timestamp()
-    )
+        datetime.now(timezone.utc) + test_token_settings["expires_delta"]
+    ).timestamp()
     assert -2.0 < (expected_expires - payload["exp"]) < 2.0
 
 
@@ -84,10 +82,8 @@ def test_post_token_form_data(anon_client, test_token_settings, client_id_and_se
     )
     assert payload["sub"] == f"api_client:{client_id}"
     expected_expires = (
-        (datetime.utcnow() + test_token_settings["expires_delta"])
-        .replace(tzinfo=timezone.utc)
-        .timestamp()
-    )
+        datetime.now(timezone.utc) + test_token_settings["expires_delta"]
+    ).timestamp()
     assert -2.0 < (expected_expires - payload["exp"]) < 2.0
 
 
@@ -209,7 +205,7 @@ def test_get_ctms_with_expired_token_fails(
     example_contact, anon_client, test_token_settings, client_id_and_secret
 ):
     """Calling an authenticated API with an expired token is an error"""
-    yesterday = datetime.utcnow() - timedelta(days=1)
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
     client_id, client_secret = client_id_and_secret
     token = create_access_token(
         {"sub": f"api_client:{client_id}"}, **test_token_settings, now=yesterday


### PR DESCRIPTION
[datetime.utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) returns the current UTC time as a naive datetime, which is often interpreted as a local time. The Python docs recommend using [datetime.now(timezone.utc)](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) instead. I'm having a hard time thinking of when ``utcnow()`` is appropriate.

This is follow-on work for PR #110. It works with ``make test``. I don't have my environment setup to test outside of docker.

## Types of changes

What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- N/A I have added tests that prove my fix is effective or that my feature works
- N/A I have added necessary documentation (if appropriate)
- N/A Any dependent changes have been merged and published in downstream modules