### PR TITLE
Add Prometheus metrics to API

### DIFF
--- a/ctms/config.py
+++ b/ctms/config.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
-from typing import Literal
+from typing import Literal, Optional
 
-from pydantic import BaseSettings, PostgresDsn
+from pydantic import BaseSettings, DirectoryPath, PostgresDsn
 
 
 class Settings(BaseSettings):
@@ -13,8 +13,18 @@ class Settings(BaseSettings):
     logging_level: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = "INFO"
     sentry_debug: bool = False
 
+    fastapi_env: Optional[str] = None
+    is_gunicorn: bool = False
+    prometheus_multiproc_dir: Optional[DirectoryPath] = None
+
     class Config:
         env_prefix = "ctms_"
+
+        fields = {
+            "fastapi_env": {"env": "fastapi_env"},
+            "is_gunicorn": {"env": "is_gunicorn"},
+            "prometheus_multiproc_dir": {"env": "prometheus_multiproc_dir"},
+        }
 
 
 class BackgroundSettings(Settings):

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
 from pydantic import UUID4
 from sqlalchemy import asc, or_
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import Session, joinedload, selectinload
+from sqlalchemy.orm import Session, joinedload, load_only, selectinload
 
 from .auth import hash_password
 from .database import Base
@@ -560,3 +560,14 @@ def create_api_client(db: Session, api_client: ApiClientSchema, secret):
 
 def get_api_client_by_id(db: Session, client_id: str):
     return db.query(ApiClient).filter(ApiClient.client_id == client_id).one_or_none()
+
+
+def get_active_api_client_ids(db: Session) -> List[str]:
+    rows = (
+        db.query(ApiClient)
+        .filter(ApiClient.enabled.is_(True))
+        .options(load_only("client_id"))
+        .order_by("client_id")
+        .all()
+    )
+    return [row.client_id for row in rows]

