### PR TITLE
Sentry integration (again)

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -102,6 +102,7 @@ def init_sentry():
 # Initialize Sentry for each thread, unless we're in tests
 if "pytest" not in sys.argv[0]:
     init_sentry()
+    app.add_middleware(SentryAsgiMiddleware)
 
 
 @app.on_event("startup")
@@ -696,9 +697,5 @@ def lbheartbeat():
     return {"status": "OK"}
 
 
-# Setup the sentry-wrapped app
-# The dsn is read from the environment variable SENTRY_DSN
-sentry_app = SentryAsgiMiddleware(app)
-
 if __name__ == "__main__":
-    uvicorn.run("app:sentry_app", host="0.0.0.0", port=80, reload=True)
+    uvicorn.run("app:app", host="0.0.0.0", port=80, reload=True)

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -697,5 +697,11 @@ def lbheartbeat():
     return {"status": "OK"}
 
 
+@app.get("/__crash__", tags=["Platform"], include_in_schema=False)
+def crash(api_client: ApiClientSchema = Depends(get_enabled_api_client)):
+    """Raise an exception to test Sentry integration."""
+    raise RuntimeError("Test exception handling")
+
+
 if __name__ == "__main__":
     uvicorn.run("app:app", host="0.0.0.0", port=80, reload=True)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,7 +75,7 @@ COPY --chown=app:app . .
 
 EXPOSE $PORT
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD uvicorn ctms.app:sentry_app --reload --host=0.0.0.0 --port=$PORT
+CMD uvicorn ctms.app:app --reload --host=0.0.0.0 --port=$PORT
 
 
 # 'lint' stage runs black and isort
@@ -110,4 +110,4 @@ WORKDIR /app
 
 EXPOSE $PORT
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD uvicorn ctms.app:sentry_app --host=0.0.0.0 --port=${PORT} --log-config /app/docker/log_config.json
+CMD uvicorn ctms.app:app --host=0.0.0.0 --port=${PORT} --log-config /app/docker/log_config.json

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -69,3 +69,16 @@ def test_read_health(anon_client):
     resp = anon_client.get("/__lbheartbeat__")
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK"}
+
+
+def test_crash_authorized(client):
+    """The endpoint /__crash__ can be used to test Sentry integration."""
+    with pytest.raises(RuntimeError):
+        client.get("/__crash__")
+
+
+def test_crash_unauthorized(anon_client):
+    """The endpoint /__crash__ can not be used without credentials."""
+    resp = anon_client.get("/__crash__")
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Not authenticated"}


### PR DESCRIPTION
For issue #139, adjust the Sentry integration strategy:

Move initialization to a function ``init_sentry()``. This reads ``sentry_debug`` from settings, which can fail if a required setting like the database URL is missing. This is what was causing the ``pylint-pytest`` plugin to fail for me earlier.

Call ``init_sentry()`` at the module level, unless it looks like we're running tests. It is needed at the module level because FastAPI integrates async and sync code by running sync code in thread pools, and Sentry needs to be initialized for each thread. We don't want it to run during tests however (at least not without mocked network calls), and report our tested exceptions to Sentry. I'm using ``pytest`` in the command to detect tests, which should work 90% of the time. Most developers will want to leave ``SENTRY_DSN`` unset in their ``.env``, which allows calling ``init_sentry()`` to succeed but will not attempt to send exceptions anywhere.

Register the Sentry middleware as a FastAPI middleware, rather than wrapping the FastAPI app. The FastAPI app is based on Starlette, which includes a ``ServerErrorMiddleware`` (see [Middleware](https://www.starlette.io/middleware/) and [Exceptions](https://www.starlette.io/exceptions/) docs) that may have interfered with Sentry. This will allow Sentry to handle the exception before the ``ServerErrorMiddleware``.

Add an endpoint ``/__crash__``, which requires an OAuth2 token, that will raise an exception, for the purpose of testing Sentry integration and exception handling. This was useful in figuring out the ``init_sentry()`` interaction with threads, and should be useful to confirm Sentry works in stage, production, and other deployments. This endpoint is not advertised in the Swagger docs.

These changes will require a ``make build`` for testing, and for any devs once it is merged.

To test this code, I added these to my ``.env`` file:

```
CTMS_SENTRY_DEBUG=True
SENTRY_DSN=https://bad-9c7b6b6bcb7a45d7ae01fe8f60594083@sentry.127.0.0.1.nip.io/0
```
This ``SENTRY_DSN`` enables Sentry bundling of exceptions, but submits them to 127.0.0.1, which will fail noisily.

I ran ``make build`` to update the ``CMD`` in the docker images.

Then I ran ``make test-shell``, and ``pytest -sx -vv tests/unit/test_app.py``. The tests pass, and Sentry is _not_ initialized.

I ran ``make start`` to run the server. I used the Swagger docs at http://localhost:8000/docs, logged in to generate an OAuth2 token, and then used ``GET /ctms`` to see the example ``curl`` command. I then adjusted the command to call ``/__crash__`` instead. This returns ``Internal Server Error``, and the server logs shows the attempt to upload the traceback to Sentry.