### PR TITLE
Adding HEAD for heartbeat api calls. Issue #165

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -748,8 +748,7 @@ def version():
     return get_version()
 
 
-@app.get("/__heartbeat__", tags=["Platform"])
-def heartbeat(response: Response, db: Session = Depends(get_db)):
+def heartbeat(response: Response, db: Session):
     """Return status of backing services, as required by Dockerflow."""
     data = {"database": check_database(db)}
     if not data["database"]["up"]:
@@ -757,10 +756,29 @@ def heartbeat(response: Response, db: Session = Depends(get_db)):
     return data
 
 
-@app.get("/__lbheartbeat__", tags=["Platform"])
+@app.get("/__heartbeat__", tags=["Platform"])
+def get_heartbeat(response: Response, db: Session = Depends(get_db)):
+    return heartbeat(response, db)
+
+
+@app.head("/__heartbeat__", tags=["Platform"])
+def head_heartbeat(response: Response, db: Session = Depends(get_db)):
+    return heartbeat(response, db)
+
+
 def lbheartbeat():
     """Return response when application is running, as required by Dockerflow."""
     return {"status": "OK"}
+
+
+@app.get("/__lbheartbeat__", tags=["Platform"])
+def get_lbheartbeat():
+    return lbheartbeat()
+
+
+@app.head("/__lbheartbeat__", tags=["Platform"])
+def head_lbheartbeat():
+    return lbheartbeat()
 
 
 @app.get("/__crash__", tags=["Platform"], include_in_schema=False)

--- a/ctms/sample_data.py
+++ b/ctms/sample_data.py
@@ -177,7 +177,8 @@ class ContactVendor:
     }
 
     def __getitem__(self, key: str) -> ContactSchema:
-        return self.contacts[key][0].copy(deep=True)
+        contact: ContactSchema = self.contacts[key][0].copy(deep=True)
+        return contact
 
     def get_not_written(self, key: str) -> Set[str]:
         return self.contacts[key][1]

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -402,10 +402,6 @@ API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=&after=&mofo_relevant=",
         None,
     ),
-    ("HEAD", "/__lbheartbeat__", None),
-    ("GET", "/__lbheartbeat__", None),
-    ("HEAD", "/__heartbeat__", None),
-    ("GET", "/__heartbeat__", None),
 )
 
 
@@ -414,47 +410,30 @@ def test_unauthorized_api_call_fails(
     anon_client, example_contact, method, path, params
 ):
     """Calling the API without credentials fails."""
-    is_heartbeat = "heartbeat__" in path
-    put_patch_post = lambda operation: {
-        "method": operation,
-        "url": path,
-        "json": params,
-    }
-    _map = {  # METHOD: ( {_REQUEST_PARAMS} , {_EXPECTED_RESULTS}
-        "GET": ({"method": "GET", "url": path, "params": params}, {401}),
-        "HEAD": ({"method": "HEAD", "url": path}, {200}),
-        "PUT": (put_patch_post("PUT"), {401}),
-        "PATCH": (put_patch_post("PATCH"), {401}),
-        "POST": (put_patch_post("POST"), {401}),
-    }
-    if method in _map.keys():
-        _request, _results = _map.get(method)
-        resp = anon_client.request(**_request)
-        heartbeat_check = is_heartbeat and resp.status_code == 200
-        assert heartbeat_check or resp.status_code in _results
-        if method != "HEAD":
-            assert heartbeat_check or resp.json() == {"detail": "Not authenticated"}
+    if method == "GET":
+        resp = anon_client.get(path, params=params)
+    else:
+        assert method in ("PATCH", "POST", "PUT")
+        resp = anon_client.request(method, path, json=params)
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Not authenticated"}
 
 
 @pytest.mark.parametrize("method,path,params", API_TEST_CASES)
 def test_authorized_api_call_succeeds(client, example_contact, method, path, params):
     """Calling the API without credentials fails."""
-    put_patch_post = lambda operation: {
-        "method": operation,
-        "url": path,
-        "json": params,
-    }
-    _map = {  # METHOD: ( {_REQUEST_PARAMS} , {_EXPECTED_RESULTS}
-        "GET": ({"method": "GET", "url": path, "params": params}, {200}),
-        "HEAD": ({"method": "HEAD", "url": path}, {200}),
-        "PUT": (put_patch_post("PUT"), {200, 201}),  # Either creates or updates
-        "PATCH": (put_patch_post("PATCH"), {200}),
-        "POST": (put_patch_post("POST"), {201}),
-    }
-    if method in _map.keys():
-        _request, _results = _map.get(method)
-        resp = client.request(**_request)
-        assert resp.status_code in _results
+    if method == "GET":
+        resp = client.get(path, params=params)
+        assert resp.status_code == 200
+    else:
+        assert method in ("PATCH", "POST", "PUT")
+        resp = client.request(method, path, json=params)
+        if method == "PUT":
+            assert resp.status_code in {200, 201}  # Either creates or updates
+        elif method == "POST":
+            assert resp.status_code == 201
+        else:  # PATCH
+            assert resp.status_code == 200
 
 
 def test_get_ctms_not_found(client, dbsession):

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -15,10 +15,10 @@ from ctms.metrics import init_metrics, init_metrics_labels, init_metrics_registr
 # Higher numbers = more ways to slice data, more storage, more processing time for summaries
 
 # Cardinality of ctms_requests_total counter
