### PR TITLE
Add pylint-pytest, and lint the tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -851,6 +851,18 @@ toml = ">=0.7.1"
 docs = ["sphinx (==3.5.1)", "python-docs-theme (==2020.12)"]
 
 [[package]]
+name = "pylint-pytest"
+version = "1.1.2"
+description = "A Pylint plugin to suppress pytest-related false positives."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pylint = "*"
+pytest = ">=4.6"
+
+[[package]]
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
@@ -1274,7 +1286,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.10" # google-cloud-bigquery requires this range
-content-hash = "403b1e1030a10f429f69d0069399e77a201a1ab960eaf13fa35e416e9e08ae47"
+content-hash = "1c029b67c5487e7c700b01b701b2ccccfc9e9e06ae99bfe683c5735f4fb23fd8"
 
 [metadata.files]
 alabaster = [
@@ -1898,6 +1910,9 @@ pygments = [
 pylint = [
     {file = "pylint-2.7.2-py3-none-any.whl", hash = "sha256:d09b0b07ba06bcdff463958f53f23df25e740ecd81895f7d2699ec04bbd8dc3b"},
     {file = "pylint-2.7.2.tar.gz", hash = "sha256:0e21d3b80b96740909d77206d741aa3ce0b06b41be375d92e1f3244a274c1f8a"},
+]
+pylint-pytest = [
+    {file = "pylint_pytest-1.1.2-py2.py3-none-any.whl", hash = "sha256:fb20ef318081cee3d5febc631a7b9c40fa356b05e4f769d6e60a337e58c8879b"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,9 @@ testpaths = [
     generated-members='alembic.*'
     [tool.pylint.MASTER]
     extension-pkg-whitelist='pydantic'
+    load-plugins='pylint_pytest'
     ignore='third_party'
-    ignore-patterns = "migrations/.*,tests/.*/.*" # Not worth fixing yet
+    ignore-patterns = "migrations/.*" # Not worth fixing yet
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ detect-secrets = "^0.14.3"
 bandit = "^1.7.0"
 SQLAlchemy-Utils = "^0.36.8"
 pylint = "^2.7.2"
+pylint-pytest = "^1.1.2"
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -14,4 +14,4 @@ detect-secrets-hook $SECRETS_TO_SCAN --baseline .secrets.baseline
 mypy --no-strict-optional --ignore-missing-imports "${BASE_DIR}"
 black --config "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
 isort --recursive --settings-path "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
-pylint ctms
+pylint ctms tests/unit

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -60,9 +60,9 @@ def engine(pytestconfig):
 @pytest.fixture
 def connection(engine):
     """Return a connection to the database that rolls back automatically."""
-    with engine.begin() as connection:
-        savepoint = connection.begin_nested()
-        yield connection
+    with engine.begin() as conn:
+        savepoint = conn.begin_nested()
+        yield conn
         savepoint.rollback()
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -792,7 +792,7 @@ def test_create_or_update_basic_id_is_different(client, minimal_contact):
 
     # This id is different from the one in the contact
     resp = client.put(
-        f"/ctms/d16c4ec4-caa0-4bf2-a06f-1bbf07bf03c7", minimal_contact.json()
+        "/ctms/d16c4ec4-caa0-4bf2-a06f-1bbf07bf03c7", minimal_contact.json()
     )
     assert resp.status_code == 422, resp.text
 
@@ -805,7 +805,7 @@ def test_create_or_update_basic_id_is_none(put_contact):
         contact.email.email_id = None
         return contact
 
-    saved_contacts, sample, email_id = put_contact(
+    put_contact(
         modifier=_remove_id,
         check_redirect=False,
         code=422,

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -5,7 +5,7 @@ import os.path
 from unittest.mock import Mock
 
 import pytest
-from sqlalchemy.exc import TimeoutError
+from sqlalchemy.exc import TimeoutError as SQATimeoutError
 
 from ctms.app import app, get_db
 
@@ -13,13 +13,13 @@ from ctms.app import app, get_db
 @pytest.fixture
 def mock_db():
     """Mock the database session."""
-    mock_db = Mock()
+    mocked_db = Mock()
 
     def mock_get_db():
-        yield mock_db
+        yield mocked_db
 
     app.dependency_overrides[get_db] = mock_get_db
-    yield mock_db
+    yield mocked_db
     del app.dependency_overrides[get_db]
 
 
@@ -56,7 +56,7 @@ def test_read_heartbeat(anon_client, dbsession):
 
 def test_read_heartbeat_no_db_fails(anon_client, mock_db):
     """/__heartbeat__ returns 503 when the database is unavailable."""
-    mock_db.execute.side_effect = TimeoutError()
+    mock_db.execute.side_effect = SQATimeoutError()
     resp = anon_client.get("/__heartbeat__")
     assert resp.status_code == 503
     data = resp.json()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -160,7 +160,7 @@ def test_get_ctms_with_token(
     example_contact, anon_client, test_token_settings, client_id_and_secret
 ):
     """An authenticated API can be fetched with a valid token"""
-    client_id, client_secret = client_id_and_secret
+    client_id = client_id_and_secret[0]
     token = create_access_token(
         {"sub": f"api_client:{client_id}"}, **test_token_settings
     )
@@ -175,7 +175,7 @@ def test_get_ctms_with_invalid_token_fails(
     example_contact, anon_client, test_token_settings, client_id_and_secret
 ):
     """Calling an authenticated API with an invalid token is an error"""
-    client_id, client_secret = client_id_and_secret
+    client_id = client_id_and_secret[0]
     token = create_access_token(
         {"sub": f"api_client:{client_id}"},
         secret_key="secret_key_from_other_deploy",
@@ -193,7 +193,7 @@ def test_get_ctms_with_invalid_namespace_fails(
     example_contact, anon_client, test_token_settings, client_id_and_secret
 ):
     """Calling an authenticated API with an unexpected namespace is an error"""
-    client_id, client_secret = client_id_and_secret
+    client_id = client_id_and_secret[0]
     token = create_access_token({"sub": f"unknown:{client_id}"}, **test_token_settings)
     resp = anon_client.get(
         f"/ctms/{example_contact.email.email_id}",
@@ -207,7 +207,7 @@ def test_get_ctms_with_unknown_client_fails(
     example_contact, anon_client, test_token_settings, client_id_and_secret
 ):
     """A token with an unknown (deleted?) API client name is an error"""
-    client_id, client_secret = client_id_and_secret
+    client_id = client_id_and_secret[0]
     token = create_access_token(
         {"sub": f"api_client:not_{client_id}"}, **test_token_settings
     )
@@ -224,7 +224,7 @@ def test_get_ctms_with_expired_token_fails(
 ):
     """Calling an authenticated API with an expired token is an error"""
     yesterday = datetime.now(timezone.utc) - timedelta(days=1)
-    client_id, client_secret = client_id_and_secret
+    client_id = client_id_and_secret[0]
     token = create_access_token(
         {"sub": f"api_client:{client_id}"}, **test_token_settings, now=yesterday
     )
@@ -240,7 +240,7 @@ def test_get_ctms_with_disabled_client_fails(
     dbsession, example_contact, anon_client, test_token_settings, client_id_and_secret
 ):
     """Calling an authenticated API with a valid token for an expired client is an error."""
-    client_id, client_secret = client_id_and_secret
+    client_id = client_id_and_secret[0]
     token = create_access_token(
         {"sub": f"api_client:{client_id}"}, **test_token_settings
     )

--- a/tests/unit/test_bin_client_credentials.py
+++ b/tests/unit/test_bin_client_credentials.py
@@ -3,7 +3,6 @@
 import pytest
 
 from ctms.bin.client_credentials import main
-from ctms.config import Settings
 from ctms.models import ApiClient
 
 
@@ -25,7 +24,7 @@ def test_create(dbsession, settings):
     client = dbsession.query(ApiClient).one()
     assert client.client_id == "id_test"
     assert client.email == "test@example.com"
-    assert client.enabled == True
+    assert client.enabled
 
 
 def test_create_explicit_id(dbsession, settings):
@@ -36,7 +35,7 @@ def test_create_explicit_id(dbsession, settings):
     client = dbsession.query(ApiClient).one()
     assert client.client_id == "id_tst"
     assert client.email == "test@example.com"
-    assert client.enabled == True
+    assert client.enabled
 
 
 def test_create_disabled(dbsession, settings):
@@ -49,7 +48,7 @@ def test_create_disabled(dbsession, settings):
     client = dbsession.query(ApiClient).one()
     assert client.client_id == "id_test2"
     assert client.email == "test@example.com"
-    assert client.enabled == False
+    assert not client.enabled
 
 
 def test_create_email_required(dbsession, settings):
@@ -71,7 +70,7 @@ def test_create_valid_client_id(dbsession, settings, client_id):
     client = dbsession.query(ApiClient).one()
     assert client.client_id == f"id_{client_id}"
     assert client.email == "test@example.com"
-    assert client.enabled == True
+    assert client.enabled
 
 
 @pytest.mark.parametrize("client_id", ("test@example.com", "Résumé", "💩.la"))

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -62,6 +62,7 @@ def _check_saved(dbsession, emails=None, amos=None, newsletters=None):
 
 def test_ingest_empty(connection, empty_ios):
     ingester = Ingester(empty_ios, connection)
+    ingester.run()
 
 
 @pytest.mark.parametrize("batch_size", [10, 1, 2, 100])


### PR DESCRIPTION
Add [pylint-pytest](https://github.com/reverbc/pylint-pytest), which tunes pylint to remove false positives around pytest fixtures and other conventions (and is completely different from [pytest-pylint](https://github.com/carsongee/pytest-pylint), which turns pylint issues into pytest errors).

Once the cruft is gone, almost all the issues were cosmetic (``sw`` for ``StatementWatcher`` changed to ``watcher``, remove some unused variables). There were a few linting issues that were bugs in the tests, such as looping through contacts but only testing the first contact.

My editor is configured to run pylint on every save, so the pylint errors in tests are annoying me, probably more than anyone else. This fixes linting of tests, and also adds tests to the linting commands. I'd be willing to just fix the code and not add tests to linting for now.