### PR TITLE
Add MozLog format for request logging

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -32,6 +32,7 @@ from .crud import (
     update_contact,
 )
 from .database import get_db_engine
+from .logging import configure_logging
 from .models import Email
 from .monitor import check_database, get_version
 from .schemas import (
@@ -73,7 +74,9 @@ def get_settings():
 @app.on_event("startup")
 def startup_event():
     global SessionLocal  # pylint:disable = W0603
-    _, session_factory = get_db_engine(get_settings())
+    settings = get_settings()
+    configure_logging(settings.use_mozlog, settings.logging_level)
+    _, session_factory = get_db_engine(settings)
     SessionLocal = scoped_session(session_factory)
 
 

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Literal
 
 from pydantic import BaseSettings, PostgresDsn
 
@@ -8,6 +9,8 @@ class Settings(BaseSettings):
     secret_key: str
     token_expiration: timedelta = timedelta(minutes=60)
     server_prefix: str = "http://localhost:8000"
+    use_mozlog: bool = True
+    logging_level: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = "INFO"
 
     class Config:
         env_prefix = "ctms_"

--- a/ctms/logging.py
+++ b/ctms/logging.py
@@ -65,6 +65,10 @@ class UvicornJsonLogFormatter(JsonLogFormatter):
                             f"headers{'.' if hfield else ''}{hfield}"
                             for hfield in byte_fields
                         )