-METHOD_PATH_CODE_COMBINATIONS = 45
+METHOD_PATH_CODE_COMBINATIONS = 47
 
 # Cardinality of ctms_requests_duration_seconds histogram
-METHOD_PATH_CODEFAM_COMBOS = 31
+METHOD_PATH_CODEFAM_COMBOS = 33
 DURATION_BUCKETS = 8
 DURATION_COMBINATIONS = METHOD_PATH_CODEFAM_COMBOS * (DURATION_BUCKETS + 2)
 

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -2,37 +2,9 @@ from typing import Any, Tuple
 
 import pytest
 
-MONITOR_API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
-    ("HEAD", "/__lbheartbeat__", None),
-    ("GET", "/__lbheartbeat__", None),
-    ("HEAD", "/__heartbeat__", None),
-    ("GET", "/__heartbeat__", None),
-)
-
-
-@pytest.mark.parametrize("method,path,params", MONITOR_API_TEST_CASES)
-def test_unauthorized_api_call_fails(
-    anon_client, example_contact, method, path, params
-):
-    """Calling the API without credentials fails."""
-    _map = {  # METHOD: ( {_REQUEST_PARAMS} , {_EXPECTED_RESULTS}
-        "GET": ({"method": "GET", "url": path, "params": params}, {200}),
-        "HEAD": ({"method": "HEAD", "url": path}, {200}),
-    }
-    if method in _map.keys():
-        _request, _results = _map.get(method)
-        resp = anon_client.request(**_request)
-        assert resp.status_code in _results
-
-
-@pytest.mark.parametrize("method,path,params", MONITOR_API_TEST_CASES)
-def test_authorized_api_call_succeeds(client, example_contact, method, path, params):
-    """Calling the API without credentials fails."""
-    _map = {  # METHOD: ( {_REQUEST_PARAMS} , {_EXPECTED_RESULTS}
-        "GET": ({"method": "GET", "url": path, "params": params}, {200}),
-        "HEAD": ({"method": "HEAD", "url": path}, {200}),
-    }
-    if method in _map.keys():
-        _request, _results = _map.get(method)
-        resp = client.request(**_request)
-        assert resp.status_code in _results
+@pytest.mark.parametrize("method", ("HEAD", "GET"))
+@pytest.mark.parametrize("path", ("/__lbheartbeat__", "/__heartbeat__"))
+def test_monitoring_endpoints(anon_client, db_session, method, path):
+    """Monitoring endpoints can be called without credentials"""
+    resp = anon_client.request(method, path)
+    assert resp.status_code == 200

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,10 +1,9 @@
-from typing import Any, Tuple
-
 import pytest
+
 
 @pytest.mark.parametrize("method", ("HEAD", "GET"))
 @pytest.mark.parametrize("path", ("/__lbheartbeat__", "/__heartbeat__"))
-def test_monitoring_endpoints(anon_client, db_session, method, path):
+def test_monitoring_endpoints(anon_client, dbsession, method, path):
     """Monitoring endpoints can be called without credentials"""
     resp = anon_client.request(method, path)
     assert resp.status_code == 200

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,38 @@
+from typing import Any, Tuple
+
+import pytest
+
+MONITOR_API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
+    ("HEAD", "/__lbheartbeat__", None),
+    ("GET", "/__lbheartbeat__", None),
+    ("HEAD", "/__heartbeat__", None),
+    ("GET", "/__heartbeat__", None),
+)
+
+
+@pytest.mark.parametrize("method,path,params", MONITOR_API_TEST_CASES)
+def test_unauthorized_api_call_fails(
+    anon_client, example_contact, method, path, params
+):
+    """Calling the API without credentials fails."""
+    _map = {  # METHOD: ( {_REQUEST_PARAMS} , {_EXPECTED_RESULTS}
+        "GET": ({"method": "GET", "url": path, "params": params}, {200}),
+        "HEAD": ({"method": "HEAD", "url": path}, {200}),
+    }
+    if method in _map.keys():
+        _request, _results = _map.get(method)
+        resp = anon_client.request(**_request)
+        assert resp.status_code in _results
+
+
+@pytest.mark.parametrize("method,path,params", MONITOR_API_TEST_CASES)
+def test_authorized_api_call_succeeds(client, example_contact, method, path, params):
+    """Calling the API without credentials fails."""
+    _map = {  # METHOD: ( {_REQUEST_PARAMS} , {_EXPECTED_RESULTS}
+        "GET": ({"method": "GET", "url": path, "params": params}, {200}),
+        "HEAD": ({"method": "HEAD", "url": path}, {200}),
+    }
+    if method in _map.keys():
+        _request, _results = _map.get(method)
+        resp = client.request(**_request)
+        assert resp.status_code in _results


### PR DESCRIPTION
Allow HEAD as well as GET requests to :

    /__heartbeat__
    /__lb_heartbeat__
