### PR TITLE
Use scoped_session for database session

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -9,7 +9,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import EmailStr
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, scoped_session
 
 from . import config
 from .auth import (
@@ -63,7 +63,8 @@ def get_settings():
 @app.on_event("startup")
 def startup_event():
     global SessionLocal  # pylint:disable = W0603
-    _, SessionLocal = get_db_engine(get_settings())
+    _, session_factory = get_db_engine(get_settings())
+    SessionLocal = scoped_session(session_factory)
 
 
 def get_db():
@@ -72,6 +73,7 @@ def get_db():
         yield db
     finally:
         db.close()
+        SessionLocal.remove()
 
 
 def _token_settings(


### PR DESCRIPTION
## Proposed changes

Follow [SQLAlchemy's advice](https://docs.sqlalchemy.org/en/13/orm/contextual.html#using-thread-local-scope-with-web-applications) to use [scoped_session](https://docs.sqlalchemy.org/en/13/orm/contextual.htm) to wrap the session factory. This may be unnecessary with FastAPI's dependency injection, but if we're wrong, it should prevent issues of multiple threads getting the same (not thread-safe) session.

Fixes #70

## Types of changes

What types of changes does your code introduce?
- New feature (non-breaking change which adds functionality)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- N/A I have added tests that prove my fix is effective or that my feature works
- N/A I have added necessary documentation (if appropriate)
- N/A Any dependent changes have been merged and published in downstream modules

## Further comments

We do not use the changed functions in tests, only in the web application, so there are no changes to tests. I ran the web application locally to check that the code worked without errors.