### PR TITLE
Add "trivial": true to logs for bots and boring requests

### DIFF
--- a/ctms/log.py
+++ b/ctms/log.py
@@ -127,6 +127,7 @@ def configure_logging(use_mozlog: bool = True, logging_level: str = "INFO") -> N
 def context_from_request(request: Request) -> Dict:
     """Extract data from a log request."""
     context = {
+        "trivial": False,  # For filtering in papertrail, place early in log
         "client_host": request.client.host,
         "method": request.method,
         "path": request.url.path,

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -4,16 +4,21 @@ import json
 import os.path
 
 import pytest
+from structlog.testing import capture_logs
 
 
 def test_read_root(anon_client):
     """The site root redirects to the Swagger docs"""
-    resp = anon_client.get("/")
+    with capture_logs() as caplogs:
+        resp = anon_client.get("/")
     assert resp.status_code == 200
     assert len(resp.history) == 1
     prev_resp = resp.history[0]
     assert prev_resp.status_code == 307  # Temporary Redirect
     assert prev_resp.headers["location"] == "./docs"
+    assert len(caplogs) == 2
+    assert caplogs[0]["trivial"] is True
+    assert "trivial" not in caplogs[1]
 
 
 def test_read_version(anon_client):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2,25 +2,8 @@
 
 import json
 import os.path
-from unittest.mock import Mock
 
 import pytest
-from sqlalchemy.exc import TimeoutError as SQATimeoutError
-
-from ctms.app import app, get_db
-
-
-@pytest.fixture
-def mock_db():
-    """Mock the database session."""
-    mocked_db = Mock()
-
-    def mock_get_db():
-        yield mocked_db
-
-    app.dependency_overrides[get_db] = mock_get_db
-    yield mocked_db
-    del app.dependency_overrides[get_db]
 
 
 def test_read_root(anon_client):
@@ -43,32 +26,6 @@ def test_read_version(anon_client):
     resp = anon_client.get("/__version__")
     assert resp.status_code == 200
     assert resp.json() == expected
-
-
-def test_read_heartbeat(anon_client, dbsession):
-    """The platform calls /__heartbeat__ to check backing services."""
-    resp = anon_client.get("/__heartbeat__")
-    assert resp.status_code == 200
-    data = resp.json()
-    expected = {"database": {"up": True, "time_ms": data["database"]["time_ms"]}}
-    assert data == expected
-
-
-def test_read_heartbeat_no_db_fails(anon_client, mock_db):
-    """/__heartbeat__ returns 503 when the database is unavailable."""
-    mock_db.execute.side_effect = SQATimeoutError()
-    resp = anon_client.get("/__heartbeat__")
-    assert resp.status_code == 503
-    data = resp.json()
-    expected = {"database": {"up": False, "time_ms": data["database"]["time_ms"]}}
-    assert data == expected
-
-
-def test_read_health(anon_client):
-    """The platform calls /__lbheartbeat__ to see when the app is running."""
-    resp = anon_client.get("/__lbheartbeat__")
-    assert resp.status_code == 200
-    assert resp.json() == {"status": "OK"}
 
 
 def test_crash_authorized(client):

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,9 +1,53 @@
+"""Unit tests for dockerflow health monitoring endpoints"""
+from unittest.mock import Mock
+
 import pytest
+from sqlalchemy.exc import TimeoutError as SQATimeoutError
+
+from ctms.app import app, get_db
 
 
-@pytest.mark.parametrize("method", ("HEAD", "GET"))
+@pytest.fixture
+def mock_db():
+    """Mock the database session."""
+    mocked_db = Mock()
+
+    def mock_get_db():
+        yield mocked_db
+
+    app.dependency_overrides[get_db] = mock_get_db
+    yield mocked_db
+    del app.dependency_overrides[get_db]
+
+
+def test_read_heartbeat(anon_client, dbsession):
+    """The platform calls /__heartbeat__ to check backing services."""
+    resp = anon_client.get("/__heartbeat__")
+    assert resp.status_code == 200
+    data = resp.json()
+    expected = {"database": {"up": True, "time_ms": data["database"]["time_ms"]}}
+    assert data == expected
+
+
+def test_read_heartbeat_no_db_fails(anon_client, mock_db):
+    """/__heartbeat__ returns 503 when the database is unavailable."""
+    mock_db.execute.side_effect = SQATimeoutError()
+    resp = anon_client.get("/__heartbeat__")
+    assert resp.status_code == 503
+    data = resp.json()
+    expected = {"database": {"up": False, "time_ms": data["database"]["time_ms"]}}
+    assert data == expected
+
+
+def test_read_health(anon_client):
+    """The platform calls /__lbheartbeat__ to see when the app is running."""
+    resp = anon_client.get("/__lbheartbeat__")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "OK"}
+
+
 @pytest.mark.parametrize("path", ("/__lbheartbeat__", "/__heartbeat__"))
