### PR TITLE
Adding a docker-compose lint check, that uses the dockerfile's multistage lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 	@echo "CTMS make rules:"
 	@echo ""
 	@echo "  build   - build docker containers"
+	@echo "  lint    - lint check for code"
 	@echo "  setup   - (re)create the database"
 	@echo "  start   - run the API service"
 	@echo ""
@@ -37,6 +38,11 @@ help:
 .PHONY: build
 build: .env
 	docker-compose -f ./docker-compose.yaml -f ./tests/docker-compose.test.yaml build \
+		--build-arg userid=${CTMS_UID} --build-arg groupid=${CTMS_GID}
+
+.PHONY: lint
+lint: .env
+	docker-compose -f ./docker-compose.lint.yaml build \
 		--build-arg userid=${CTMS_UID} --build-arg groupid=${CTMS_GID}
 
 .PHONY: db-only

--- a/docker-compose.lint.yaml
+++ b/docker-compose.lint.yaml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  lint:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: lint
+    volumes:
+      - type: bind
+        source: .
+        target: /app
+    # Let the init system handle signals for us.
+    # among other things this helps shutdown be fast
+    init: true
+    env_file:
+      - docker/config/local_dev.env
+      - .env


### PR DESCRIPTION
A potential solution for : https://github.com/mozilla-it/ctms-api/issues/66

adds:
`make lint`


_which rather checks to confirm/deny if linting has been done; rather than to lint the code._

---

💭 Should this be `lint-check`? 
💭 Would we want a `make lint` to lint the code as well? (Is this preferred to pre-commit?)
🤔  