### PR TITLE
Updating to 4xx on bad requests to bulk read

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -1,12 +1,10 @@
-import base64
 import sys
 import time
 from datetime import datetime, timedelta
 from functools import lru_cache
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Union
 from uuid import UUID, uuid4
 
-import dateutil.parser
 import sentry_sdk
 import structlog
 import uvicorn
@@ -240,23 +238,6 @@ def get_contacts_by_ids(
     ]
 
 
-def extractor_for_bulk_encoded_details(after: str) -> Tuple[str, datetime]:
-    str_decode = base64.urlsafe_b64decode(after)
-    result_after_list = str(str_decode.decode("utf-8")).split(",")
-    after_email_id = result_after_list[0]
-    after_start_time = dateutil.parser.parse(result_after_list[1])
-    return after_email_id, after_start_time
-
-
-def compressor_for_bulk_encoded_details(last_result: CTMSResponse):
-    last_email_id = last_result.email.email_id
-    last_update_time = last_result.email.update_timestamp
-    result_after_encoded = base64.urlsafe_b64encode(
-        f"{last_email_id},{last_update_time}".encode("utf-8")
-    )
-    return result_after_encoded.decode()
-
-
 def get_bulk_contacts_by_timestamp_or_4xx(
     db: Session,
     start_time: datetime,
@@ -269,9 +250,10 @@ def get_bulk_contacts_by_timestamp_or_4xx(
     after_email_id = None
     after_start_time = start_time
     if after is not None:
-        after_email_id, after_start_time = extractor_for_bulk_encoded_details(
-            after=after
-        )
+        (
+            after_email_id,
+            after_start_time,
+        ) = BulkRequestSchema.extractor_for_bulk_encoded_details(after)
 
     results = get_bulk_contacts(
         db=db,
@@ -302,7 +284,11 @@ def get_bulk_contacts_by_timestamp_or_4xx(
         next_url = None
     else:
         last_result: CTMSResponse = results[-1]
-        after_encoded = compressor_for_bulk_encoded_details(last_result)
+        after_encoded = BulkRequestSchema.compressor_for_bulk_encoded_details(
+            last_email_id=last_result.email.email_id,
+            last_update_time=last_result.email.update_timestamp,
+        )
+
         next_url = (
             f"{get_settings().server_prefix}/updates?"
             f"start={start_time.isoformat()}"

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -261,7 +261,7 @@ def compressor_for_bulk_encoded_details(last_result: CTMSResponse):
     return result_after_encoded.decode()
 
 
-def get_bulk_contacts_by_timestamp_or_404(
+def get_bulk_contacts_by_timestamp_or_4xx(
     db: Session,
     start_time: datetime,
     end_time: datetime,
@@ -648,7 +648,7 @@ def read_ctms_in_bulk_by_timestamps_and_limit(
     limit_param = updates_helper(value=limit, default=10)
     end_param = updates_helper(value=end, default=datetime.now(timezone.utc))
     mofo_relevant_param = updates_helper(value=mofo_relevant, default=None)
-    return get_bulk_contacts_by_timestamp_or_404(
+    return get_bulk_contacts_by_timestamp_or_4xx(
         db=db,
         start_time=start,
         end_time=end_param,

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -320,13 +320,6 @@ def get_bulk_contacts_by_timestamp_or_4xx(
     )
 
 
-def updates_helper(value, default):
-    blank_vals = [None, "", "null"]
-    if value in blank_vals:
-        return default
-    return value
-
-
 def get_api_client(
     request: Request,
     token: str = Depends(oauth2_scheme),

--- a/ctms/schemas/__init__.py
+++ b/ctms/schemas/__init__.py
@@ -5,6 +5,7 @@ from .addons import (
     UpdatedAddOnsInSchema,
 )
 from .api_client import ApiClientSchema
+from .bulk import BulkRequestSchema
 from .contact import (
     ContactInSchema,
     ContactPatchSchema,

--- a/ctms/schemas/bulk.py
+++ b/ctms/schemas/bulk.py
@@ -1,0 +1,54 @@
+import base64
+from datetime import datetime, timezone
+from typing import Literal, Optional, Union
+
+from pydantic import validator
+
+from .base import ComparableBase
+
+BLANK_VALS = [None, "", "null"]  # TODO: Should "null" be allowed?
+
+
+class BulkRequestSchema(ComparableBase):
+    """A Bulk Read Request."""
+
+    start_time: datetime
+
+    end_time: Optional[Union[datetime, Literal[""]]] = None
+
+    @validator("end_time")
+    def end_must_not_be_blank(self, value):
+        if value in BLANK_VALS:
+            return datetime.now(timezone.utc)
+        return value
+
+    limit: Optional[Union[int, Literal[""]]] = 10
+
+    @validator("limit")
+    def limit_must_not_be_blank(self, value):
+        if value in BLANK_VALS:
+            return 10
+        return value
+
+    mofo_relevant: Optional[Union[bool, Literal[""]]] = None
+
+    @validator("mofo_relevant")
+    def mofo_relevant_must_not_be_blank(self, value):
+        if value in BLANK_VALS:
+            return None
+        return value
+
+    after: Optional[str] = None
+
+    @validator("after")
+    def after_must_be_base64_decodable(self, value):
+        if value in BLANK_VALS:
+            return None
+        try:
+            str_decode = base64.urlsafe_b64decode(value)
+            str(str_decode.decode("utf-8")).split(
+                ","
+            )  # 'after' should be decodable otherwise err and invalid
+            return value
+        except Exception as e:
+            raise ValueError("'after' param validation error.") from e

--- a/ctms/schemas/bulk.py
+++ b/ctms/schemas/bulk.py
@@ -27,7 +27,7 @@ class BulkRequestSchema(ComparableBase):
             return datetime.now(timezone.utc)
         return value
 
-    limit: Optional[Union[ConstrainedLimit, Literal[""]]] = None
+    limit: Optional[Union[ConstrainedLimit, Literal[""]]] = None  # type: ignore
 
     @validator("limit", always=True)
     def limit_must_not_be_blank(cls, value):  # pylint: disable=no-self-argument

--- a/ctms/schemas/bulk.py
+++ b/ctms/schemas/bulk.py
@@ -17,7 +17,7 @@ class BulkRequestSchema(ComparableBase):
     end_time: Optional[Union[datetime, Literal[""]]] = None
 
     @validator("end_time")
-    def end_must_not_be_blank(self, value):
+    def end_time_must_not_be_blank(cls, value):  # pylint: disable=E0213
         if value in BLANK_VALS:
             return datetime.now(timezone.utc)
         return value
@@ -25,7 +25,7 @@ class BulkRequestSchema(ComparableBase):
     limit: Optional[Union[int, Literal[""]]] = 10
 
     @validator("limit")
-    def limit_must_not_be_blank(self, value):
+    def limit_must_not_be_blank(cls, value):  # pylint: disable=E0213
         if value in BLANK_VALS:
             return 10
         return value
@@ -33,7 +33,7 @@ class BulkRequestSchema(ComparableBase):
     mofo_relevant: Optional[Union[bool, Literal[""]]] = None
 
     @validator("mofo_relevant")
-    def mofo_relevant_must_not_be_blank(self, value):
+    def mofo_relevant_must_not_be_blank(cls, value):  # pylint: disable=E0213
         if value in BLANK_VALS:
             return None
         return value
@@ -41,7 +41,7 @@ class BulkRequestSchema(ComparableBase):
     after: Optional[str] = None
 
     @validator("after")
-    def after_must_be_base64_decodable(self, value):
+    def after_must_be_base64_decodable(cls, value):  # pylint: disable=E0213
         if value in BLANK_VALS:
             return None
         try:

--- a/ctms/schemas/bulk.py
+++ b/ctms/schemas/bulk.py
@@ -2,11 +2,15 @@ import base64
 from datetime import datetime, timezone
 from typing import Literal, Optional, Union
 
-from pydantic import validator
+from pydantic import ConstrainedInt, conint, validator
 
 from .base import ComparableBase
 
-BLANK_VALS = [None, "", "null"]  # TODO: Should "null" be allowed?
+BLANK_VALS = [None, ""]
+
+ConstrainedLimit: ConstrainedInt = conint(gt=0, le=100)
+# Known issue with MyPy and constrained types
+#   https://github.com/samuelcolvin/pydantic/issues/156
 
 
 class BulkRequestSchema(ComparableBase):
@@ -16,34 +20,34 @@ class BulkRequestSchema(ComparableBase):
 
     end_time: Optional[Union[datetime, Literal[""]]] = None
 
-    @validator("end_time")
-    def end_time_must_not_be_blank(cls, value):  # pylint: disable=E0213
+    @validator("end_time", always=True)
+    def end_time_must_not_be_blank(cls, value):  # pylint: disable=no-self-argument
         if value in BLANK_VALS:
             return datetime.now(timezone.utc)
         return value
 
-    limit: Optional[Union[int, Literal[""]]] = 10
+    limit: Optional[Union[ConstrainedLimit, Literal[""]]] = 10
 
-    @validator("limit")
-    def limit_must_not_be_blank(cls, value):  # pylint: disable=E0213
+    @validator("limit", always=True)
+    def limit_must_not_be_blank(cls, value):  # pylint: disable=no-self-argument
         if value in BLANK_VALS:
-            return 10
+            return 10  # Default
         return value
 
     mofo_relevant: Optional[Union[bool, Literal[""]]] = None
 
-    @validator("mofo_relevant")
-    def mofo_relevant_must_not_be_blank(cls, value):  # pylint: disable=E0213
+    @validator("mofo_relevant", always=True)
+    def mofo_relevant_must_not_be_blank(cls, value):  # pylint: disable=no-self-argument
         if value in BLANK_VALS:
-            return None
+            return None  # Default
         return value
 
     after: Optional[str] = None
 
-    @validator("after")
-    def after_must_be_base64_decodable(cls, value):  # pylint: disable=E0213
+    @validator("after", always=True)
+    def after_must_be_base64_decodable(cls, value):  # pylint: disable=no-self-argument
         if value in BLANK_VALS:
-            return None
+            return None  # Default
         try:
             str_decode = base64.urlsafe_b64decode(value)
             str(str_decode.decode("utf-8")).split(
@@ -51,4 +55,6 @@ class BulkRequestSchema(ComparableBase):
             )  # 'after' should be decodable otherwise err and invalid
             return value
         except Exception as e:
-            raise ValueError("'after' param validation error.") from e
+            raise ValueError(
+                "'after' param validation error when decoding value."
+            ) from e

--- a/ctms/schemas/bulk.py
+++ b/ctms/schemas/bulk.py
@@ -8,7 +8,7 @@ from .base import ComparableBase
 
 BLANK_VALS = [None, ""]
 
-ConstrainedLimit: ConstrainedInt = conint(gt=0, le=100)
+ConstrainedLimit: ConstrainedInt = conint(gt=0, le=1000)
 # Known issue with MyPy and constrained types
 #   https://github.com/samuelcolvin/pydantic/issues/156
 
@@ -26,12 +26,12 @@ class BulkRequestSchema(ComparableBase):
             return datetime.now(timezone.utc)
         return value
 
-    limit: Optional[Union[ConstrainedLimit, Literal[""]]] = 10
+    limit: Optional[Union[ConstrainedLimit, Literal[""]]] = None
 
     @validator("limit", always=True)
     def limit_must_not_be_blank(cls, value):  # pylint: disable=no-self-argument
         if value in BLANK_VALS:
-            return 10  # Default
+            return 100  # Default
         return value
 
     mofo_relevant: Optional[Union[bool, Literal[""]]] = None

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -402,6 +402,11 @@ API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=&after=&mofo_relevant=",
         None,
     ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=&after=null&mofo_relevant=",
+        None,
+    ),
 )
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,12 +1,9 @@
 """pytest tests for API functionality"""
-import urllib.parse
-from datetime import timedelta
 from typing import Any, Callable, Optional, Tuple
 from uuid import UUID, uuid4
 
 import pytest
 
-from ctms.app import compressor_for_bulk_encoded_details
 from ctms.crud import (
     get_amo_by_email_id,
     get_contacts_by_any_id,
@@ -16,75 +13,7 @@ from ctms.crud import (
     get_vpn_by_email_id,
 )
 from ctms.sample_data import SAMPLE_CONTACTS
-from ctms.schemas import (
-    ContactInSchema,
-    ContactSchema,
-    CTMSResponse,
-    NewsletterInSchema,
-)
-
-
-def test_get_ctms_bulk_by_timerange(
-    client, example_contact, maximal_contact, minimal_contact
-):
-    contact_list = [example_contact, maximal_contact, minimal_contact]
-    sorted_list = sorted(
-        contact_list,
-        key=lambda contact: (contact.email.update_timestamp, contact.email.email_id),
-    )
-    first_contact = sorted_list[0]
-    last_contact = sorted_list[-1]
-    after = compressor_for_bulk_encoded_details(first_contact)
-    limit = 1
-    start = first_contact.email.update_timestamp - timedelta(hours=12)
-    start_time = urllib.parse.quote_plus(start.isoformat())
-    end = last_contact.email.update_timestamp + timedelta(hours=12)
-    end_time = urllib.parse.quote_plus(end.isoformat())
-    url = f"/updates?start={start_time}&end={end_time}&limit={limit}&after={after}"
-    resp = client.get(url)
-    assert resp.status_code == 200
-    results = resp.json()
-    assert "start" in results
-    assert "end" in results
-    assert "after" in results
-    assert "limit" in results
-    assert "next" in results
-    assert "items" in results
-    assert len(results["items"]) > 0
-    dict_contact_expected = sorted_list[1].dict()
-    dict_contact_actual = CTMSResponse.parse_obj(results["items"][0]).dict()
-    assert dict_contact_expected == dict_contact_actual
-    assert results["next"] is not None
-
-
-def test_get_ctms_bulk_by_timerange_no_results(
-    client, example_contact, maximal_contact, minimal_contact
-):
-    contact_list = [example_contact, maximal_contact, minimal_contact]
-    sorted_list = sorted(
-        contact_list,
-        key=lambda contact: (contact.email.update_timestamp, contact.email.email_id),
-    )
-    first_contact = sorted_list[0]
-    last_contact = sorted_list[-1]
-    after = compressor_for_bulk_encoded_details(last_contact)
-    limit = 1
-    start = first_contact.email.update_timestamp - timedelta(hours=12)
-    start_time = urllib.parse.quote_plus(start.isoformat())
-    end = last_contact.email.update_timestamp + timedelta(hours=12)
-    end_time = urllib.parse.quote_plus(end.isoformat())
-    url = f"/updates?start={start_time}&end={end_time}&limit={limit}&after={after}"
-    resp = client.get(url)
-    assert resp.status_code == 200
-    results = resp.json()
-    assert "start" in results
-    assert "end" in results
-    assert "after" in results
-    assert "limit" in results
-    assert "next" in results
-    assert "items" in results
-    assert len(results["items"]) == 0
-    assert results["next"] is None
+from ctms.schemas import ContactInSchema, ContactSchema, NewsletterInSchema
 
 
 def test_get_ctms_for_minimal_contact(client, minimal_contact):
@@ -391,21 +320,6 @@ API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
                 "email_format": "T",
             }
         },
-    ),
-    (
-        "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=2021-01-29T09%3A26%3A57.511000%2B00%3A00&limit=1&after=OTNkYjgzZDQtNDExOS00ZTBjLWFmODctYTcxMzc4NmZhODFkLDIwMjAtMDEtMjIgMTU6MjQ6MDArMDA6MDA=",
-        None,
-    ),
-    (
-        "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=&after=&mofo_relevant=",
-        None,
-    ),
-    (
-        "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=&after=null&mofo_relevant=",
-        None,
     ),
 )
 

--- a/tests/unit/test_bulk.py
+++ b/tests/unit/test_bulk.py
@@ -5,8 +5,7 @@ from typing import Tuple
 
 import pytest
 
-from ctms.app import compressor_for_bulk_encoded_details
-from ctms.schemas import CTMSResponse
+from ctms.schemas import BulkRequestSchema, CTMSResponse
 
 INVALID_BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
     (
@@ -90,7 +89,9 @@ def test_get_ctms_bulk_by_timerange(
     )
     first_contact = sorted_list[0]
     last_contact = sorted_list[-1]
-    after = compressor_for_bulk_encoded_details(first_contact)
+    after = BulkRequestSchema.compressor_for_bulk_encoded_details(
+        first_contact.email.email_id, first_contact.email.update_timestamp
+    )
     limit = 1
     start = first_contact.email.update_timestamp - timedelta(hours=12)
     start_time = urllib.parse.quote_plus(start.isoformat())
@@ -123,7 +124,9 @@ def test_get_ctms_bulk_by_timerange_no_results(
     )
     first_contact = sorted_list[0]
     last_contact = sorted_list[-1]
-    after = compressor_for_bulk_encoded_details(last_contact)
+    after = BulkRequestSchema.compressor_for_bulk_encoded_details(
+        last_contact.email.email_id, last_contact.email.update_timestamp
+    )
     limit = 1
     start = first_contact.email.update_timestamp - timedelta(hours=12)
     start_time = urllib.parse.quote_plus(start.isoformat())

--- a/tests/unit/test_bulk.py
+++ b/tests/unit/test_bulk.py
@@ -1,0 +1,123 @@
+"""pytest tests for API functionality"""
+import urllib.parse
+from datetime import timedelta
+from typing import Tuple
+
+import pytest
+
+from ctms.app import compressor_for_bulk_encoded_details
+from ctms.schemas import CTMSResponse
+
+INVALID_BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=2021-01-29T09%3A26%3A57.511000%2B00%3A00&limit=-11&after=OTNkYjgzZDQtNDExOS00ZTBjLWFmODctYTcxMzc4NmZhODFkLDIwMjAtMDEtMjIgMTU6MjQ6MDArMDA6MDA=",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=101&after=&mofo_relevant=",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&after=null",
+    ),
+)
+BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=2021-01-29T09%3A26%3A57.511000%2B00%3A00&limit=1&after=OTNkYjgzZDQtNDExOS00ZTBjLWFmODctYTcxMzc4NmZhODFkLDIwMjAtMDEtMjIgMTU6MjQ6MDArMDA6MDA=",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=100&after=&mofo_relevant=",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00",
+    ),
+)
+
+
+@pytest.mark.parametrize("method,path", INVALID_BULK_TEST_CASES)
+def test_authorized_bulk_call_errs_on_validation(client, example_contact, method, path):
+    """Calling the API without credentials fails."""
+    resp = client.get(path)
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("method,path", BULK_TEST_CASES)
+def test_authorized_bulk_call_succeeds(client, example_contact, method, path):
+    """Calling the API without credentials fails."""
+    resp = client.get(path)
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize("method,path", BULK_TEST_CASES)
+def test_unauthorized_api_call_fails(anon_client, example_contact, method, path):
+    """Calling the API without credentials fails."""
+    resp = anon_client.get(path)
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Not authenticated"}
+
+
+def test_get_ctms_bulk_by_timerange(
+    client, example_contact, maximal_contact, minimal_contact
+):
+    contact_list = [example_contact, maximal_contact, minimal_contact]
+    sorted_list = sorted(
+        contact_list,
+        key=lambda contact: (contact.email.update_timestamp, contact.email.email_id),
+    )
+    first_contact = sorted_list[0]
+    last_contact = sorted_list[-1]
+    after = compressor_for_bulk_encoded_details(first_contact)
+    limit = 1
+    start = first_contact.email.update_timestamp - timedelta(hours=12)
+    start_time = urllib.parse.quote_plus(start.isoformat())
+    end = last_contact.email.update_timestamp + timedelta(hours=12)
+    end_time = urllib.parse.quote_plus(end.isoformat())
+    url = f"/updates?start={start_time}&end={end_time}&limit={limit}&after={after}"
+    resp = client.get(url)
+    assert resp.status_code == 200
+    results = resp.json()
+    assert "start" in results
+    assert "end" in results
+    assert "after" in results
+    assert "limit" in results
+    assert "next" in results
+    assert "items" in results
+    assert len(results["items"]) > 0
+    dict_contact_expected = sorted_list[1].dict()
+    dict_contact_actual = CTMSResponse.parse_obj(results["items"][0]).dict()
+    assert dict_contact_expected == dict_contact_actual
+    assert results["next"] is not None
+
+
+def test_get_ctms_bulk_by_timerange_no_results(
+    client, example_contact, maximal_contact, minimal_contact
+):
+    contact_list = [example_contact, maximal_contact, minimal_contact]
+    sorted_list = sorted(
+        contact_list,
+        key=lambda contact: (contact.email.update_timestamp, contact.email.email_id),
+    )
+    first_contact = sorted_list[0]
+    last_contact = sorted_list[-1]
+    after = compressor_for_bulk_encoded_details(last_contact)
+    limit = 1
+    start = first_contact.email.update_timestamp - timedelta(hours=12)
+    start_time = urllib.parse.quote_plus(start.isoformat())
+    end = last_contact.email.update_timestamp + timedelta(hours=12)
+    end_time = urllib.parse.quote_plus(end.isoformat())
+    url = f"/updates?start={start_time}&end={end_time}&limit={limit}&after={after}"
+    resp = client.get(url)
+    assert resp.status_code == 200
+    results = resp.json()
+    assert "start" in results
+    assert "end" in results
+    assert "after" in results
+    assert "limit" in results
+    assert "next" in results
+    assert "items" in results
+    assert len(results["items"]) == 0
+    assert results["next"] is None

--- a/tests/unit/test_bulk.py
+++ b/tests/unit/test_bulk.py
@@ -15,11 +15,27 @@ INVALID_BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
     ),
     (
         "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=101&after=&mofo_relevant=",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=1001&after=&mofo_relevant=",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=-3&after=&mofo_relevant=",
     ),
     (
         "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&after=null",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&limit=null",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&after=hello",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&mofo_relevant=nah",
     ),
 )
 BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
@@ -34,6 +50,10 @@ BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
     (
         "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00",
+    ),
+    (
+        "GET",
+        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&mofo_relevant=yes",
     ),
 )
 


### PR DESCRIPTION
On query params, a new validation error of 422 will be presented to users hitting the endpoint with any string.:
- empty string "" as an exception
- after is allowed to have strs, decoding is wrapped to throw a 422 if after is invalid.