### PR TITLE
Add grant=refresh-token to /token

### DIFF
--- a/ctms/auth.py
+++ b/ctms/auth.py
@@ -95,7 +95,7 @@ class OAuth2ClientCredentialsRequestForm:
 
     def __init__(
         self,
-        grant_type: str = Form(None, regex="client_credentials"),
+        grant_type: str = Form(None, regex="^(client_credentials|refresh_token)$"),
         scope: str = Form(""),
         client_id: Optional[str] = Form(None),
         client_secret: Optional[str] = Form(None),

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -96,6 +96,23 @@ def test_post_token_succeeds_no_grant(anon_client, client_id_and_secret):
     assert resp.status_code == 200
 
 
+def test_post_token_succeeds_refresh_grant(
+    anon_client, test_token_settings, client_id_and_secret
+):
+    """If grant_type is refresh_token, the token grant is successful."""
+    client_id, client_secret = client_id_and_secret
+    resp = anon_client.post(
+        "/token",
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": None,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+    )
+    assert resp.status_code == 200
+
+
 def test_post_token_fails_wrong_grant(anon_client, client_id_and_secret):
     """If grant_type is omitted, getting a token fails."""
     resp = anon_client.post(
@@ -104,10 +121,11 @@ def test_post_token_fails_wrong_grant(anon_client, client_id_and_secret):
         auth=HTTPBasicAuth(*client_id_and_secret),
     )
     assert resp.status_code == 422
+    pattern = "^(client_credentials|refresh_token)$"
     assert resp.json()["detail"][0] == {
-        "ctx": {"pattern": "client_credentials"},
+        "ctx": {"pattern": pattern},
         "loc": ["body", "grant_type"],
-        "msg": 'string does not match regex "client_credentials"',
+        "msg": f'string does not match regex "{pattern}"',
         "type": "value_error.str.regex",
     }
 


### PR DESCRIPTION
Allow ``grant=refresh-token`` as well as ``grant=client-credentials`` for the ``/token`` endpoint to get an access token. The ``client_id`` and ``client_password`` are still required, and a ``refresh_token`` is not provided, required or checked. This gives it the same security as granting the original token.

This fixes issue #132, which explains why Basket will use this code.