### PR TITLE
Add more features to ``PATCH`` API

### DIFF
--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -408,12 +408,16 @@ def update_contact(db: Session, email: Email, update_data: dict) -> None:
     for group_name, (creator, schema) in simple_groups.items():
         if group_name in update_data:
             existing = getattr(email, group_name)
-            if existing is None:
-                creator(db, email_id, schema(**update_data[group_name]))
-            else:
-                update_orm(existing, update_data[group_name])
-                if schema.from_orm(existing).is_default():
+            if update_data[group_name] == "DELETE":
+                if existing:
                     db.delete(existing)
+            else:
+                if existing is None:
+                    creator(db, email_id, schema(**update_data[group_name]))
+                else:
+                    update_orm(existing, update_data[group_name])
+                    if schema.from_orm(existing).is_default():
+                        db.delete(existing)
 
     if "newsletters" in update_data:
         if update_data["newsletters"] == "UNSUBSCRIBE":

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -416,14 +416,18 @@ def update_contact(db: Session, email: Email, update_data: dict) -> None:
                     db.delete(existing)
 
     if "newsletters" in update_data:
-        existing = {}
-        for newsletter in getattr(email, "newsletters", []):
-            existing[newsletter.name] = newsletter
-        for nl_update in update_data["newsletters"]:
-            if nl_update["name"] in existing:
-                update_orm(existing[nl_update["name"]], nl_update)
-            elif nl_update.get("subscribed", True):
-                create_newsletter(db, email_id, NewsletterInSchema(**nl_update))
+        if update_data["newsletters"] == "UNSUBSCRIBE":
+            for newsletter in getattr(email, "newsletters", []):
+                update_orm(newsletter, {"subscribed": False})
+        else:
+            existing = {}
+            for newsletter in getattr(email, "newsletters", []):
+                existing[newsletter.name] = newsletter
+            for nl_update in update_data["newsletters"]:
+                if nl_update["name"] in existing:
+                    update_orm(existing[nl_update["name"]], nl_update)
+                elif nl_update.get("subscribed", True):
+                    create_newsletter(db, email_id, NewsletterInSchema(**nl_update))
 
 
 def create_api_client(db: Session, api_client: ApiClientSchema, secret):

--- a/ctms/schemas/contact.py
+++ b/ctms/schemas/contact.py
@@ -104,13 +104,36 @@ class ContactInSchema(ContactInBase):
 
 
 class ContactPutSchema(ContactInBase):
-    """A contact as provided by callers when using POST. This is nearly identical to the ContactInSchema but does require an email_id."""
+    """A contact as provided by callers when using PUT. This is nearly identical to the ContactInSchema but does require an email_id."""
 
     email: EmailPutSchema
 
 
-class ContactPatchSchema(ContactInBase):
+class ContactPatchSchema(ComparableBase):
+    """A contact provided by callers when using PATCH.
+
+    This is nearly identical to ContactInSchema, but almost everything
+    is optional, and some values can be action strings instead of lists or
+    objects.
+    """
+
+    amo: Optional[AddOnsInSchema]
     email: Optional[EmailPatchSchema]
+    fxa: Optional[FirefoxAccountsInSchema]
+    mofo: Optional[MozillaFoundationInSchema]
+    newsletters: Optional[Union[List[NewsletterSchema], Literal["UNSUBSCRIBE"]]]
+    vpn_waitlist: Optional[VpnWaitlistInSchema]
+
+    class Config:
+        fields = {
+            "newsletters": {
+                "description": (
+                    "List of newsletters to add or update, or 'UNSUBSCRIBE' to"
+                    " unsubscribe from all."
+                ),
+                "example": [{"name": "firefox-welcome", "subscribed": False}],
+            }
+        }
 
 
 class CTMSResponse(BaseModel):

--- a/ctms/schemas/contact.py
+++ b/ctms/schemas/contact.py
@@ -113,26 +113,36 @@ class ContactPatchSchema(ComparableBase):
     """A contact provided by callers when using PATCH.
 
     This is nearly identical to ContactInSchema, but almost everything
-    is optional, and some values can be action strings instead of lists or
-    objects.
+    is optional, and some values can be action strings (like "DELETE" or
+    "UNSUBSCRIBE" instead of lists or objects.
     """
 
-    amo: Optional[AddOnsInSchema]
+    amo: Optional[Union[Literal["DELETE"], AddOnsInSchema]]
     email: Optional[EmailPatchSchema]
-    fxa: Optional[FirefoxAccountsInSchema]
-    mofo: Optional[MozillaFoundationInSchema]
+    fxa: Optional[Union[Literal["DELETE"], FirefoxAccountsInSchema]]
+    mofo: Optional[Union[Literal["DELETE"], MozillaFoundationInSchema]]
     newsletters: Optional[Union[List[NewsletterSchema], Literal["UNSUBSCRIBE"]]]
-    vpn_waitlist: Optional[VpnWaitlistInSchema]
+    vpn_waitlist: Optional[Union[Literal["DELETE"], VpnWaitlistInSchema]]
 
     class Config:
         fields = {
+            "amo": {"description": 'Add-ons data to update, or "DELETE" to reset.'},
+            "fxa": {
+                "description": 'Firefox Accounts data to update, or "DELETE" to reset.'
+            },
+            "mofo": {
+                "description": 'Mozilla Foundation data to update, or "DELETE" to reset.'
+            },
             "newsletters": {
                 "description": (
                     "List of newsletters to add or update, or 'UNSUBSCRIBE' to"
                     " unsubscribe from all."
                 ),
                 "example": [{"name": "firefox-welcome", "subscribed": False}],
-            }
+            },
+            "vpn_waitlist": {
+                "description": 'VPN Waitlist data to update, or "DELETE" to reset.'
+            },
         }
 
 

--- a/tests/unit/test_api_patch.py
+++ b/tests/unit/test_api_patch.py
@@ -409,3 +409,13 @@ def test_patch_to_unsubscribe_but_not_subscribed(client, maximal_contact):
     actual = resp.json()
     assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
     assert not any(nl["name"] == unknown_name for nl in actual["newsletters"])
+
+
+def test_patch_unsubscribe_all(client, maximal_contact):
+    email_id = maximal_contact.email.email_id
+    patch_data = {"newsletters": "UNSUBSCRIBE"}
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
+    assert all(not nl["subscribed"] for nl in actual["newsletters"])


### PR DESCRIPTION
## Proposed changes

To fix issue #131, add some more features to the ``PATCH`` API:

* If there is an ID collision, such as a matching ``primary_email``, return a ``409 Conflict`` and make none of the changes.
* Use ``{"newsletters": "UNSUBSCRIBE"}`` to unsubscribe from all newsletters
* Use ``{"amo": "DELETE"}`` to delete the CTMS add-ons data and reset to defaults. A similar command works for ``fxa``, ``mofo``, and ``vpn_waitlist``.

## Types of changes

What types of changes does your code introduce?
- ✓ Bugfix (non-breaking change which fixes an issue)
- ✓ New feature (non-breaking change which adds functionality)

## Checklist

- ✓ I have read the [guides](https://github.com/mozilla-it/ctms-api/tree/main/guides)
- ✓ I have followed the [Mozilla Lean Data Policies](https://www.mozilla.org/en-US/about/policy/lean-data/)
- ✓ Lint and tests pass both locally and on the cicd with my changes
- ✓ I have added tests that prove my fix is effective or that my feature works
- ✓ I have added necessary documentation (if appropriate)
- *N/A* Any dependent changes have been merged and published in downstream modules