+                    elif key == "state":
+                        # Import log context from CTMS
+                        for skey, sval in value.get("log_context", {}).items():
+                            out[skey] = sval
                     elif key == "endpoint" and hasattr(value, "__name__"):
                         out["endpoint"] = value.__name__  # Endpoint function
                     elif (

--- a/ctms/logging.py
+++ b/ctms/logging.py
@@ -13,6 +13,10 @@ class UvicornJsonLogFormatter(JsonLogFormatter):
     DROP_FIELDS = {
         "color_message",
     }
+    DROP_SCOPE_FIELDS = {
+        "root_path",  # FastAPI proxy path
+        "raw_path",  # Uvicorn path as bytes
+    }
     SECURITY_HEADERS = {
         "cookie",  # CSRF token, not needed in logs
         "authorization",  # Basic auth or OAuth2 bearer tokens
@@ -60,7 +64,10 @@ class UvicornJsonLogFormatter(JsonLogFormatter):
             elif field_key == "scope":
                 # Lift up relevant request details from scope, drop irrelevant details
                 for key, value in field_value.items():
-                    if key == "headers":
+                    if key in self.DROP_SCOPE_FIELDS:
+                        if self.log_dropped_fields:
+                            dropped.append(f"scope.{key}")
+                    elif key == "headers":
                         headers, byte_fields, have_dupes = self.convert_headers(value)
                         out["headers"] = headers
                         if have_dupes:

--- a/ctms/logging.py
+++ b/ctms/logging.py
@@ -18,9 +18,13 @@ class UvicornJsonLogFormatter(JsonLogFormatter):
         "authorization",  # Basic auth or OAuth2 bearer tokens
     }
 
-    def __init__(self, report_dropped=False, **kwargs):
+    def __init__(self, log_dropped_fields=False, **kwargs):
         """
-        Allow recording dropped uvicorn fields.
+        Initialize the UvicornJsonLogFormatter.
+
+        Adds one extra parameter to JsonLogFormatter:
+
+        * log_dropped_fields: Add "dropped_fields" list to log context.
 
         These fields are dropped because they tend to be class instances that
         are not useful for logging. This setting could be used in production
@@ -28,7 +32,7 @@ class UvicornJsonLogFormatter(JsonLogFormatter):
         available.
         """
         super().__init__(**kwargs)
-        self.report_dropped = report_dropped
+        self.log_dropped_fields = log_dropped_fields
 
     def convert_record(self, record):
         """
@@ -51,7 +55,7 @@ class UvicornJsonLogFormatter(JsonLogFormatter):
         is_bytes = []
         for field_key, field_value in fields.items():
             if field_key in self.DROP_FIELDS:
-                if self.report_dropped:
+                if self.log_dropped_fields:
                     dropped.append(field_key)
             elif field_key == "scope":
                 # Lift up relevant request details from scope, drop irrelevant details
@@ -88,7 +92,7 @@ class UvicornJsonLogFormatter(JsonLogFormatter):
                             is_bytes.append(key)
                     elif isinstance(value, str):
                         out[key] = value
-                    elif self.report_dropped:
+                    elif self.log_dropped_fields:
                         dropped.append(f"scope.{key}")
             else:
                 out[field_key] = field_value

--- a/ctms/logging.py
+++ b/ctms/logging.py
@@ -187,7 +187,7 @@ def configure_logging(use_mozlog=True, logging_level="INFO"):
     uvicorn_formatters = uvicorn.config.LOGGING_CONFIG["formatters"]
     logging_config = {
         "version": 1,
-        "disable_existing_loggers": True,
+        "disable_existing_loggers": False,
         "formatters": {
             "dev_console": {
                 "format": "%(asctime)s %(levelname)s:%(name)s:  %(message)s"

--- a/ctms/logging.py
+++ b/ctms/logging.py
@@ -1,0 +1,250 @@
+"""Logging configuration"""
+
+import logging
+import logging.config
+
+import uvicorn
+from dockerflow.logging import JsonLogFormatter
+
+
+class UvicornJsonLogFormatter(JsonLogFormatter):
+    """Dockerflow JsonLogFormatter, with special handling for uvicorn scope."""
+
+    DROP_FIELDS = {
+        "color_message",
+    }
+    SECURITY_HEADERS = {
+        "cookie",  # CSRF token, not needed in logs
+        "authorization",  # Basic auth or OAuth2 bearer tokens
+    }
+
+    def __init__(self, report_dropped=False, **kwargs):
+        """
+        Allow recording dropped uvicorn fields.
+
+        These fields are dropped because they tend to be class instances that
+        are not useful for logging. This setting could be used in production
+        to detect when the interface changes, and a new useful field is
+        available.
+        """
+        super().__init__(**kwargs)
+        self.report_dropped = report_dropped
+
+    def convert_record(self, record):
+        """
+        Convert a Python LogRecord attribute into a dict that follows MozLog
+        application logging standard, with special processing of the Fields
+        data added by uvicorn.
+
+        * from - https://docs.python.org/3/library/logging.html#logrecord-attributes
+        * to - https://wiki.mozilla.org/Firefox/Services/Logging
+        """
+        out = super().convert_record(record)
+        fields_in = out.get("Fields", {})
+        out["Fields"] = self.convert_fields(fields_in)
+        return out
+
+    def convert_fields(self, fields):
+        """Convert the raw uvicorn Fields dictionary to more useful data."""
+        out = {}
+        dropped = []
+        is_bytes = []
+        for field_key, field_value in fields.items():
+            if field_key in self.DROP_FIELDS:
+                if self.report_dropped:
+                    dropped.append(field_key)
+            elif field_key == "scope":
+                # Lift up relevant request details from scope, drop irrelevant details
+                for key, value in field_value.items():
+                    if key == "headers":
+                        headers, byte_fields, have_dupes = self.convert_headers(value)
+                        out["headers"] = headers
+                        if have_dupes:
+                            out["headers_have_duplicates"] = True
+                        is_bytes.extend(
+                            f"headers{'.' if hfield else ''}{hfield}"
+                            for hfield in byte_fields
+                        )
+                    elif key == "endpoint" and hasattr(value, "__name__"):
+                        out["endpoint"] = value.__name__  # Endpoint function
+                    elif (
+                        key in ("client", "server")
+                        and isinstance(value, list)
+                        and len(value) == 2
+                    ):
+                        out[f"{key}_ip"], out[f"{key}_port"] = value
+                    elif key == "path_params" and isinstance(value, dict):
+                        # Dictionary of path parameters
+                        out["path_params"] = value
+                    elif isinstance(value, bytes):
+                        # HTTP values are probably ASCII, try converting
+                        clean_value, decoded = self.attempt_to_decode_bytestring(value)
+                        out[key] = clean_value
+                        if not decoded:
+                            is_bytes.append(key)
+                    elif isinstance(value, str):
+                        out[key] = value
+                    elif self.report_dropped:
+                        dropped.append(f"scope.{key}")
+            else:
+                out[field_key] = field_value
+        if dropped:
+            out["dropped_fields"] = sorted(dropped)
+        if is_bytes:
+            out["bytes_fields"] = sorted(is_bytes)
+        return out
+
+    def attempt_to_decode_bytestring(self, string):
+        """
+        Attempt to decode a bytestring as ASCII string
+
+        Return is two elements:
+        * The converted or original string
+        * True if the output is a string, False if original
+        """
+        if isinstance(string, str):
+            return string, True
+
+        if isinstance(string, bytes):
+            try:
+                out = string.decode("ascii")
+            except:  # pylint: disable=bare-except
+                # Handle Python bugs like #31825
+                return string, False
+            else:
+                return out, True
+        else:
+            return string, False
+
+    def convert_headers(self, headers):
+        """
+        Convert uvicorn raw headers
+
+        Actions:
+        * Omit the values from security headers
+        * Attempt to convert header names and values to strings
+        * Turn into a dictionary of header to values, or list of
+          values when multiple headers returned
+
+        Return is tuple:
+        * headers dict
+        * list of fields with bytes, or empty string if a header name is bytes
+        * True if any header was provided twice
+        """
+        # Process bytestring headers, omit security details
+        new_headers = {}
+        byte_fields = []
+        has_duplicates = False
+
+        for header_name, header_val in headers:
+            header_name, header_decoded = self.attempt_to_decode_bytestring(header_name)
+            if not header_decoded:
+                byte_fields.append("")
+            if header_name in self.SECURITY_HEADERS:
+                clean_val = "[OMITTED]"
+            else:
+                clean_val, decoded = self.attempt_to_decode_bytestring(header_val)
+                if header_decoded and not decoded:
+                    byte_fields.append(header_name)
+            if header_name in new_headers:
+                has_duplicates = True
+                old_value = new_headers[header_name]
+                if isinstance(old_value, list):
+                    new_value = old_value
+                else:
+                    new_value = [old_value]
+                new_value.append(clean_val)
+                new_headers[header_name] = new_value
+            else:
+                new_headers[header_name] = clean_val
+        return new_headers, byte_fields, has_duplicates
+
+
+def configure_logging(use_mozlog=True, logging_level="INFO"):
+    """Configure Python logging.
+
+    :param use_mozlog: If True, use MozLog format, appropriate for deployments.
+        If False, format logs for human consumption.
+    :param logging_level: The logging level, such as DEBUG or INFO.
+    """
+
+    # Processors used for logs generated by stdlib's logging
+    uvicorn_formatters = uvicorn.config.LOGGING_CONFIG["formatters"]
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "dev_console": {
+                "format": "%(asctime)s %(levelname)s:%(name)s:  %(message)s"
+            },
+            "mozlog_json": {
+                "()": "ctms.logging.JsonLogFormatter",
+                "logger_name": "ctms",
+            },
+            "uvicorn_access": uvicorn_formatters["access"],
+            "uvicorn_default": uvicorn_formatters["default"],
+            "uvicorn_mozlog": {
+                "()": "ctms.logging.UvicornJsonLogFormatter",
+                "logger_name": "ctms",
+            },
+        },
+        "handlers": {
+            "humans": {
+                "class": "logging.StreamHandler",
+                "formatter": "dev_console",
+                "level": "DEBUG",
+            },
+            "mozlog": {
+                "class": "logging.StreamHandler",
+                "formatter": "mozlog_json",
+                "level": "DEBUG",
+            },
+            "uvicorn.access": {
+                "class": "logging.StreamHandler",
+                "formatter": "uvicorn_access",
+                "level": "INFO",
+            },
+            "uvicorn.default": {
+                "class": "logging.StreamHandler",
+                "formatter": "uvicorn_default",
+                "level": "INFO",
+            },
+            "uvicorn.mozlog": {
+                "class": "logging.StreamHandler",
+                "formatter": "uvicorn_mozlog",
+                "level": "INFO",
+            },
+        },
+        "loggers": {
+            "alembic": {
+                "propagate": False,
+                "handlers": ["mozlog" if use_mozlog else "humans"],
+                "level": logging_level,
+            },
+            "ctms": {
+                "propagate": False,
+                "handlers": ["mozlog" if use_mozlog else "humans"],
+                "level": logging_level,
+            },
+            "uvicorn": {
+                "handlers": ["uvicorn.mozlog" if use_mozlog else "uvicorn.default"],
+                "level": logging_level,
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "handlers": ["uvicorn.mozlog" if use_mozlog else "uvicorn.default"],
+                "level": logging_level,
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["uvicorn.mozlog" if use_mozlog else "uvicorn.access"],
+                "level": logging_level,
+                "propagate": False,
+            },
+        },
+        "root": {
+            "handlers": ["mozlog" if use_mozlog else "humans"],
+            "level": "WARNING",
+        },
+    }
+    logging.config.dictConfig(logging_config)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,4 +110,4 @@ WORKDIR /app
 
 EXPOSE $PORT
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD uvicorn ctms.app:app --host=0.0.0.0 --port=${PORT}
+CMD uvicorn ctms.app:app --host=0.0.0.0 --port=${PORT} --log-config /app/docker/log_config.json

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -8,3 +8,7 @@ CTMS_SECRET_KEY=dev_only_secret_key_not_for_production
 
 # Webserver protocol and domain
 CTMS_SERVER_PREFIX=http://localhost:8000
+
+# Logging
+CTMS_USE_MOZLOG=False
+CTMS_LOGGING_LEVEL=INFO

--- a/docker/log_config.json
+++ b/docker/log_config.json
@@ -1,0 +1,47 @@
+{
+    "_note": "Overwritten when CTMS app starts up.",
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "uvicorn_mozlog": {
+            "()": "dockerflow.logging.JsonLogFormatter",
+            "logger_name": "ctms"
+        }
+    },
+    "handlers": {
+        "uvicorn.mozlog": {
+            "class": "logging.StreamHandler",
+            "formatter": "uvicorn_mozlog",
+            "level": "INFO"
+        }
+    },
+    "loggers": {
+        "uvicorn": {
+            "handlers": [
+                "uvicorn.mozlog"
+            ],
+            "level": "INFO",
+            "propagate": false
+        },
+        "uvicorn.error": {
+            "handlers": [
+                "uvicorn.mozlog"
+            ],
+            "level": "INFO",
+            "propagate": false
+        },
+        "uvicorn.access": {
+            "handlers": [
+                "uvicorn.mozlog"
+            ],
+            "level": "INFO",
+            "propagate": false
+        }
+    },
+    "root": {
+        "handlers": [
+            "uvicorn.mozlog"
+        ],
+        "level": "WARNING"
+    }
+}

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -35,6 +35,8 @@ production, they are set as part of the runtime environment.
 * ``CTMS_USE_MOZLOG`` - Use the JSON
   [MozLog](https://wiki.mozilla.org/Firefox/Services/Logging) format for logs.
   Defaults to `True` as used in production, and is set to `False` for development.
+  See the [deployment guide](./deployment_guide.md) for more information on the
+  MozLog format.
 
 * ``MK_KEEP_DOCKER_UP`` - If unset, then ``make test`` runs ``docker-compose down``
   after tests run, shutting down the PostgreSQL container.  If set to ``1``,

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,0 +1,72 @@
+# Configuration
+
+Most configuration is done through environment variables. In the development
+environment, these are stored in files for ease of editing and loading. In
+production, they are set as part of the runtime environment.
+
+## Environment Configuration
+
+* ``CTMS_DB_URL`` - The database connection parameters, formatted as a URL.
+  In the development environment, this defaults to talk to the ``postgres``
+  container. In production, it is set to talk to the provisioned database.
+
+* ``CTMS_GID`` - The group ID of the ``app`` account, used to run the CTMS
+  application. If unset, defaults to 10001. On Linux development systems, set
+  along with ``CTMS_UID`` to match the development user, for consistent permissions.
+
+* ``CTMS_LOGGING_LEVEL`` - The minimum level for logs. Defaults to ``INFO`` if
+  unset. Unset in production, and set to ``INFO`` in development.
+
+* ``CTMS_SECRET_KEY`` - An encryption key, used for OAuth2 and other hashes.
+  Set to a long but non-secret value for development, and set to a randomized
+  string for each production deployment.
+
+* ``CTMS_TOKEN_EXPIRATION`` - How long an OAuth2 access token is valid, in seconds.
+  If unset, defaults to one hour.
+
+* ``CTMS_SERVER_PREFIX`` - The protocol and domain part of the server name, used
+  to construct full URLS. Set to ``http://localhost:8000`` in development, and
+  the user-facing prefix in production.
+
+* ``CTMS_UID`` - The user ID of the ``app`` account, used to run the CTMS
+  application. If unset, defaults to 10001. On Linux development systems, set
+  along with ``CTMS_GID`` to match the development user, for consistent permissions.
+
+* ``CTMS_USE_MOZLOG`` - Use the JSON
+  [MozLog](https://wiki.mozilla.org/Firefox/Services/Logging) format for logs.
+  Defaults to `True` as used in production, and is set to `False` for development.
+
+* ``MK_KEEP_DOCKER_UP`` - If unset, then ``make test`` runs ``docker-compose down``
+  after tests run, shutting down the PostgreSQL container.  If set to ``1``,
+  ``make test`` keeps containers running.
+
+* ``MK_WITH_SERVICE_PORTS`` - If set to ``--service-ports``, passes that option
+  to ``docker run`` commands, allowing access to host-based commands.
+
+* ``PORT`` - The port for the web service. Defaults to 8000 if unset.
+
+### Environment Configuration Files
+
+The file ``ctms/config.py`` defines the environment settings for the CTMS API.
+
+In the production environment, environment variables are set in the deployment
+instances and read by the CTMS API application for configuration. When
+possible, the default values of environment variables are appropriate for
+production.
+
+In the local development environment, the default configuration is in
+``docker/config/local_dev.env``, and overrides are in ``.env``. The file
+``docker/config/env.dist`` is the ``.env`` template for new developer
+environments.
+
+All configuration in ``.env`` is optional. Linux users should set
+``CTMS_UID`` and ``CTMS_GID`` to match their user account, so that files
+created inside the docker container have the same permissions as their user
+account.
+
+``.env`` is loaded in the ``Makefile``, making those configuration items
+available in Makefile targets and commands. ``local_dev.env`` and ``.env``
+are loaded by ``docker-compose`` and passed to Docker. Some adjust the build
+process by setting `ARG` variables in the ``Dockerfile``. Others are passed
+to the runtime environment. The CTMS API application then loads these from
+the environment.

--- a/guides/deployment_guide.md
+++ b/guides/deployment_guide.md
@@ -102,15 +102,15 @@ access token. These values are replaced by ``[OMITTED]``.
 
 The fields added by uvicorn are:
 
-* ``status_code`` - HTTP status code as integer, such as 200 or 404
-* ``type`` - Type of request, such as "http"
+* ``headers`` - Dictionary of header names (lowercased) to header values
 * ``http_version`` - HTTP version, such as "1.0" or "1.1"
-* ``scheme`` - Scheme, such as "http" or "https"
 * ``method`` - HTTP method, such as "GET" or "POST"
+* ``msg`` - A request summary suitable for humans
 * ``path`` - Path portion of URL, such as "/ctms"
 * ``query_string`` - Querystring portion of URL, not decoded
-* ``headers`` - Dictionary of header names (lowercased) to header values
-* ``msg`` - A request summary suitable for humans
+* ``scheme`` - Scheme, such as "http" or "https"
+* ``status_code`` - HTTP status code as integer, such as 200 or 404
+* ``type`` - Type of request, such as "http"
 
 Others are added by FastAPI:
 

--- a/guides/deployment_guide.md
+++ b/guides/deployment_guide.md
@@ -42,7 +42,7 @@ When the environment variable ``CTMS_USE_MOZLOG`` is set to true or unset, then
 the [MozLog JSON format](https://wiki.mozilla.org/Firefox/Services/Logging) is
 used for logging.
 
-## Example
+### Example
 
 Here's what a single log line from development looks like, formatted as
 multi-line JSON for clarity:

--- a/guides/deployment_guide.md
+++ b/guides/deployment_guide.md
@@ -34,3 +34,98 @@ We use a variety of technologies to get this code into production.  Starting fro
       1. the images with v{semver} will automatically be deployed to prod
 1. The eks clusters in the ess account are configured with fluxcd/helm operator to watch those helm release files
 1. terraform defines the eks clusters, and any databases we may require (https://github.com/mozilla-it/ctms-infra/tree/main/terraform)
+
+
+## Logging
+
+When the environment variable ``CTMS_USE_MOZLOG`` is set to true or unset, then
+the [MozLog JSON format](https://wiki.mozilla.org/Firefox/Services/Logging) is
+used for logging.
+
+## Example
+
+Here's what a single log line from development looks like, formatted as
+multi-line JSON for clarity:
+
+```json
+{
+  "Timestamp": 1618616777743526400,
+  "Type": "uvicorn.access",
+  "Logger": "ctms",
+  "Hostname": "a-random-docker-hostname",
+  "EnvVersion": "2.0",
+  "Severity": 6,
+  "Pid": 207,
+  "Fields": {
+    "status_code": 200,
+    "type": "http",
+    "http_version": "1.1",
+    "scheme": "http",
+    "method": "GET",
+    "root_path": "",
+    "path": "/ctms",
+    "raw_path": "/ctms",
+    "query_string": "primary_email=test%40example.com",
+    "headers": {
+      "host": "localhost:8000",
+      "accept-encoding": "gzip, deflate",
+      "cookie": "[OMITTED]",
+      "connection": "keep-alive",
+      "accept": "application/json",
+      "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15",
+      "authorization": "[OMITTED]",
+      "referer": "http://localhost:8000/docs",
+      "accept-language": "en-us"
+    },
+    "client_allowed": true,
+    "client_id": "id_test",
+    "duration_s": 0.102,
+    "endpoint": "read_ctms_by_any_id",
+    "path_params": {},
+    "msg": "172.19.0.1:57428 - \"GET /ctms?primary_email=test%40example.com HTTP/1.1\" 200"
+  }
+}
+```
+
+### Logging Fields
+The MozLog format allows for per-application data in the ``Fields`` parameter.
+
+Several fields are injected by [uvicorn](https://www.uvicorn.org), the ASGI
+server.
+
+Some of these, such as `raw_path` and the headers, are originally
+bytestrings, but the logger attempts to decode them as ASCII to unicode strings,
+and falls back to ``repr()`` to convert to a string, such as ``"b'byte string'"``.
+
+Some headers contain security sensitive information, such as client credentials and
+access token. These values are replaced by ``[OMITTED]``.
+
+The fields added by uvicorn are:
+
+* ``status_code`` - HTTP status code as integer, such as 200 or 404
+* ``type`` - Type of request, such as "http"
+* ``http_version`` - HTTP version, such as "1.0" or "1.1"
+* ``scheme`` - Scheme, such as "http" or "https"
+* ``method`` - HTTP method, such as "GET" or "POST"
+* ``path`` - Path portion of URL, such as "/ctms"
+* ``query_string`` - Querystring portion of URL, not decoded
+* ``headers`` - Dictionary of header names (lowercased) to header values
+* ``msg`` - A request summary suitable for humans
+
+Others are added by FastAPI:
+
+* ``endpoint`` - The name of the function handling the endpoint
+* ``path_params`` - A dictionary of parameters such as ``email_id`` extracted from
+  the path
+
+CTMS adds fields for some requests:
+
+* ``auth_fail``: The reason authentication failed for an endpoint requiring an
+  OAuth2 access token
+* ``client_allowed``: ``true`` if API credentials were accepted for an endpoint
+  requiring credentials, ``false`` if rejected
+* ``client_id``: Name of the API client, such as "id_test"
+* ``duration_s``: How long the request took in seconds, rounded to the millisecond
+* ``token_cred_from``: For ``/token``, if the credentials were read from the
+  ``Authentication`` header ("header") or from the form-encoded body ("form")
+* ``token_fail``: For ``/token``, why the token request failed

--- a/guides/deployment_guide.md
+++ b/guides/deployment_guide.md
@@ -65,7 +65,9 @@ multi-line JSON for clarity:
     "root_path": "",
     "path": "/ctms",
     "raw_path": "/ctms",
-    "query_string": "primary_email=test%40example.com",
+    "query": {
+        "primary_email": "[OMITTED]",
+    },
     "headers": {
       "host": "localhost:8000",
       "accept-encoding": "gzip, deflate",
@@ -98,7 +100,8 @@ bytestrings, but the logger attempts to decode them as ASCII to unicode strings,
 and falls back to ``repr()`` to convert to a string, such as ``"b'byte string'"``.
 
 Some headers contain security sensitive information, such as client credentials and
-access token. These values are replaced by ``[OMITTED]``.
+access token. These values are replaced by ``[OMITTED]``. Similar replacement
+removes emails from the querystring (when parsed).
 
 The fields added by uvicorn are:
 
@@ -107,7 +110,8 @@ The fields added by uvicorn are:
 * ``method`` - HTTP method, such as "GET" or "POST"
 * ``msg`` - A request summary suitable for humans
 * ``path`` - Path portion of URL, such as "/ctms"
-* ``query_string`` - Querystring portion of URL, not decoded
+* ``query_string`` - Querystring portion of URL, if not decoded and parse
+* ``query`` - Query parameters, if decoded and parsed
 * ``scheme`` - Scheme, such as "http" or "https"
 * ``status_code`` - HTTP status code as integer, such as 200 or 404
 * ``type`` - Type of request, such as "http"

--- a/guides/developer_setup.md
+++ b/guides/developer_setup.md
@@ -244,5 +244,8 @@ Please view the [Git Strategy](git_strategy.md)
 ### Testing
 Please view the [Testing Strategy](testing_strategy.md)
 
+### Configuration
+See [Configuration](configuration.md) for local and production configuration settings.
+
 ---
 [View All Docs](./)

--- a/poetry.lock
+++ b/poetry.lock
@@ -259,6 +259,19 @@ curio = ["curio (>=1.2)", "sniffio (>=1.1)"]
 trio = ["trio (>=0.14.0)", "sniffio (>=1.1)"]
 
 [[package]]
+name = "dockerflow"
+version = "2020.10.0"
+description = "Python tools and helpers for Mozilla's Dockerflow"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+django = ["django"]
+flask = ["flask", "blinker"]
+sanic = ["sanic"]
+
+[[package]]
 name = "docutils"
 version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
@@ -1261,7 +1274,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.10" # google-cloud-bigquery requires this range
-content-hash = "8f591b594ffe87742e214b621e970c432190cf1ff05379d5ec60f664cce9cc9f"
+content-hash = "403b1e1030a10f429f69d0069399e77a201a1ab960eaf13fa35e416e9e08ae47"
 
 [metadata.files]
 alabaster = [
@@ -1461,6 +1474,10 @@ distlib = [
 dnspython = [
     {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
     {file = "dnspython-2.1.0.zip", hash = "sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4"},
+]
+dockerflow = [
+    {file = "dockerflow-2020.10.0-py2.py3-none-any.whl", hash = "sha256:226086becc436b5a1995348e26c4fb2ad1d4e5dbc10dffec0c675c9a43306c8b"},
+    {file = "dockerflow-2020.10.0.tar.gz", hash = "sha256:36787fa016e5505d71d60c36cd4e0de7b2d1e50059160bd4e93ceb62bb40d3f8"},
 ]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ python-jose = {extras = ["cryptography"], version = "^3.2.0"}
 passlib = {extras = ["argon2"], version = "^1.7.4"}
 python-dateutil = "^2.8.1"
 google-cloud-bigquery = "^2.13.1"
+dockerflow = "^2020.10.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,309 @@
+# -*- coding: utf-8 -*-
+"""Tests for logging helpers"""
+from unittest.mock import Mock
+
+import pytest
+
+from ctms.app import app, create_or_update_ctms_contact, login, root
+from ctms.logging import UvicornJsonLogFormatter
+
+
+@pytest.fixture
+def formatter():
+    return UvicornJsonLogFormatter(logger_name="ctms", report_dropped=True)
+
+
+def test_uvicorn_mozlog_drop_color_message(formatter):
+    """UvicornJsonLogFormatter drops color_message, sent by some error logs."""
+    fields_in = {
+        "color_message": "Finished server process [\u001b[36m%d\u001b[0m]",
+        "msg": "Finished server process [30]",
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "dropped_fields": ["color_message"],
+        "msg": "Finished server process [30]",
+    }
+
+
+def test_uvicorn_mozlog_silent_drop_fields():
+    """The field dropped_fields can be omitted."""
+    fmt = UvicornJsonLogFormatter(logger_name="ctms", report_dropped=False)
+    fields_in = {
+        "color_message": "Finished server process [\u001b[36m%d\u001b[0m]",
+        "msg": "Finished server process [30]",
+    }
+    out = fmt.convert_fields(fields_in)
+    assert out == {"msg": "Finished server process [30]"}
+
+
+def test_uvicorn_mozlog_root_path_call(formatter):
+    """
+    UvicornJsonLogFormatter converts the 307 redirect from calling /.
+
+    This is similar to a call in the local development environment.
+    """
+    fields_in = {
+        "status_code": 307,
+        "scope": {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.1"},
+            "http_version": "1.1",
+            "server": ["172.19.0.3", 8000],
+            "client": ["172.19.0.1", 56988],
+            "scheme": "http",
+            "method": "GET",
+            "root_path": "",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": [
+                [b"host", b"localhost:8000"],
+                [b"accept", b"text/html,application/xhtml+xml"],
+                [b"upgrade-insecure-requests", b"1"],
+                [b"cookie", b"csrftoken=0WzTs-more-base64"],
+                [b"user-agent", b"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6)"],
+                [b"accept-language", b"en-us"],
+                [b"accept-encoding", b"gzip, deflate"],
+                [b"connection", b"keep-alive"],
+            ],
+            "fastapi_astack": Mock(),
+            "app": app,
+            "router": Mock(),
+            "endpoint": root,
+            "path_params": {},
+        },
+        "msg": '172.19.0.1:56988 - "GET / HTTP/1.1" 307',
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "client_ip": "172.19.0.1",
+        "client_port": 56988,
+        "dropped_fields": [
+            "scope.app",
+            "scope.asgi",
+            "scope.fastapi_astack",
+            "scope.router",
+        ],
+        "endpoint": "root",
+        "headers": {
+            "accept": "text/html,application/xhtml+xml",
+            "accept-encoding": "gzip, deflate",
+            "accept-language": "en-us",
+            "connection": "keep-alive",
+            "cookie": "[OMITTED]",
+            "host": "localhost:8000",
+            "upgrade-insecure-requests": "1",
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6)",
+        },
+        "http_version": "1.1",
+        "method": "GET",
+        "msg": '172.19.0.1:56988 - "GET / HTTP/1.1" 307',
+        "path": "/",
+        "path_params": {},
+        "query_string": "",
+        "raw_path": "/",
+        "root_path": "",
+        "scheme": "http",
+        "server_ip": "172.19.0.3",
+        "server_port": 8000,
+        "status_code": 307,
+        "type": "http",
+    }
+
+
+def test_uvicorn_mozlog_token_request(formatter):
+    """
+    UvicornJsonLogFormatter converts the 200 from a successful token request.
+
+    This is similar to a call in the local development environment,
+    but omits most fields from previous tests.
+    """
+    fields_in = {
+        "status_code": 200,
+        "scope": {
+            "method": "POST",
+            "headers": [
+                [b"authorization", b"Basic base64-string"],
+                [b"x-requested-with", b"XMLHttpRequest"],
+                [b"content-type", b"application/x-www-form-urlencoded"],
+                [b"content-length", b"29"],
+                [b"referer", b"http://localhost:8000/docs"],
+                [b"origin", b"http://localhost:8000"],
+                [b"cookie", b"csrftoken=0WzT-base64-string"],
+            ],
+            "path": "/token",
+            "endpoint": login,
+        },
+        "msg": '172.19.0.1:57002 - "POST /token HTTP/1.1" 200',
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "endpoint": "login",
+        "headers": {
+            "authorization": "[OMITTED]",
+            "content-length": "29",
+            "content-type": "application/x-www-form-urlencoded",
+            "cookie": "[OMITTED]",
+            "origin": "http://localhost:8000",
+            "referer": "http://localhost:8000/docs",
+            "x-requested-with": "XMLHttpRequest",
+        },
+        "method": "POST",
+        "msg": '172.19.0.1:57002 - "POST /token HTTP/1.1" 200',
+        "path": "/token",
+        "status_code": 200,
+    }
+
+
+def test_uvicorn_mozlog_put_api_call(formatter):
+    """
+    UvicornJsonLogFormatter converts the 303 from a successful PUT request.
+
+    This is similar to a call in the local development environment,
+    but omits most fields from previous tests.
+    """
+    fields_in = {
+        "status_code": 303,
+        "scope": {
+            "method": "PUT",
+            "path": "/ctms/e1d35779-9f14-4553-b2aa-85f9629f68bb",
+            "headers": [
+                [b"authorization", b"Bearer eyJh-base64-string"],
+                [b"content-length", b"1300"],
+                [b"cookie", b"csrftoken=a-base64-string"],
+            ],
+            "endpoint": create_or_update_ctms_contact,
+            "path_params": {"email_id": "e1d35779-9f14-4553-b2aa-85f9629f68bb"},
+        },
+        "msg": '172.19.0.1:57014 - "PUT /ctms/e1d35779-9f14-4553-b2aa-85f9629f68bb HTTP/1.1" 303',
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "endpoint": "create_or_update_ctms_contact",
+        "headers": {
+            "authorization": "[OMITTED]",
+            "content-length": "1300",
+            "cookie": "[OMITTED]",
+        },
+        "method": "PUT",
+        "msg": (
+            "172.19.0.1:57014 - "
+            '"PUT /ctms/e1d35779-9f14-4553-b2aa-85f9629f68bb HTTP/1.1"'
+            " 303"
+        ),
+        "path": "/ctms/e1d35779-9f14-4553-b2aa-85f9629f68bb",
+        "path_params": {"email_id": "e1d35779-9f14-4553-b2aa-85f9629f68bb"},
+        "status_code": 303,
+    }
+
+
+def test_uvicorn_mozlog_non_ascii_header_value(formatter):
+    """
+    A non-ascii header value is added to the log as bytes
+
+    curl refuses to send these, so this is theoretical.
+    """
+    fields_in = {
+        "scope": {
+            "headers": [
+                [b"x-star", "✰".encode("utf8")],
+            ],
+        },
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "bytes_fields": ["headers.x-star"],
+        "headers": {"x-star": b"\xe2\x9c\xb0"},
+    }
+
+
+def test_uvicorn_mozlog_non_ascii_header_name(formatter):
+    """
+    A non-ascii header is added to the log as bytes
+
+    Currently, uvicorn rejects requests with invalid headers,
+    so this code path is even more theoretical.
+    """
+    fields_in = {
+        "scope": {
+            "headers": [
+                ["x-✰".encode("utf8"), b"star"],
+            ],
+        },
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "bytes_fields": ["headers"],
+        "headers": {b"x-\xe2\x9c\xb0": "star"},
+    }
+
+
+def test_uvicorn_mozlog_non_ascii_path(formatter):
+    """
+    A non-ascii path is added to the log as bytes
+
+    Currently, uvicorn rejects requests with unicode paths,
+    so this code path is even more theoretical.
+    """
+    fields_in = {
+        "scope": {
+            "raw_path": "/✰".encode("utf8"),
+        }
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "bytes_fields": ["raw_path"],
+        "raw_path": b"/\xe2\x9c\xb0",
+    }
+
+
+def test_uvicorn_mozlog_duplicate_headers(formatter):
+    """A repeated header is reported as a list."""
+    fields_in = {
+        "scope": {
+            "headers": [
+                [b"x-decision", b"yes"],
+                [b"x-decision", b"no"],
+                [b"x-decision", b"maybe"],
+                [b"x-decision", b"I don't know"],
+                [b"x-decision", b"Can you repeat the question?"],
+            ]
+        }
+    }
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "headers": {
+            "x-decision": [
+                "yes",
+                "no",
+                "maybe",
+                "I don't know",
+                "Can you repeat the question?",
+            ]
+        },
+        "headers_have_duplicates": True,
+    }
+
+
+def test_uvicorn_mozlog_string_header(formatter):
+    """If a header is already a string, it is kept a string."""
+    fields_in = {"scope": {"headers": [["x-unicode", "✓"]]}}
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "headers": {"x-unicode": "✓"},
+    }
+
+
+def test_uvicorn_mozlog_string_object(formatter):
+    """
+    If a header is an object, is is kept as an object.
+
+    This would be an assertion, but we're in logging, so don't raise.
+    """
+    fields_in = {"scope": {"headers": [["x-set", {}]]}}
+    out = formatter.convert_fields(fields_in)
+    assert out == {
+        "bytes_fields": ["headers.x-set"],
+        "headers": {"x-set": {}},
+    }

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -10,7 +10,7 @@ from ctms.logging import UvicornJsonLogFormatter
 
 @pytest.fixture
 def formatter():
-    return UvicornJsonLogFormatter(logger_name="ctms", report_dropped=True)
+    return UvicornJsonLogFormatter(logger_name="ctms", log_dropped_fields=True)
 
 
 def test_uvicorn_mozlog_drop_color_message(formatter):
@@ -28,7 +28,7 @@ def test_uvicorn_mozlog_drop_color_message(formatter):
 
 def test_uvicorn_mozlog_silent_drop_fields():
     """The field dropped_fields can be omitted."""
-    fmt = UvicornJsonLogFormatter(logger_name="ctms", report_dropped=False)
+    fmt = UvicornJsonLogFormatter(logger_name="ctms", log_dropped_fields=False)
     fields_in = {
         "color_message": "Finished server process [\u001b[36m%d\u001b[0m]",
         "msg": "Finished server process [30]",

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -88,6 +88,8 @@ def test_uvicorn_mozlog_root_path_call(formatter):
             "scope.app",
             "scope.asgi",
             "scope.fastapi_astack",
+            "scope.raw_path",
+            "scope.root_path",
             "scope.router",
         ],
         "duration_s": 0.017,
@@ -108,8 +110,6 @@ def test_uvicorn_mozlog_root_path_call(formatter):
         "path": "/",
         "path_params": {},
         "query_string": "",
-        "raw_path": "/",
-        "root_path": "",
         "scheme": "http",
         "server_ip": "172.19.0.3",
         "server_port": 8000,
@@ -264,13 +264,13 @@ def test_uvicorn_mozlog_non_ascii_path(formatter):
     """
     fields_in = {
         "scope": {
-            "raw_path": "/✰".encode("utf8"),
+            "path": "/✰".encode("utf8"),
         }
     }
     out = formatter.convert_fields(fields_in)
     assert out == {
-        "bytes_fields": ["raw_path"],
-        "raw_path": b"/\xe2\x9c\xb0",
+        "bytes_fields": ["path"],
+        "path": b"/\xe2\x9c\xb0",
     }
 
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -72,6 +72,11 @@ def test_uvicorn_mozlog_root_path_call(formatter):
             "router": Mock(),
             "endpoint": root,
             "path_params": {},
+            "state": {
+                "log_context": {
+                    "duration_s": 0.017,
+                }
+            },
         },
         "msg": '172.19.0.1:56988 - "GET / HTTP/1.1" 307',
     }
