### PR TITLE
Move Sentry initialization to app startup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
         name: pylint
         entry: pylint
         language: system
-        exclude: ^(migrations|tests)/
+        exclude: ^migrations/
         types: [python]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -77,6 +77,11 @@ def get_settings():
 def startup_event():
     global SessionLocal  # pylint:disable = W0603
     settings = get_settings()
+    sentry_sdk.init(
+        release=get_version().get("commit", None),
+        debug=settings.sentry_debug,
+        send_default_pii=False,
+    )
     configure_logging(settings.use_mozlog, settings.logging_level)
     _, session_factory = get_db_engine(settings)
     SessionLocal = scoped_session(session_factory)
@@ -667,11 +672,6 @@ def lbheartbeat():
 
 # Setup the sentry-wrapped app
 # The dsn is read from the environment variable SENTRY_DSN
-sentry_sdk.init(
-    release=get_version().get("commit", None),
-    debug=config.Settings().sentry_debug,
-    send_default_pii=False,
-)
 sentry_app = SentryAsgiMiddleware(app)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sentry was interfering with the `pylint_pytest` plugin, and shouldn't be initialized in tests. By moving ``sentry_sdk.init`` inside of ``startup_event``, it is not initialized for tests, and the plugin works.

I've also adjusted the pre-commit hook to run linting on the tests.