### PR TITLE
Add Sentry middleware, rely on server-side filtering

### DIFF
--- a/ctms/config.py
+++ b/ctms/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     server_prefix: str = "http://localhost:8000"
     use_mozlog: bool = True
     logging_level: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = "INFO"
+    sentry_debug: bool = False
 
     class Config:
         env_prefix = "ctms_"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,7 +75,7 @@ COPY --chown=app:app . .
 
 EXPOSE $PORT
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD uvicorn ctms.app:app --reload --host=0.0.0.0 --port=$PORT
+CMD uvicorn ctms.app:sentry_app --reload --host=0.0.0.0 --port=$PORT
 
 
 # 'lint' stage runs black and isort
@@ -110,4 +110,4 @@ WORKDIR /app
 
 EXPOSE $PORT
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD uvicorn ctms.app:app --host=0.0.0.0 --port=${PORT} --log-config /app/docker/log_config.json
+CMD uvicorn ctms.app:sentry_app --host=0.0.0.0 --port=${PORT} --log-config /app/docker/log_config.json

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -9,43 +9,40 @@ production, they are set as part of the runtime environment.
 * ``CTMS_DB_URL`` - The database connection parameters, formatted as a URL.
   In the development environment, this defaults to talk to the ``postgres``
   container. In production, it is set to talk to the provisioned database.
-
 * ``CTMS_GID`` - The group ID of the ``app`` account, used to run the CTMS
   application. If unset, defaults to 10001. On Linux development systems, set
   along with ``CTMS_UID`` to match the development user, for consistent permissions.
-
 * ``CTMS_LOGGING_LEVEL`` - The minimum level for logs. Defaults to ``INFO`` if
   unset. Unset in production, and set to ``INFO`` in development.
-
 * ``CTMS_SECRET_KEY`` - An encryption key, used for OAuth2 and other hashes.
   Set to a long but non-secret value for development, and set to a randomized
   string for each production deployment.
-
 * ``CTMS_TOKEN_EXPIRATION`` - How long an OAuth2 access token is valid, in seconds.
   If unset, defaults to one hour.
-
+* ``CTMS_SENTRY_DEBUG`` - If set to True, then sentry initialization and capture is
+  logged as well. This may be useful for development, but is not recommended for
+  production.
 * ``CTMS_SERVER_PREFIX`` - The protocol and domain part of the server name, used
   to construct full URLS. Set to ``http://localhost:8000`` in development, and
   the user-facing prefix in production.
-
 * ``CTMS_UID`` - The user ID of the ``app`` account, used to run the CTMS
   application. If unset, defaults to 10001. On Linux development systems, set
   along with ``CTMS_GID`` to match the development user, for consistent permissions.
-
 * ``CTMS_USE_MOZLOG`` - Use the JSON
   [MozLog](https://wiki.mozilla.org/Firefox/Services/Logging) format for logs.
   Defaults to `True` as used in production, and is set to `False` for development.
   See the [deployment guide](./deployment_guide.md) for more information on the
   MozLog format.
-
 * ``MK_KEEP_DOCKER_UP`` - If unset, then ``make test`` runs ``docker-compose down``
   after tests run, shutting down the PostgreSQL container.  If set to ``1``,
   ``make test`` keeps containers running.
-
 * ``MK_WITH_SERVICE_PORTS`` - If set to ``--service-ports``, passes that option
   to ``docker run`` commands, allowing access to host-based commands.
-
 * ``PORT`` - The port for the web service. Defaults to 8000 if unset.
+* ``SENTRY_DSN`` - The Sentry connection string. The sentry-sdk reads this
+  in production. It should be unset in development, except for Sentry testing,
+  and after informing operations engineers.
+
 
 ### Environment Configuration Files
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -996,6 +996,34 @@ python-versions = ">=3.5, <4"
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "sentry-sdk"
+version = "1.0.0"
+description = "Python client for Sentry (https://sentry.io)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.10.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+chalice = ["chalice (>=1.16.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+pure_eval = ["pure-eval", "executing", "asttokens"]
+pyspark = ["pyspark (>=2.4.4)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+tornado = ["tornado (>=5)"]
+
+[[package]]
 name = "six"
 version = "1.15.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1286,7 +1314,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.10" # google-cloud-bigquery requires this range
-content-hash = "1c029b67c5487e7c700b01b701b2ccccfc9e9e06ae99bfe683c5735f4fb23fd8"
+content-hash = "186a801ef7061d7cfe0316632a1184304b15ba87c7e71fd54fbac7fd9daedf35"
 
 [metadata.files]
 alabaster = [
@@ -2017,6 +2045,10 @@ requests = [
 rsa = [
     {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
     {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
+]
+sentry-sdk = [
+    {file = "sentry-sdk-1.0.0.tar.gz", hash = "sha256:71de00c9711926816f750bc0f57ef2abbcb1bfbdf5378c601df7ec978f44857a"},
+    {file = "sentry_sdk-1.0.0-py2.py3-none-any.whl", hash = "sha256:9221e985f425913204989d0e0e1cbb719e8b7fa10540f1bc509f660c06a34e66"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ passlib = {extras = ["argon2"], version = "^1.7.4"}
 python-dateutil = "^2.8.1"
 google-cloud-bigquery = "^2.13.1"
 dockerflow = "^2020.10.0"
+sentry-sdk = "^1.0.0"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
For issue #139:

* Add ``sentry-sdk``
* Initialize it from ``SENTRY_SDK`` and with the commit number from ``version.json``.
* Wrap the FastAPI app with the [ASGI middleware](https://docs.sentry.io/platforms/python/guides/asgi/). This is done in a new variable because the Sentry middleware doesn't expose the wrapped app's interface, and to make ``mypy`` happier.
* Use the wrapped Sentry app in dev and production

I've added a new setting ``CTMS_SENTRY_DEBUG`` to turn on debug-level logging for Sentry, which makes for a noisy initialization and shutdown.

To test it locally, I added these settings in `.env`:

```sh
CTMS_SENTRY_DEBUG=1
SENTRY_DSN=https://bad-9c7b6b6bcb7a45d7ae01fe8f60594083@sentry.127.0.0.1.nip.io/0
```

and then ran ``make test`` and ``make start``, and adding a line like ``raise Exception("Testing Sentry")`` to a view (such as ``version()``. The ``SENTRY_DSN`` enables Sentry, but it is a fake connection string (to local host) so it won't be able to send any data, but prints a lot of details about what it is trying to do. The deployment environments will have the real ``SENTRY_DSN`` values.

A few years ago, I implemented client-side filtering in https://github.com/mozilla-services/socorro/pull/4917. That was a lot of work, and would look similar to the monitoring code. I'd like to try the server-side filtering for CTMS. This means that some security details like authorization headers may be sent, but the Sentry server will obfuscate them. I feel better about this than logging because Mozilla is running our own Sentry server. But, I'm open to implementing client-side filtering instead.