--- a/ctms/metrics.py
+++ b/ctms/metrics.py
@@ -1,0 +1,156 @@
+"""Prometheus metrics for instrumentation and monitoring."""
+
+from itertools import product
+from typing import Dict, Optional, cast
+
+from fastapi import FastAPI
+from fastapi.requests import Request
+from prometheus_client import CollectorRegistry, Counter, Histogram
+from prometheus_client.metrics import MetricWrapperBase
+from prometheus_client.utils import INF
+from sqlalchemy.orm import Session
+from starlette.routing import Match, Route
+
+from ctms.crud import get_active_api_client_ids
+
+METRICS_PARAMS = {
+    "requests": (
+        Counter,
+        {
+            "name": "ctms_requests_total",
+            "documentation": "Total count of requests by method, path, and status code.",
+            "labelnames": ["method", "path_template", "status_code"],
+        },
+    ),
+    "requests_duration": (
+        Histogram,
+        {
+            "name": "ctms_requests_duration_seconds",
+            "documentation": "Histogram of requests processing time by path (in seconds)",
+            "labelnames": ["method", "path_template"],
+            "buckets": (0.01, 0.05, 0.1, 0.5, 1, 5, 10, INF),
+        },
+    ),
+    "api_requests": (
+        Counter,
+        {
+            "name": "ctms_api_requests_total",
+            "documentation": "Total count of API requests by method, path, client ID, and status code family",
+            "labelnames": [
+                "method",
+                "path_template",
+                "client_id",
+                "status_code_family",
+            ],
+        },
+    ),
+}
+
+
+def init_metrics_registry() -> CollectorRegistry:
+    """
+    Initialize a metrics registry.
+
+    TODO: Add multiprocessor support
+
+    We could use the default REGISTRY, but a fresh registry is easier to reset
+    for tests, and forcing the web code to go through this method will ensure
+    we're using roughly the same code paths in development and production.
+    """
+    return CollectorRegistry()
+
+
+def init_metrics(registry: CollectorRegistry) -> Dict[str, MetricWrapperBase]:
+    """Initialize the metrics with the registry."""
+    metrics = {}
+    for name, init_bits in METRICS_PARAMS.items():
+        metric_type, params = init_bits
+        metrics[name] = metric_type(registry=registry, **params)
+    return metrics
+
+
+def init_metrics_labels(
+    dbsession: Session, app: FastAPI, metrics: Dict[str, MetricWrapperBase]
+) -> None:
+    """Create the initial metric combinations."""
+    openapi = app.openapi()
+    client_ids = get_active_api_client_ids(dbsession) or ["none"]
+    request_metric = metrics["requests"]
+    timing_metric = metrics["requests_duration"]
+    api_request_metric = metrics["api_requests"]
+    for route in app.routes:
+        assert isinstance(route, Route)
+        route = cast(Route, route)  # Route defines.methods and .path_format
+        methods = list(route.methods)
+        path = route.path_format
+
+        api_spec = openapi["paths"].get(path)
+        is_api = False
+        if api_spec:
+            status_codes = []
+            for method_lower, mspec in api_spec.items():
+                if method_lower.upper() in methods:
+                    status_codes.extend(
+                        [int(code) for code in list(mspec.get("responses", [200]))]
+                    )
+                    is_api |= "security" in mspec
+            status_code_families = sorted(
+                {str(code)[0] + "xx" for code in status_codes}
+            )
+        elif path == "/":
+            status_codes = [307]
+        else:
+            status_codes = [200]
+
+        for combo in product(methods, status_codes):
+            method, status_code = combo
+            request_metric.labels(method, path, status_code)
+        for method in methods:
+            timing_metric.labels(method, path)
+        if is_api:
+            for api_combo in product(methods, status_code_families):
+                method, status_code_family = api_combo
+                for client_id in client_ids:
+                    api_request_metric.labels(
+                        method, path, client_id, status_code_family
+                    )
+
+
+def emit_response_metrics(
+    request: Request, status_code: int, metrics: Dict[str, MetricWrapperBase]
+) -> None:
+    """Emit metrics for a response."""
+    if not metrics:
+        return
+    path_template = get_path_template(request)
+    if path_template is None:
+        return
+    method = request.method
+    metrics["requests"].labels(
+        method=method, path_template=path_template, status_code=status_code
+    ).inc()
+
+    duration_s = request.state.log_context["duration_s"]
+    metrics["requests_duration"].labels(
+        method=method, path_template=path_template
+    ).observe(duration_s)
+
+    client_id = request.state.log_context.get("client_id")
+    if client_id:
+        status_code_family = str(status_code)[0] + "xx"
+        metrics["api_requests"].labels(
+            method=method,
+            path_template=path_template,
+            client_id=client_id,
+            status_code_family=status_code_family,
+        ).inc()
+
+
+def get_path_template(request: Request) -> Optional[str]:
+    """Get the path template for the request, or fall back to plain path."""
+    for route in request.app.routes:
+        match, _ = route.matches(request.scope)
+        if match == Match.FULL:
+            return str(route.path)
+
+    return None  # Not a known application route

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,7 +97,9 @@ CMD ./scripts/test.sh
 # 'production' stage uses the clean 'python-base' stage and copyies
 # in only our runtime deps that were installed in the 'builder-base'
 FROM python-base as production
-ENV FASTAPI_ENV=production
+ENV FASTAPI_ENV=production \
+    IS_GUNICORN=1 \
+    PROMETHEUS_MULTIPROC=1
 
 COPY --from=builder-base $VENV_PATH $VENV_PATH
 COPY ./docker/gunicorn_conf.py /gunicorn_conf.py

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -5,7 +5,15 @@ set -e
 # activate our virtual environment here
 . /opt/pysetup/.venv/bin/activate
 
-# You can put other setup logic here
+# setup an empty directory for Prometheus metrics
+if [ ${PROMETHEUS_MULTIPROC:-0} -eq 1 ]; then
+    prometheus_multiproc_dir=`mktemp -td prometheus.XXXXXXXXXX` || exit 1
+    export prometheus_multiproc_dir
+fi
 
 # Evaluating passed command:
 exec "$@"
+
+if [ -z ${prometheus_multiproc_dir+x} ]; then
+    rm -rf ${prometheus_multiproc_dir}
+fi

--- a/docker/gunicorn_conf.py
+++ b/docker/gunicorn_conf.py
@@ -5,6 +5,8 @@ import json
 import multiprocessing
 import os
 
+from prometheus_client import multiprocess
+
 workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
 max_workers_str = os.getenv("MAX_WORKERS")
 use_max_workers = None
@@ -68,3 +70,7 @@ log_data = {
     "port": port,
 }
 print(json.dumps(log_data))
+
+
+def child_exit(server, worker):
+    multiprocess.mark_process_dead(worker.pid)

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,3 +20,9 @@ ignore_missing_imports = False
 [mypy-ctms.crud]
 strict_optional = True
 ignore_missing_imports = False
