### PR TITLE
Adding FeatureFlags to the Sync Job as Background EnvVars

### DIFF
--- a/ctms/bin/acoustic_sync.py
+++ b/ctms/bin/acoustic_sync.py
@@ -16,6 +16,7 @@ def main(db, settings):
         acoustic_newsletter_table_id=settings.acoustic_newsletter_table_id,
         server_number=settings.acoustic_server_number,
         retry_limit=settings.acoustic_retry_limit,
+        is_acoustic_enabled=settings.acoustic_integration_feature_flag,
     )
     prev = monotonic()
     while settings.acoustic_sync_feature_flag:

--- a/ctms/bin/acoustic_sync.py
+++ b/ctms/bin/acoustic_sync.py
@@ -18,7 +18,7 @@ def main(db, settings):
         retry_limit=settings.acoustic_retry_limit,
     )
     prev = monotonic()
-    while True:
+    while settings.acoustic_sync_feature_flag:
         sync_service.sync_records(db)
         to_sleep = settings.acoustic_loop_min_secs - (monotonic() - prev)
         if to_sleep > 0:

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
 
 
 class BackgroundSettings(Settings):
-    acoustic_sync_feature_flag: bool = False  # Enable/disable whole job
+    acoustic_sync_feature_flag: bool = False  # Enable/disable whole background sync job
     acoustic_integration_feature_flag: bool = (
         False  # Enable/disable integration w/ Acoustic
     )

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
 
 
 class BackgroundSettings(Settings):
+    acoustic_sync_feature_flag: bool = False
     acoustic_retry_limit: int = 6
     acoustic_server_number: int = 6
     acoustic_loop_min_secs: int = 5

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -28,7 +28,10 @@ class Settings(BaseSettings):
 
 
 class BackgroundSettings(Settings):
-    acoustic_sync_feature_flag: bool = False
+    acoustic_sync_feature_flag: bool = False  # Enable/disable whole job
+    acoustic_integration_feature_flag: bool = (
+        False  # Enable/disable integration w/ Acoustic
+    )
     acoustic_retry_limit: int = 6
     acoustic_server_number: int = 6
     acoustic_loop_min_secs: int = 5

--- a/ctms/sync.py
+++ b/ctms/sync.py
@@ -56,16 +56,16 @@ class CTMSToAcousticSync:
     def _sync_pending_record(self, db, pending_record: PendingAcousticRecord):
         try:
             if self.is_acoustic_enabled:
+                contact: ContactSchema = get_acoustic_record_as_contact(
+                    db, pending_record
+                )
+                is_success = self.sync_contact_with_acoustic(contact)
+            else:
                 self.logger.debug(
                     "Acoustic is not currently enabled. Records will be classified as successful and "
                     "dropped from queue at this time."
                 )
                 is_success = True
-            else:
-                contact: ContactSchema = get_acoustic_record_as_contact(
-                    db, pending_record
-                )
-                is_success = self.sync_contact_with_acoustic(contact)
 
             if is_success:
                 # on success delete pending_record from table

--- a/ctms/sync.py
+++ b/ctms/sync.py
@@ -48,21 +48,24 @@ class CTMSToAcousticSync:
         """
         try:
             # Convert ContactSchema to Acoustic Readable, attempt API call
-            if self.is_acoustic_enabled:
-                return self.ctms_to_acoustic.attempt_to_upload_ctms_contact(contact)
-            self.logger.debug(
-                "Acoustic is not currently enabled. Records will be classified as successful and "
-                "dropped from queue at this time."
-            )
-            return True
+            return self.ctms_to_acoustic.attempt_to_upload_ctms_contact(contact)
         except Exception:  # pylint: disable=W0703
             self.logger.exception("Error executing sync.sync_contact_with_acoustic")
             return False
 
     def _sync_pending_record(self, db, pending_record: PendingAcousticRecord):
         try:
-            contact: ContactSchema = get_acoustic_record_as_contact(db, pending_record)
-            is_success = self.sync_contact_with_acoustic(contact)
+            if self.is_acoustic_enabled:
+                self.logger.debug(
+                    "Acoustic is not currently enabled. Records will be classified as successful and "
+                    "dropped from queue at this time."
+                )
+                is_success = True
+            else:
+                contact: ContactSchema = get_acoustic_record_as_contact(
+                    db, pending_record
+                )
+                is_success = self.sync_contact_with_acoustic(contact)
 
             if is_success:
                 # on success delete pending_record from table

--- a/ctms/sync.py
+++ b/ctms/sync.py
@@ -23,6 +23,7 @@ class CTMSToAcousticSync:
         acoustic_newsletter_table_id,
         server_number,
         retry_limit=5,
+        is_acoustic_enabled=True,
     ):
         acoustic_client = Acoustic(
             client_id=client_id,
@@ -37,6 +38,7 @@ class CTMSToAcousticSync:
         )
         self.logger = logging.getLogger(__name__)
         self.retry_limit = retry_limit
+        self.is_acoustic_enabled = is_acoustic_enabled
 
     def sync_contact_with_acoustic(self, contact: ContactSchema):
         """
@@ -46,7 +48,13 @@ class CTMSToAcousticSync:
         """
         try:
             # Convert ContactSchema to Acoustic Readable, attempt API call
-            return self.ctms_to_acoustic.attempt_to_upload_ctms_contact(contact)
+            if self.is_acoustic_enabled:
+                return self.ctms_to_acoustic.attempt_to_upload_ctms_contact(contact)
+            self.logger.debug(
+                "Acoustic is not currently enabled. Records will be classified as successful and "
+                "dropped from queue at this time."
+            )
+            return True
         except Exception:  # pylint: disable=W0703
             self.logger.exception("Error executing sync.sync_contact_with_acoustic")
             return False


### PR DESCRIPTION
```
CTMS_ACOUSTIC_SYNC_FEATURE_FLAG
CTMS_ACOUSTIC_INTEGRATION_FEATURE_FLAG
```

Both booleans, defaulted to False in the BackgroundSettings.

`CTMS_ACOUSTIC_SYNC_FEATURE_FLAG` allows for enabling (True) the background machinery to begin looping and pulling records, otherwise (False) the background machinery will not loop.  

`CTMS_ACOUSTIC_INTEGRATION_FEATURE_FLAG` allows for enabling (True) the records to be sent to acoustic, otherwise (False) records will be dropped from the database.

---
```
CTMS_ACOUSTIC_SYNC_FEATURE_FLAG=True
CTMS_ACOUSTIC_INTEGRATION_FEATURE_FLAG=True 
```

Is the expected end state, when we're pulling all records and syncing them into acoustic.

---
```
CTMS_ACOUSTIC_SYNC_FEATURE_FLAG=True
CTMS_ACOUSTIC_INTEGRATION_FEATURE_FLAG=False 
```

Is an interim state, when we're pulling all records without pushing to acoustic, marking them as successful to delete the pending records.

 ---
```
CTMS_ACOUSTIC_SYNC_FEATURE_FLAG=False
CTMS_ACOUSTIC_INTEGRATION_FEATURE_FLAG=True/False 
```

A shutoff-state, when `CTMS_ACOUSTIC_SYNC_FEATURE_FLAG` is False, the system will not run, no matter the `CTMS_ACOUSTIC_INTEGRATION_FEATURE_FLAG`
