### PR TITLE
Do not send uvicorn.error logs to Sentry

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -14,6 +14,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import ValidationError
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+from sentry_sdk.integrations.logging import ignore_logger
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -98,6 +99,7 @@ def init_sentry():
         debug=sentry_debug,
         send_default_pii=False,
     )
+    ignore_logger("uvicorn.error")
 
 
 # Initialize Sentry for each thread, unless we're in tests


### PR DESCRIPTION
Exceptions are being captured by Sentry twice, once by the Sentry middleware, and then again when logged by uvicorn. Ignore the one from ``uvicorn.error``, which doesn't contain request data.

Fixes issue #160