@@ -85,6 +90,7 @@ def test_uvicorn_mozlog_root_path_call(formatter):
             "scope.fastapi_astack",
             "scope.router",
         ],
+        "duration_s": 0.017,
         "endpoint": "root",
         "headers": {
             "accept": "text/html,application/xhtml+xml",
@@ -175,11 +181,21 @@ def test_uvicorn_mozlog_put_api_call(formatter):
             ],
             "endpoint": create_or_update_ctms_contact,
             "path_params": {"email_id": "e1d35779-9f14-4553-b2aa-85f9629f68bb"},
+            "state": {
+                "log_context": {
+                    "duration_s": 0.116,
+                    "client_id": "id_test",
+                    "client_allowed": True,
+                }
+            },
         },
         "msg": '172.19.0.1:57014 - "PUT /ctms/e1d35779-9f14-4553-b2aa-85f9629f68bb HTTP/1.1" 303',
     }
     out = formatter.convert_fields(fields_in)
     assert out == {
+        "client_allowed": True,
+        "client_id": "id_test",
+        "duration_s": 0.116,
         "endpoint": "create_or_update_ctms_contact",
         "headers": {
             "authorization": "[OMITTED]",


### PR DESCRIPTION
For issue #106, add the option (`CTMS_USE_MOZLOG=True`) to use the MozLog JSON format (see https://wiki.mozilla.org/Firefox/Services/Logging), for uvicorn request logging, as well as any other logs we would add. The log includes the details of the request, as well as some additional application context.

For testing, rebuild with ``make build`` and add to your ``.env`` file:

```
CTMS_USE_MOZLOG=True
```

then restart your development server, try out the interactive API

Here's a log line:
```json
{"Timestamp": 1618616777743526400, "Type": "uvicorn.access", "Logger": "ctms", "Hostname": "ad3f42667525", "EnvVersion": "2.0", "Severity": 6, "Pid": 207, "Fields": {"status_code": 200, "type": "http", "http_version": "1.1", "scheme": "http", "method": "GET", "root_path": "", "path": "/ctms", "raw_path": "/ctms", "query_string": "primary_email=test%40example.com", "headers": {"host": "localhost:8000", "accept-encoding": "gzip, deflate", "cookie": "[OMITTED]", "connection": "keep-alive", "accept": "application/json", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15", "authorization": "[OMITTED]", "referer": "http://localhost:8000/docs", "accept-language": "en-us"}, "client_allowed": true, "client_id": "id_test", "duration_s": 0.102, "endpoint": "read_ctms_by_any_id", "path_params": {}, "msg": "172.19.0.1:57428 - \"GET /ctms?primary_email=test%40example.com HTTP/1.1\" 200"}}
```

Pretty-printed:

```json
{
  "Timestamp": 1618616777743526400,
  "Type": "uvicorn.access",
  "Logger": "ctms",
  "Hostname": "ad3f42667525",
  "EnvVersion": "2.0",
  "Severity": 6,
  "Pid": 207,
  "Fields": {
    "status_code": 200,
    "type": "http",
    "http_version": "1.1",
    "scheme": "http",
    "method": "GET",
    "root_path": "",
    "path": "/ctms",
    "raw_path": "/ctms",
    "query_string": "primary_email=test%40example.com",
    "headers": {
      "host": "localhost:8000",
      "accept-encoding": "gzip, deflate",
      "cookie": "[OMITTED]",
      "connection": "keep-alive",
      "accept": "application/json",
      "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15",
      "authorization": "[OMITTED]",
      "referer": "http://localhost:8000/docs",
      "accept-language": "en-us"
    },
    "client_allowed": true,
    "client_id": "id_test",
    "duration_s": 0.102,
    "endpoint": "read_ctms_by_any_id",
    "path_params": {},
    "msg": "172.19.0.1:57428 - \"GET /ctms?primary_email=test%40example.com HTTP/1.1\" 200"
  }
}
```

Some of the items are specified by the MozLog format, and the `Fields` is application specific. A lot of this comes from the request itself. Sensitive fields, such as authorization headers and cookies, are replaced with `"[OMITTED]"`.

The application-specific stuff is:

* ``auth_fail``: If OAuth2 access token failed, why it failed.
* ``client_allowed``: For authenticated endpoints, `true` if allows, `false` if not.
* ``client_id``: The OAuth2 client ID, if parsed
* ``duration_s``: The time to fulfill the request, in seconds rounded to the millisecond
* ``token_cred_from``: If the token request credentials came from the header or the form (request body)
* ``token_fail``: Why a token request failed, if it did.

I skipped converting any scripts to use logging, since this PR was getting big. I think we may want to add a framework like [click](https://click.palletsprojects.com/en/7.x/) for ones that meant to be interactive, like ``client_credentials.py``, and use some form of logging for ones that will run via a cronjob or automated process.

The process to log in a script would look something like this:

```python
from logging import getLogger
from ctms.config import Settings
from ctms.logging import configure_logging

log = getLogger(__name__)  #  ctms.bin.script_name

if __name__ == "__main__":
    use_mozlog = Settings().use_mozlog
    logging_level = Settings().logging_level
    configure_logging(use_mozlog, log_level)
    log.info("Log configured", extra={"extra": "data"})
```

which would log something like:

```json
{"Timestamp": 1618858469691094784, "Type": "ctms.bin.foo", "Logger": "ctms", "Hostname": "ce229f33608b", "EnvVersion": "2.0", "Severity": 6, "Pid": 2020, "Fields": {"extra": "data", "msg": "Log configured"}}
```


Work-in-progress Tasks:

* [x] Add some in-project docs - New guide ``configuration.md``, and logging details in ``deployment_guide.md``
* [x] Default to ``CTMS_USE_MOZLOG=False`` in development
* [x] Add some logs items for token requests
* [x] See if scripts ~can be quickly converted to logs~, or if I should handle in a new issue. **This PR has gotten big enough already, skipping**
