### PR TITLE
Add PATCH /ctms/{email_id}

### DIFF
--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -1,10 +1,11 @@
-from typing import Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from pydantic import UUID4, EmailStr
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from .auth import hash_password
+from .database import Base
 from .models import (
     AmoAccount,
     ApiClient,
@@ -192,7 +193,7 @@ def get_contacts_by_any_id(
     return data
 
 
-def create_amo(db: Session, email_id: UUID4, amo: AddOnsInSchema):
+def create_amo(db: Session, email_id: UUID4, amo: AddOnsInSchema) -> None:
     if amo.is_default():
         return
     db_amo = AmoAccount(email_id=email_id, **amo.dict())
@@ -223,7 +224,7 @@ def create_or_update_email(db: Session, email: EmailPutSchema):
     db.execute(stmt)
 
 
-def create_fxa(db: Session, email_id: UUID4, fxa: FirefoxAccountsInSchema):
+def create_fxa(db: Session, email_id: UUID4, fxa: FirefoxAccountsInSchema) -> None:
     if fxa.is_default():
         return
     db_fxa = FirefoxAccount(email_id=email_id, **fxa.dict())
@@ -243,7 +244,7 @@ def create_or_update_fxa(
     db.execute(stmt)
 
 
-def create_mofo(db: Session, email_id: UUID4, mofo: MozillaFoundationInSchema):
+def create_mofo(db: Session, email_id: UUID4, mofo: MozillaFoundationInSchema) -> None:
     if mofo.is_default():
         return
     db_mofo = MozillaFoundationContact(email_id=email_id, **mofo.dict())
@@ -269,7 +270,7 @@ def create_or_update_mofo(
 
 def create_vpn_waitlist(
     db: Session, email_id: UUID4, vpn_waitlist: VpnWaitlistInSchema
-):
+) -> None:
     if vpn_waitlist.is_default():
         return
     db_vpn_waitlist = VpnWaitlist(email_id=email_id, **vpn_waitlist.dict())
@@ -340,6 +341,47 @@ def create_or_update_contact(db: Session, email_id: UUID4, contact: ContactPutSc
     create_or_update_mofo(db, email_id, contact.mofo)
     create_or_update_vpn_waitlist(db, email_id, contact.vpn_waitlist)
     create_or_update_newsletters(db, email_id, contact.newsletters)
+
+
+def update_contact(db: Session, email: Email, update_data: dict) -> None:
+    """Update an existing contact using a sparse update dictionary"""
+    email_id = email.email_id
+
+    def update_orm(orm: Base, update_dict: dict):
+        """Update a SQLAlchemy model from an update dictionary."""
+        for key, value in update_dict.items():
+            setattr(orm, key, value)
+
+    if "email" in update_data:
+        update_orm(email, update_data["email"])
+
+    simple_groups: Dict[
+        str, Tuple[Callable[[Session, UUID4, Any], None], Type[Any]]
+    ] = {
+        "amo": (create_amo, AddOnsInSchema),
+        "fxa": (create_fxa, FirefoxAccountsInSchema),
+        "mofo": (create_mofo, MozillaFoundationInSchema),
+        "vpn_waitlist": (create_vpn_waitlist, VpnWaitlistInSchema),
+    }
+    for group_name, (creator, schema) in simple_groups.items():
+        if group_name in update_data:
+            existing = getattr(email, group_name)
+            if existing is None:
+                creator(db, email_id, schema(**update_data[group_name]))
+            else:
+                update_orm(existing, update_data[group_name])
+                if schema.from_orm(existing).is_default():
+                    db.delete(existing)
+
+    if "newsletters" in update_data:
+        existing = {}
+        for newsletter in getattr(email, "newsletters", []):
+            existing[newsletter.name] = newsletter
+        for nl_update in update_data["newsletters"]:
+            if nl_update["name"] in existing:
+                update_orm(existing[nl_update["name"]], nl_update)
+            elif nl_update.get("subscribed", True):
+                create_newsletter(db, email_id, NewsletterInSchema(**nl_update))
 
 
 def create_api_client(db: Session, api_client: ApiClientSchema, secret):

--- a/ctms/schemas/__init__.py
+++ b/ctms/schemas/__init__.py
@@ -2,13 +2,20 @@ from .addons import AddOnsInSchema, AddOnsSchema, AddOnsTableSchema
 from .api_client import ApiClientSchema
 from .contact import (
     ContactInSchema,
+    ContactPatchSchema,
     ContactPutSchema,
     ContactSchema,
     CTMSResponse,
     CTMSSingleResponse,
     IdentityResponse,
 )
-from .email import EmailInSchema, EmailPutSchema, EmailSchema, EmailTableSchema
+from .email import (
+    EmailInSchema,
+    EmailPatchSchema,
+    EmailPutSchema,
+    EmailSchema,
+    EmailTableSchema,
+)
 from .fxa import (
     FirefoxAccountsInSchema,
     FirefoxAccountsSchema,

--- a/ctms/schemas/contact.py
+++ b/ctms/schemas/contact.py
@@ -5,7 +5,13 @@ from pydantic import BaseModel, EmailStr, Field
 
 from .addons import AddOnsInSchema, AddOnsSchema
 from .base import ComparableBase
-from .email import EmailBase, EmailInSchema, EmailPutSchema, EmailSchema
+from .email import (
+    EmailBase,
+    EmailInSchema,
+    EmailPatchSchema,
+    EmailPutSchema,
+    EmailSchema,
+)
 from .fxa import FirefoxAccountsInSchema, FirefoxAccountsSchema
 from .mofo import MozillaFoundationInSchema, MozillaFoundationSchema
 from .newsletter import NewsletterInSchema, NewsletterSchema
@@ -100,6 +106,10 @@ class ContactPutSchema(ContactInBase):
     """A contact as provided by callers when using POST. This is nearly identical to the ContactInSchema but does require an email_id."""
 
     email: EmailPutSchema
+
+
+class ContactPatchSchema(ContactInBase):
+    email: Optional[EmailPatchSchema]
 
 
 class CTMSResponse(BaseModel):

--- a/ctms/schemas/email.py
+++ b/ctms/schemas/email.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import UUID4, EmailStr, Field
+from pydantic import UUID4, EmailStr, Field, validator
 
 from .base import ComparableBase
 
@@ -13,11 +13,7 @@ EMAIL_ID_EXAMPLE = "332de237-cab7-4461-bcc3-48e68f42bd5c"
 class EmailBase(ComparableBase):
     """Data that is included in input/output/db of a primary_email and such."""
 
-    primary_email: EmailStr = Field(
-        ...,
-        description="Contact email address, Email in Salesforce",
-        example="contact@example.com",
-    )
+    primary_email: EmailStr
     basket_token: Optional[UUID] = Field(
         default=None,
         description="Basket token, Token__c in Salesforce",
@@ -70,6 +66,12 @@ class EmailBase(ComparableBase):
 
     class Config:
         orm_mode = True
+        fields = {
+            "primary_email": {
+                "description": "Contact email address, Email in Salesforce",
+                "example": "contact@example.com",
+            }
+        }
 
 
 class EmailSchema(EmailBase):
@@ -120,3 +122,15 @@ class EmailPutSchema(EmailBase):
         description=EMAIL_ID_DESCRIPTION,
         example=EMAIL_ID_EXAMPLE,
     )
+
+
+class EmailPatchSchema(EmailInSchema):
+    """Nearly identical to EmailInSchema but nothing is required."""
+
+    primary_email: Optional[EmailStr]
+
+    @validator("primary_email")
+    @classmethod
+    def prevent_none(cls, value):
+        assert value is not None, "primary_email may not be None"
+        return value

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -312,6 +312,15 @@ API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
             }
         },
     ),
+    (
+        "PATCH",
+        "/ctms/332de237-cab7-4461-bcc3-48e68f42bd5c",
+        {
+            "email": {
+                "email_format": "T",
+            }
+        },
+    ),
 )
 
 
@@ -323,7 +332,7 @@ def test_unauthorized_api_call_fails(
     if method == "GET":
         resp = anon_client.get(path, params=params)
     else:
-        assert method in ("POST", "PUT")
+        assert method in ("PATCH", "POST", "PUT")
         resp = anon_client.request(method, path, json=params)
     assert resp.status_code == 401
     assert resp.json() == {"detail": "Not authenticated"}
@@ -336,7 +345,7 @@ def test_authorized_api_call_succeeds(client, example_contact, method, path, par
         resp = client.get(path, params=params)
         assert resp.status_code == 200
     else:
-        assert method in ("POST", "PUT")
+        assert method in ("PATCH", "POST", "PUT")
         resp = client.request(method, path, json=params)
         assert resp.status_code == 303
 

--- a/tests/unit/test_api_patch.py
+++ b/tests/unit/test_api_patch.py
@@ -1,0 +1,354 @@
+"""Tests for PATCH /ctms/{email_id}"""
+import json
+from uuid import uuid4
+
+import pytest
+
+from ctms.crud import get_email
+from ctms.schemas import (
+    AddOnsSchema,
+    CTMSResponse,
+    EmailSchema,
+    FirefoxAccountsSchema,
+    MozillaFoundationSchema,
+    VpnWaitlistSchema,
+)
+
+
+def swap_bool(existing):
+    """Use the opposite of the existing value for this boolean."""
+    return not existing
+
+
+@pytest.mark.parametrize("contact_name", ("minimal", "maximal"))
+@pytest.mark.parametrize(
+    "group_name,key,value",
+    (
+        ("amo", "add_on_ids", "new-addon-id"),
+        ("amo", "display_name", "New Display Name"),
+        ("amo", "email_opt_in", swap_bool),
+        ("amo", "language", "es"),
+        ("amo", "last_login", "2020-04-07"),
+        ("amo", "location", "New Location"),
+        ("amo", "profile_url", "firefox/user/14612345"),
+        ("amo", "user", swap_bool),
+        ("amo", "user_id", "987"),
+        ("amo", "username", "NewUsername"),
+        ("email", "primary_email", "new-email@example.com"),
+        ("email", "basket_token", "8b359504-d1b4-4691-9175-cfee3059b171"),
+        ("email", "double_opt_in", swap_bool),
+        ("email", "sfdc_id", "001A000001aNewUser"),
+        ("email", "first_name", "New"),
+        ("email", "last_name", "LastName"),
+        ("email", "mailing_country", "uk"),
+        ("email", "email_format", "T"),
+        ("email", "email_lang", "eo"),
+        ("email", "has_opted_out_of_email", swap_bool),
+        ("email", "unsubscribe_reason", "new reason"),
+        ("fxa", "fxa_id", "8b359504-d1b4-4691-9175-cfee3059b171"),
+        ("fxa", "primary_email", "new-fxa-email@example.com"),
+        ("fxa", "created_date", "2021-04-07T10:00:00+00:00"),
+        ("fxa", "lang", "es"),
+        ("fxa", "first_service", "vpn"),
+        ("fxa", "account_deleted", swap_bool),
+        ("mofo", "mofo_email_id", "8b359504-d1b4-4691-9175-cfee3059b171"),
+        ("mofo", "mofo_contact_id", "8b359504-d1b4-4691-9175-cfee3059b171"),
+        ("mofo", "mofo_relevant", swap_bool),
+        ("vpn_waitlist", "geo", "uk"),
+        ("vpn_waitlist", "platform", "linux"),
+    ),
+)
+def test_patch_one_new_value(
+    client, sample_contacts, contact_name, group_name, key, value
+):
+    """PATCH can update a single value."""
+    email_id, contact = sample_contacts[contact_name]
+    # Add in defaults for unset groups, and convert Python values like
+    # datetimes to JSON strings
+    expected = json.loads(
+        CTMSResponse(
+            amo=contact.amo or AddOnsSchema(),
+            email=contact.email,
+            fxa=contact.fxa or FirefoxAccountsSchema(),
+            mofo=contact.mofo or MozillaFoundationSchema(),
+            newsletters=contact.newsletters or [],
+            vpn_waitlist=contact.vpn_waitlist or VpnWaitlistSchema(),
+        ).json()
+    )
+    existing_value = expected[group_name][key]
+
+    # Set dynamic test values
+    if callable(value):
+        new_value = value(existing_value)
+    else:
+        new_value = value
+
+    patch_data = {group_name: {key: new_value}}
+    expected[group_name][key] = new_value
+    assert existing_value != new_value
+
+    resp_patch = client.patch(f"/ctms/{email_id}", json=patch_data)
+    assert resp_patch.status_code == 303
+    resp = client.get(f"/ctms/{email_id}")
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert actual["status"] == "ok"
+    del actual["status"]
+
+    # Timestamps should be set for newly created amo group
+    if group_name == "amo" and contact.amo is None:
+        assert expected["amo"]["create_timestamp"] is None
+        assert expected["amo"]["update_timestamp"] is None
+        assert actual["amo"]["create_timestamp"] is not None
+        assert actual["amo"]["update_timestamp"] is not None
+        assert actual["amo"]["create_timestamp"] == actual["amo"]["update_timestamp"]
+        expected["amo"]["create_timestamp"] = actual["amo"]["create_timestamp"]
+        expected["amo"]["update_timestamp"] = actual["amo"]["update_timestamp"]
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "group_name,key",
+    (
+        ("amo", "add_on_ids"),
+        ("amo", "display_name"),
+        ("amo", "email_opt_in"),
+        ("amo", "language"),
+        ("amo", "last_login"),
+        ("amo", "location"),
+        ("amo", "profile_url"),
+        ("amo", "user"),
+        ("amo", "user_id"),
+        ("amo", "username"),
+        ("email", "basket_token"),
+        ("email", "double_opt_in"),
+        ("email", "sfdc_id"),
+        ("email", "first_name"),
+        ("email", "last_name"),
+        ("email", "mailing_country"),
+        ("email", "email_lang"),
+        ("email", "unsubscribe_reason"),
+        ("fxa", "fxa_id"),
+        ("fxa", "primary_email"),
+        ("fxa", "created_date"),
+        ("fxa", "lang"),
+        ("fxa", "first_service"),
+        ("mofo", "mofo_email_id"),
+        ("mofo", "mofo_contact_id"),
+        ("mofo", "mofo_relevant"),
+        ("vpn_waitlist", "geo"),
+        ("vpn_waitlist", "platform"),
+    ),
+)
+def test_patch_to_default(client, maximal_contact, group_name, key):
+    """PATCH can set a field to the default value."""
+    email_id = maximal_contact.email.email_id
+    # Add in defaults for unset groups, and convert Python values like
+    # datetimes to JSON strings
+    expected = json.loads(
+        CTMSResponse(
+            amo=maximal_contact.amo or AddOnsSchema(),
+            email=maximal_contact.email,
+            fxa=maximal_contact.fxa or FirefoxAccountsSchema(),
+            mofo=maximal_contact.mofo or MozillaFoundationSchema(),
+            newsletters=maximal_contact.newsletters or [],
+            vpn_waitlist=maximal_contact.vpn_waitlist or VpnWaitlistSchema(),
+        ).json()
+    )
+    existing_value = expected[group_name][key]
+
+    # Load the default value from the schema
+    field = {
+        "amo": AddOnsSchema(),
+        "email": EmailSchema(
+            email_id=email_id, primary_email=maximal_contact.email.primary_email
+        ),
+        "fxa": FirefoxAccountsSchema(),
+        "mofo": MozillaFoundationSchema(),
+        "vpn_waitlist": VpnWaitlistSchema(),
+    }[group_name].__fields__[key]
+    assert not field.required
+    default_value = field.get_default()
+    patch_data = {group_name: {key: default_value}}
+    expected[group_name][key] = default_value
+    assert existing_value != default_value
+
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert actual["status"] == "ok"
+    del actual["status"]
+    assert actual == expected
+
+
+def test_patch_to_group_default(client, dbsession, maximal_contact):
+    """PATCH to default values deletes a group."""
+    email_id = maximal_contact.email.email_id
+    email = get_email(dbsession, email_id)
+    assert email.vpn_waitlist
+
+    patch_data = {"vpn_waitlist": {"geo": None, "platform": None}}
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert actual["vpn_waitlist"] == {"geo": None, "platform": None}
+
+    email = get_email(dbsession, email_id)
+    assert not email.vpn_waitlist
+
+
+def test_patch_cannot_set_timestamps(client, maximal_contact):
+    """PATCH can not set timestamps directly."""
+    email_id = maximal_contact.email.email_id
+    expected = json.loads(maximal_contact.json())
+    new_ts = "2021-04-07T10:00:00+00:00"
+    assert expected["amo"]["create_timestamp"] == "2017-05-12T15:16:00+00:00"
+    assert expected["amo"]["create_timestamp"] != new_ts
+    assert expected["amo"]["update_timestamp"] != new_ts
+    assert expected["email"]["create_timestamp"] != new_ts
+    assert expected["email"]["update_timestamp"] != new_ts
+    patch_data = {
+        "amo": {
+            "create_timestamp": new_ts,
+            "update_timestamp": new_ts,
+        },
+        "email": {
+            "create_timestamp": new_ts,
+            "update_timestamp": new_ts,
+        },
+    }
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert actual["status"] == "ok"
+    del actual["status"]
+    assert actual == expected
+
+
+def test_patch_cannot_change_email_id(client, maximal_contact):
+    """PATCH cannot change the email_id."""
+    email_id = maximal_contact.email.email_id
+    patch_data = {"email": {"email_id": str(uuid4())}}
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data)
+    assert resp.status_code == 422
+    assert resp.json() == {"detail": "cannot change email_id"}
+
+
+def test_patch_cannot_set_email_to_null(client, maximal_contact):
+    """PATCH cannot set the email address to null."""
+    email_id = maximal_contact.email.email_id
+    patch_data = {"email": {"primary_email": None}}
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data)
+    assert resp.status_code == 422
+    assert resp.json() == {
+        "detail": [
+            {
+                "loc": ["body", "email", "primary_email"],
+                "msg": "primary_email may not be None",
+                "type": "assertion_error",
+            }
+        ]
+    }
+
+
+def test_patch_to_subscribe(client, maximal_contact):
+    """PATCH can subscribe to a single newsletter."""
+    email_id = maximal_contact.email.email_id
+    patch_data = {"newsletters": [{"name": "zzz-newsletter"}]}
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert len(actual["newsletters"]) == len(maximal_contact.newsletters) + 1
+    assert actual["newsletters"][-1] == {
+        "format": "H",
+        "lang": "en",
+        "name": "zzz-newsletter",
+        "source": None,
+        "subscribed": True,
+        "unsub_reason": None,
+    }
+
+
+def test_patch_to_update_subscription(client, maximal_contact):
+    """PATCH can update an existing newsletter subscription."""
+    email_id = maximal_contact.email.email_id
+    existing_news_data = maximal_contact.newsletters[1].dict()
+    assert existing_news_data == {
+        "format": "T",
+        "lang": "fr",
+        "name": "common-voice",
+        "source": "https://commonvoice.mozilla.org/fr",
+        "subscribed": True,
+        "unsub_reason": None,
+    }
+    patch_data = {
+        "newsletters": [{"name": "common-voice", "format": "H", "lang": "en"}]
+    }
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
+    assert actual["newsletters"][1] == {
+        "format": "H",
+        "lang": "en",
+        "name": "common-voice",
+        "source": "https://commonvoice.mozilla.org/fr",
+        "subscribed": True,
+        "unsub_reason": None,
+    }
+
+
+def test_patch_to_unsubscribe(client, maximal_contact):
+    """PATCH can unsubscribe by setting a newsletter field."""
+    email_id = maximal_contact.email.email_id
+    existing_news_data = maximal_contact.newsletters[1].dict()
+    assert existing_news_data == {
+        "format": "T",
+        "lang": "fr",
+        "name": "common-voice",
+        "source": "https://commonvoice.mozilla.org/fr",
+        "subscribed": True,
+        "unsub_reason": None,
+    }
+    patch_data = {
+        "newsletters": [
+            {
+                "name": "common-voice",
+                "subscribed": False,
+                "unsub_reason": "Too many emails.",
+            }
+        ]
+    }
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
+    assert actual["newsletters"][1] == {
+        "format": "T",
+        "lang": "fr",
+        "name": "common-voice",
+        "source": "https://commonvoice.mozilla.org/fr",
+        "subscribed": False,
+        "unsub_reason": "Too many emails.",
+    }
+
+
+def test_patch_to_unsubscribe_but_not_subscribed(client, maximal_contact):
+    """PATCH doesn't create a record when unsubscribing to a new newsletter."""
+    email_id = maximal_contact.email.email_id
+    unknown_name = "zzz-unknown-newsletter"
+    patch_data = {
+        "newsletters": [
+            {
+                "name": unknown_name,
+                "subscribed": False,
+                "unsub_reason": "bulk unsubscribe",
+            }
+        ]
+    }
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
+    assert not any(nl["name"] == unknown_name for nl in actual["newsletters"])

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -13,6 +13,8 @@ from ctms.crud import (
     create_newsletter,
     get_contact_by_email_id,
     get_contacts_by_any_id,
+    get_email,
+    get_emails_by_any_id,
 )
 from ctms.schemas import (
     AddOnsInSchema,
@@ -55,6 +57,112 @@ class StatementWatcher:
     @property
     def count(self):
         return len(self.statements)
+
+
+def test_get_email(dbsession, example_contact):
+    """An email is retrived in two queries, and newsletters are sorted by name."""
+    email_id = example_contact.email.email_id
+    with StatementWatcher(dbsession.connection()) as watcher:
+        email = get_email(dbsession, email_id)
+    assert watcher.count == 2
+    assert email.email_id == email_id
+    newsletter_names = [newsletter.name for newsletter in email.newsletters]
+    assert newsletter_names == ["firefox-welcome", "mozilla-welcome"]
+    assert sorted(newsletter_names) == newsletter_names
+
+
+def test_get_email_miss(dbsession):
+    """A missed email is one query."""
+    with StatementWatcher(dbsession.connection()) as watcher:
+        email = get_email(dbsession, str(uuid4()))
+    assert watcher.count == 1
+    assert email is None
+
+
+@pytest.mark.parametrize(
+    "alt_id_name,alt_id_value",
+    [
+        ("email_id", "67e52c77-950f-4f28-accb-bb3ea1a2c51a"),
+        ("primary_email", "mozilla-fan@example.com"),
+        ("amo_user_id", "123"),
+        ("basket_token", "d9ba6182-f5dd-4728-a477-2cc11bf62b69"),
+        ("fxa_id", "611b6788-2bba-42a6-98c9-9ce6eb9cbd34"),
+        ("fxa_primary_email", "fxa-firefox-fan@example.com"),
+        ("sfdc_id", "001A000001aMozFan"),
+        ("mofo_contact_id", "5e499cc0-eeb5-4f0e-aae6-a101721874b8"),
+        ("mofo_email_id", "195207d2-63f2-4c9f-b149-80e9c408477a"),
+    ],
+)
+def test_get_emails_by_any_id(dbsession, sample_contacts, alt_id_name, alt_id_value):
+    """An email is fetched by alternate id in two queries."""
+    with StatementWatcher(dbsession.connection()) as watcher:
+        emails = get_emails_by_any_id(dbsession, **{alt_id_name: alt_id_value})
+    assert watcher.count == 2
+    assert len(emails) == 1
+    newsletter_names = [newsletter.name for newsletter in emails[0].newsletters]
+    assert sorted(newsletter_names) == newsletter_names
+
+
+def test_get_emails_by_any_id_missing(dbsession, sample_contacts):
+    """One query is needed to find no emails."""
+    with StatementWatcher(dbsession.connection()) as watcher:
+        emails = get_emails_by_any_id(dbsession, basket_token=str(uuid4()))
+    assert watcher.count == 1
+    assert len(emails) == 0
+
+
+@pytest.mark.parametrize(
+    "alt_id_name,alt_id_value",
+    [
+        ("amo_user_id", "123"),
+        ("fxa_primary_email", "fxa-firefox-fan@example.com"),
+        ("sfdc_id", "001A000001aMozFan"),
+        ("mofo_contact_id", "5e499cc0-eeb5-4f0e-aae6-a101721874b8"),
+    ],
+)
+def test_get_multiple_emails_by_any_id(
+    dbsession, sample_contacts, alt_id_name, alt_id_value
+):
+    """Two emails are retrieved in two queries."""
+
+    dupe_id = str(uuid4())
+    create_email(
+        dbsession,
+        EmailInSchema(
+            email_id=dupe_id,
+            primary_email="dupe@example.com",
+            basket_token=str(uuid4()),
+            sfdc_id=alt_id_value
+            if alt_id_name == "sfdc_id"
+            else "other_sdfc_alt_id_value",
+        ),
+    )
+    if alt_id_name == "amo_user_id":
+        create_amo(dbsession, dupe_id, AddOnsInSchema(user_id=alt_id_value))
+    if alt_id_name == "fxa_primary_email":
+        create_fxa(
+            dbsession, dupe_id, FirefoxAccountsInSchema(primary_email=alt_id_value)
+        )
+    if alt_id_name == "mofo_contact_id":
+        create_mofo(
+            dbsession,
+            dupe_id,
+            MozillaFoundationInSchema(
+                mofo_email_id=str(uuid4()), mofo_contact_id=alt_id_value
+            ),
+        )
+
+    create_newsletter(dbsession, dupe_id, NewsletterInSchema(name="zzz_sleepy_news"))
+    create_newsletter(dbsession, dupe_id, NewsletterInSchema(name="aaa_game_news"))
+    dbsession.flush()
+
+    with StatementWatcher(dbsession.connection()) as watcher:
+        emails = get_emails_by_any_id(dbsession, **{alt_id_name: alt_id_value})
+    assert watcher.count == 2
+    assert len(emails) == 2
+    for email in emails:
+        newsletter_names = [newsletter.name for newsletter in email.newsletters]
+        assert sorted(newsletter_names) == newsletter_names
 
 
 def test_get_contact_by_email_id_found(dbsession, example_contact):


### PR DESCRIPTION
As part of issue #128, add a ``PATCH /ctms/{email_id}`` API.

* The request is similar to ``PUT /ctms/{email_id}``, but the object must already exist
* It can't be used to change the ``email_id``
* Only the included items are updated; excluded items keep the existing values
* If a group is set to all default values, it is deleted from the database
* Newsletter subscription can be done by adding it to the ``newsletters`` list. It is not required to send all the user's subscriptions, but Basket probably will anyway.
* Newsletter unsubscription is done by setting ``"subscribed": False`` for that subscription, ``name`` is required. 


Differences from issue #128:

* I used a ``303 See Other`` redirect instead of a ``200``. I think a 2xx response is still a good idea to work better with the interactive docs repo, but I think some further changes are needed to make that easy, so it should be a new PR.
* I didn't handle cases of unique ID conflicts, it currently is a 5xx error
* I didn't add a way to delete a group, other than setting everything to defaults. Basket may need this to support some private APIs
* I didn't add a way to unsubscribe from all newsletters. This could be hacked on the Basket side, but something similar to group deletion may be more elegant.

I'm planning to address these in future PRs, but I'm open to including any of these changes in this PR.

What types of changes does your code introduce?
- ✓ New feature (non-breaking change which adds functionality)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- *N/A* I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules

## Further comments

``pylint`` runs on my test files, despite them being skipped in ``scripts/lint.sh``. Some changes were suggested by linting, like ``watcher`` instead of ``sw`` for ``StatementWatcher``, and keeping ``test_api.py`` from exceeding 1000 lines by adding the tests to a new file ``test_api_patch.py``.