-def test_monitoring_endpoints(anon_client, dbsession, method, path):
+def test_head_monitoring_endpoints(anon_client, dbsession, path):
     """Monitoring endpoints can be called without credentials"""
-    resp = anon_client.request(method, path)
+    resp = anon_client.head(path)
     assert resp.status_code == 200

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from sqlalchemy.exc import TimeoutError as SQATimeoutError
+from structlog.testing import capture_logs
 
 from ctms.app import app, get_db
 
@@ -22,11 +23,14 @@ def mock_db():
 
 def test_read_heartbeat(anon_client, dbsession):
     """The platform calls /__heartbeat__ to check backing services."""
-    resp = anon_client.get("/__heartbeat__")
+    with capture_logs() as cap_logs:
+        resp = anon_client.get("/__heartbeat__")
     assert resp.status_code == 200
     data = resp.json()
     expected = {"database": {"up": True, "time_ms": data["database"]["time_ms"]}}
     assert data == expected
+    assert len(cap_logs) == 1
+    assert "trivial" not in cap_logs[0]
 
 
 def test_read_heartbeat_no_db_fails(anon_client, mock_db):
@@ -39,15 +43,60 @@ def test_read_heartbeat_no_db_fails(anon_client, mock_db):
     assert data == expected
 
 
+@pytest.mark.parametrize("method", ("GET", "HEAD"))
+@pytest.mark.parametrize("agent", ("newrelic", "amazon"))
+@pytest.mark.parametrize("success", (True, False))
+def test_read_heartbeat_by_bot(anon_client, mock_db, method, agent, success):
+    """When a known bot calls heartbeat, mark trivial on success."""
+    if agent == "newrelic":
+        headers = {
+            "x-abuse-info": "Request sent by a New Relic Synthetics Monitor (...",
+            "x-newrelic-synthetics": "YmluYXJ5IGRhdGE=",
+        }
+    else:
+        assert agent == "amazon"
+        headers = {"user-agent": "Amazon-Route53-Health-Check-Service (ref ..."}
+    if not success:
+        mock_db.execute.side_effect = SQATimeoutError()
+
+    with capture_logs() as cap_logs:
+        resp = anon_client.request(method, "/__heartbeat__", headers=headers)
+    assert len(cap_logs) == 1
+
+    if success:
+        assert resp.status_code == 200
+        assert cap_logs[0]["trivial"] is True
+    else:
+        assert resp.status_code == 503
+        assert "trivial" not in cap_logs[0]
+
+
 def test_read_health(anon_client):
     """The platform calls /__lbheartbeat__ to see when the app is running."""
-    resp = anon_client.get("/__lbheartbeat__")
+    with capture_logs() as cap_logs:
+        resp = anon_client.get("/__lbheartbeat__")
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK"}
+    assert len(cap_logs) == 1
+    assert "trivial" not in cap_logs[0]
+
+
+@pytest.mark.parametrize("method", ("GET", "HEAD"))
+def test_read_health_by_bot(anon_client, method):
+    """When a known bot calls lbheartbeat, mark the request as trivial."""
+    headers = {"user-agent": "kube-probe/1.18+"}
+    with capture_logs() as cap_logs:
+        resp = anon_client.request(method, "/__lbheartbeat__", headers=headers)
+    assert resp.status_code == 200
+    assert len(cap_logs) == 1
+    assert cap_logs[0]["trivial"] is True
 
 
 @pytest.mark.parametrize("path", ("/__lbheartbeat__", "/__heartbeat__"))
 def test_head_monitoring_endpoints(anon_client, dbsession, path):
     """Monitoring endpoints can be called without credentials"""
-    resp = anon_client.head(path)
+    with capture_logs() as cap_logs:
+        resp = anon_client.head(path)
     assert resp.status_code == 200
+    assert len(cap_logs) == 1
+    assert "trivial" not in cap_logs[0]


### PR DESCRIPTION
Move the tests for ``__heartbeat__`` and ``__lbheartbeat__`` from ``test_app.py`` into ``test_metrics.py``.

Add field ``"trivial": true`` for requests that we'd like to ignore when looking at logs:

* Requests to the root URL (redirected to ``/docs``)
* Amazon or New Relic requesting ``/__heartbeat__``
* Kubernetes requesting ``/__lbheartbeat__``
* Prometheus requesting ``/metrics``

This will allow us to write a Papertrail query that omits these noisy requests for issue #153, such as:

```
ctms-api-stage program:ctms -"\"trivial\": true"
```