+
+[mypy-ctms.metrics]
+strict_optional = True
+ignore_missing_imports = False
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -810,6 +810,17 @@ toml = "*"
 virtualenv = ">=20.0.8"
 
 [[package]]
+name = "prometheus-client"
+version = "0.10.1"
+description = "Python client for the Prometheus monitoring system."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "proto-plus"
 version = "1.18.1"
 description = "Beautiful, Pythonic protocol buffers."
@@ -2034,6 +2045,10 @@ pluggy = [
 pre-commit = [
     {file = "pre_commit-2.11.1-py2.py3-none-any.whl", hash = "sha256:94c82f1bf5899d56edb1d926732f4e75a7df29a0c8c092559c77420c9d62428b"},
     {file = "pre_commit-2.11.1.tar.gz", hash = "sha256:de55c5c72ce80d79106e48beb1b54104d16495ce7f95b0c7b13d4784193a00af"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.10.1-py2.py3-none-any.whl", hash = "sha256:030e4f9df5f53db2292eec37c6255957eb76168c6f974e4176c711cf91ed34aa"},
+    {file = "prometheus_client-0.10.1.tar.gz", hash = "sha256:b6c5a9643e3545bcbfd9451766cbaa5d9c67e7303c7bc32c750b6fa70ecb107d"},
 ]
 proto-plus = [
     {file = "proto-plus-1.18.1.tar.gz", hash = "sha256:cfc45474c7eda0fe3c4b9eca2542124f2a0ff5543242bec61e8d08bce0f5bd48"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dockerflow = "^2020.10.0"
 sentry-sdk = "^1.0.0"
 pysilverpop = "^0.2.6"
 lxml = "^4.6.3"
+prometheus-client = "^0.10.1"
+
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.7.1"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,7 @@ from sqlalchemy_utils.functions import create_database, database_exists, drop_da
 
 from ctms.app import app, get_api_client, get_db
 from ctms.config import Settings
-from ctms.crud import create_contact
+from ctms.crud import create_api_client, create_contact
 from ctms.models import Base
 from ctms.sample_data import SAMPLE_CONTACTS
 from ctms.schemas import ApiClientSchema
@@ -147,3 +147,15 @@ def client(anon_client):
 @pytest.fixture
 def settings():
     return Settings()
+
+
+@pytest.fixture
+def client_id_and_secret(dbsession):
+    """Return valid OAuth2 client_id and client_secret."""
+    api_client = ApiClientSchema(
+        client_id="id_db_api_client", email="db_api_client@example.com", enabled=True
+    )
+    secret = "secret_what_a_weird_random_string"  # pragma: allowlist secret
+    create_api_client(dbsession, api_client, secret)
+    dbsession.flush()
+    return (api_client.client_id, secret)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -8,20 +8,7 @@ from requests.auth import HTTPBasicAuth
 
 from ctms.app import _token_settings, app
 from ctms.auth import create_access_token, hash_password, verify_password
-from ctms.crud import create_api_client, get_api_client_by_id
-from ctms.schemas import ApiClientSchema
-
-
-@pytest.fixture
-def client_id_and_secret(dbsession):
-    """Return valid OAuth2 client_id and client_secret."""
-    api_client = ApiClientSchema(
-        client_id="id_db_api_client", email="db_api_client@example.com", enabled=True
-    )
-    secret = "secret_what_a_weird_random_string"  # pragma: allowlist secret
-    create_api_client(dbsession, api_client, secret)
-    dbsession.flush()
-    return (api_client.client_id, secret)
+from ctms.crud import get_api_client_by_id
 
 
 @pytest.fixture

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,279 @@
+# Test for metrics
+from unittest.mock import patch
+
+import pytest
+from prometheus_client import REGISTRY, CollectorRegistry, generate_latest
+from prometheus_client.parser import text_string_to_metric_families
+
+from ctms.app import app
+from ctms.metrics import init_metrics, init_metrics_labels, init_metrics_registry
+
+# Metric cardinatility numbers
+# These numbers change as routes are added or changed
+# Higher numbers = more ways to slice data, more storage, more processing time for summaries
+
+# Cardinality of ctms_requests_total counter
+METHOD_PATH_CODE_COMBINATIONS = 45
+
+# Cardinality of ctms_requests_duration_seconds histogram
+METHOD_PATH_COMBOS = 23
+DURATION_BUCKETS = 8
+DURATION_COMBINATIONS = METHOD_PATH_COMBOS * (DURATION_BUCKETS + 2)
+
+# Base cardinatility of ctms_api_requests_total
+# Actual is multiplied by the number of API clients
+METHOD_API_PATH_COMBINATIONS = 16
+
+
+@pytest.fixture
+def setup_metrics():
+    """Setup a metrics registry and metrics, use them in the app"""
+
+    test_registry = CollectorRegistry()
+    test_metrics = init_metrics(test_registry)
+    # Because these methods are called from a middleware
+    # we can't use dependency injection like with get_db
+    with patch("ctms.app.get_metrics_registry", return_value=test_registry), patch(
+        "ctms.app.get_metrics", return_value=test_metrics
+    ):
+        yield test_registry, test_metrics
+
+
+@pytest.fixture
+def registry(setup_metrics):
+    """Get the test metrics registry"""
+    test_registry, _ = setup_metrics
+    return test_registry
+
+
+@pytest.fixture
+def metrics(setup_metrics):
+    """Get the test metrics"""
+    _, test_metrics = setup_metrics
+    return test_metrics
+
+
+def test_init_metrics_registry():
+    """init_metrics_registry() returns a registry."""
+    the_registry = init_metrics_registry()
+    assert the_registry != REGISTRY
+
+
+def test_init_metrics_labels(dbsession, client_id_and_secret, registry, metrics):
+    """Test that init_metric_labels populates variants"""
+    init_metrics_labels(dbsession, app, metrics)
+
+    metrics_text = generate_latest(registry).decode()
+    families = list(text_string_to_metric_families(metrics_text))
+    metrics_by_name = {
+        "ctms_requests": None,
+        "ctms_requests_created": None,
+        "ctms_requests_duration_seconds": None,
+        "ctms_requests_duration_seconds_created": None,
+        "ctms_api_requests": None,
+        "ctms_api_requests_created": None,
+    }
+    for metric in families:
+        if metric.name in metrics_by_name:
+            metrics_by_name[metric.name] = metric
+    not_found = [name for name, metric in metrics_by_name.items() if metric is None]
+    assert not_found == []
+
+    def get_labels(metric_name, label_names):
+        labels = []
+        for sample in metrics_by_name[metric_name].samples:
+            sample_label = sample[1]
+            label = tuple(sample_label[name] for name in label_names)
+            labels.append(label)
+        return sorted(labels)
+
+    # ctms_requests has a metric for every method / path / status code combo
+    req_label_names = ("method", "path_template", "status_code")
+    req_labels = get_labels("ctms_requests", req_label_names)
+    reqc_labels = get_labels("ctms_requests_created", req_label_names)
+    assert len(req_labels) == METHOD_PATH_CODE_COMBINATIONS
+    assert req_labels == reqc_labels
+    assert ("GET", "/", "307") in req_labels
+    assert ("GET", "/openapi.json", "200") in req_labels
+    assert ("GET", "/ctms/{email_id}", "200") in req_labels
+    assert ("GET", "/ctms/{email_id}", "401") in req_labels
+    assert ("GET", "/ctms/{email_id}", "404") in req_labels
+    assert ("GET", "/ctms/{email_id}", "422") in req_labels
+    assert ("GET", "/ctms/{email_id}", "422") in req_labels
+    assert ("PATCH", "/ctms/{email_id}", "200") in req_labels
+    assert ("PUT", "/ctms/{email_id}", "200") in req_labels
+
+    # ctms_requests_duration_seconds has a metric for each method / path combo
+    method_path = set((method, path) for method, path, _ in req_labels)
+    assert len(method_path) == METHOD_PATH_COMBOS
+    dur_label_names = ("method", "path_template")
+    dur_labels = get_labels("ctms_requests_duration_seconds", dur_label_names)
+    assert len(dur_labels) == DURATION_COMBINATIONS
+
+    # ctms_api_requests has a metric for each
+    # (method / path / client_id / status code family) combo for API paths
+    # where API paths are those requiring authentication
+    api_label_names = ("method", "path_template", "client_id", "status_code_family")
+    api_labels = get_labels("ctms_api_requests", api_label_names)
+    apic_labels = get_labels("ctms_api_requests_created", api_label_names)
+    assert len(api_labels) == METHOD_API_PATH_COMBINATIONS
+    assert api_labels == apic_labels
+    client_id, _ = client_id_and_secret
+    assert ("GET", "/ctms/{email_id}", client_id, "2xx") in api_labels
+    assert ("GET", "/ctms/{email_id}", client_id, "4xx") in api_labels
+
+
+def test_homepage_request(anon_client, registry):
+    """A homepage request emits metrics for / and /docs"""
+    anon_client.get("/")
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_total",
+            {"method": "GET", "path_template": "/", "status_code": "307"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_total",
+            {"method": "GET", "path_template": "/docs", "status_code": "200"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_duration_seconds_bucket",
+            {"method": "GET", "path_template": "/", "le": "0.1"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_duration_seconds_count",
+            {"method": "GET", "path_template": "/"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_duration_seconds_sum",
+            {"method": "GET", "path_template": "/"},
+        )
+        < 0.1
+    )
+
+
+def test_api_request(client, minimal_contact, registry):
+    """An API request emits API metrics as well."""
+    email_id = minimal_contact.email.email_id
+    client.get(f"/ctms/{email_id}")
+    path = "/ctms/{email_id}"
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_total",
+            {"method": "GET", "path_template": path, "status_code": "200"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_duration_seconds_bucket",
+            {"method": "GET", "path_template": path, "le": "0.1"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_duration_seconds_count",
+            {"method": "GET", "path_template": path},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_duration_seconds_sum",
+            {"method": "GET", "path_template": path},
+        )
+        < 0.1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_api_requests_total",
+            {
+                "method": "GET",
+                "path_template": path,
+                "client_id": "test_client",
+                "status_code_family": "2xx",
+            },
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize(
+    "email_id,status_code",
+    (
+        ("07259262-7902-489c-ad65-473336635a3b", 404),
+        ("an-invalid-id", 422),
+    ),
+)
+def test_bad_api_request(client, dbsession, registry, email_id, status_code):
+    """An API request that returns a 404 emits metrics."""
+    resp = client.get(f"/ctms/{email_id}")
+    assert resp.status_code == status_code
+    path = "/ctms/{email_id}"
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_total",
+            {"method": "GET", "path_template": path, "status_code": str(status_code)},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_api_requests_total",
+            {
+                "method": "GET",
+                "path_template": path,
+                "client_id": "test_client",
+                "status_code_family": str(status_code)[0] + "xx",
+            },
+        )
+        == 1
+    )
+
+
+def test_crash_request(client, dbsession, registry):
+    """An exception-raising API request emits metric with 500s."""
+    path = "/__crash__"
+    with pytest.raises(RuntimeError):
+        client.get(path)
+    assert (
+        registry.get_sample_value(
+            "ctms_requests_total",
+            {"method": "GET", "path_template": path, "status_code": "500"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "ctms_api_requests_total",
+            {
+                "method": "GET",
+                "path_template": path,
+                "client_id": "test_client",
+                "status_code_family": "5xx",
+            },
+        )
+        == 1
+    )
+
+
+def test_unknown_path(anon_client, dbsession, registry):
+    """A unknown path does not emit metrics."""
+    path = "/unknown"
+    resp = anon_client.get(path)
+    assert resp.status_code == 404
+    metrics_text = generate_latest(registry).decode()
+    for family in text_string_to_metric_families(metrics_text):
+        assert len(family.samples) == 0


### PR DESCRIPTION
For issue #124, add Prometheus metrics to the API:

* New app-level variable ``METRICS_REGISTRY`` is initialized in each thread, like Sentry
* New app-level variable ``METRICS`` is initialized at app startup
* Metrics are emitted by the logging middleware as the response is returned:
  - ``ctms_requests_total`` and ``_created``: A counter incremented for each request, with labels method, path_template, and status code (estimated cardinality 45)
  - ``ctms_requests_duration_seconds_*``: A histogram of request times, with breakpoints at 10ms, 50m, 100ms, 500ms, 1s, 5s, and 10s, with labels method and path *and status_code_family like ``2xx`` and ``4xx``* (estimated cardinality ~276~ 310)
  - ``ctms_api_requests_total`` and ``_created``: A counter incremented for each API request with valid credentials, with labels method, path_template, and status_code_family (like ``2xx`` and ``4xx``) (estimated cardinality 16 * the number of API clients)

To see them in action, run `make build start`, and go to http://localhost:8000/metrics. You can then try other endpoints (or just refresh) to see the request counts increase.

In production with gunicorn, there are several changes needed to enable [multiprocessing mode](https://github.com/prometheus/client_python#multiprocess-mode-gunicorn). You can try these out by switching to ``target: production`` in ``docker-compose.yml``, running ``make build start``, and going to http://localhost:8000/metrics.