### PR TITLE
Revert "Use scoped_session for database session"

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -15,7 +15,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import ValidationError
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, scoped_session
+from sqlalchemy.orm import Session
 
 from . import config
 from .auth import (
@@ -110,8 +110,7 @@ def startup_event():
     global SessionLocal  # pylint:disable = W0603
     settings = get_settings()
     configure_logging(settings.use_mozlog, settings.logging_level)
-    _, session_factory = get_db_engine(settings)
-    SessionLocal = scoped_session(session_factory)
+    _, SessionLocal = get_db_engine(get_settings())
 
 
 def get_db():
@@ -120,7 +119,6 @@ def get_db():
         yield db
     finally:
         db.close()
-        SessionLocal.remove()
 
 
 def _token_settings(


### PR DESCRIPTION
This reverts commit 60985aedffb8827d6057c8fadb5772401d568008 from PR #117, to address re-opened issue #70.

FastAPI shares threads between requests, which causes issues for ``scoped_session``'s per-thread sessions.

@imbstack and @bsieber-mozilla have been able to reproduce in ctms-stage by making many similar requests in parallel.