### PR TITLE
Add mypy.ini, enabled warn-return-any

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
     rev: v0.782
     hooks:
       - id: mypy
-        args: [--no-strict-optional, --ignore-missing-imports]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.6.2
     hooks:

--- a/ctms/auth.py
+++ b/ctms/auth.py
@@ -48,7 +48,7 @@ def create_access_token(
     to_encode = data.copy()
     expire = (now or datetime.now(timezone.utc)) + expires_delta
     to_encode["exp"] = expire
-    encoded_jwt = jwt.encode(to_encode, secret_key, algorithm="HS256")
+    encoded_jwt: str = jwt.encode(to_encode, secret_key, algorithm="HS256")
     return encoded_jwt
 
 
@@ -133,7 +133,12 @@ class OAuth2ClientCredentials(OAuth2):
 
     async def __call__(self, request: Request) -> Optional[str]:
         authorization: str = request.headers.get("Authorization")
-        scheme, param = get_authorization_scheme_param(authorization)
+
+        # TODO: Try combining these lines after FastAPI 0.61.2 / mypy update
+        scheme_param = get_authorization_scheme_param(authorization)
+        scheme: str = scheme_param[0]
+        param: str = scheme_param[1]
+
         if not authorization or scheme.lower() != "bearer":
             raise HTTPException(
                 status_code=HTTP_401_UNAUTHORIZED,

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
 
 from pydantic import UUID4
 from sqlalchemy import asc, or_
@@ -140,12 +140,15 @@ def get_bulk_contacts(
     ]
 
 
-def get_email(db: Session, email_id: UUID4) -> Email:
+def get_email(db: Session, email_id: UUID4) -> Optional[Email]:
     """Get an Email and all related data."""
-    return _contact_base_query(db).filter(Email.email_id == email_id).one_or_none()
+    return cast(
+        Optional[Email],
+        _contact_base_query(db).filter(Email.email_id == email_id).one_or_none(),
+    )
 
 
-def get_contact_by_email_id(db: Session, email_id: UUID4) -> Dict:
+def get_contact_by_email_id(db: Session, email_id: UUID4) -> Optional[Dict]:
     """Get all the data for a contact, as a dict."""
     email = get_email(db, email_id)
     if email is None:
@@ -216,7 +219,7 @@ def get_emails_by_any_id(
         statement = statement.join(Email.fxa).filter(
             FirefoxAccount.primary_email == fxa_primary_email
         )
-    return statement.all()
+    return cast(List[Email], statement.all())
 
 
 def get_contacts_by_any_id(

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+# Sync Python version with docker/Dockerfile
+python_version = 3.8
+# Look for errors in this file
+warn_unused_configs = True
+
+# None is compatible with all types (pre-mypy 0.6 behaviour)
+strict_optional = False
+# Suppress all missing import errors for all libraries
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,19 @@ python_version = 3.8
 # Look for errors in this file
 warn_unused_configs = True
 
+# TODO: Get stricter for these options
 # None is compatible with all types (pre-mypy 0.6 behaviour)
 strict_optional = False
 # Suppress all missing import errors for all libraries
 ignore_missing_imports = True
+
+# Warn when returning Any from function with non-Any return
+warn_return_any = True
+
+[mypy-ctms.auth]
+strict_optional = True
+ignore_missing_imports = False
+
+[mypy-ctms.crud]
+strict_optional = True
+ignore_missing_imports = False

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -11,7 +11,7 @@ bandit -lll --recursive "${BASE_DIR}" --exclude "${BASE_DIR}/poetry.lock,${BASE_
 SECRETS_TO_SCAN=`git ls-tree --full-tree -r --name-only HEAD | grep -v poetry.lock`
 detect-secrets-hook $SECRETS_TO_SCAN --baseline .secrets.baseline
 
-mypy --no-strict-optional --ignore-missing-imports "${BASE_DIR}"
+mypy "${BASE_DIR}"
 black --config "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
 isort --recursive --settings-path "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
 pylint ctms tests/unit


### PR DESCRIPTION
As part of increasing mypy strictness (issue #177), switch to ``mypy.ini``, which makes it easier to override settings for particular files, and to share the configuration between the pre-commit hook and the linting script.

Add the ``warn-return-any`` option, which warns when a type with ``Any`` is returned from a function that declares a non-``Any`` return type. The default for non-annotated functions is to return ``Any``, and this includes libraries where mypy can't see the annotations. For ``ctms/crud.py``, this exposed some issues with return types for functions that can return ``None``. For ``ctms/auth.py``, it mostly involved specifying the types for return values from library functions.