### PR TITLE
Add status_code_family to request web metric

### DIFF
--- a/ctms/metrics.py
+++ b/ctms/metrics.py
@@ -20,8 +20,13 @@ METRICS_PARAMS = {
         Counter,
         {
             "name": "ctms_requests_total",
-            "documentation": "Total count of requests by method, path, and status code.",
-            "labelnames": ["method", "path_template", "status_code"],
+            "documentation": "Total count of requests by method, path, status code, and status code family.",
+            "labelnames": [
+                "method",
+                "path_template",
+                "status_code",
+                "status_code_family",
+            ],
         },
     ),
     "requests_duration": (
@@ -115,7 +120,8 @@ def init_metrics_labels(
 
         for combo in product(methods, status_codes):
             method, status_code = combo
-            request_metric.labels(method, path, status_code)
+            status_code_family = str(status_code)[0] + "xx"
+            request_metric.labels(method, path, status_code, status_code_family)
         for time_combo in product(methods, status_code_families):
             method, status_code_family = time_combo
             timing_metric.labels(method, path, status_code_family)
@@ -144,12 +150,15 @@ def emit_response_metrics(
     method = context["method"]
     duration_s = context["duration_s"]
     status_code = context["status_code"]
+    status_code_family = str(status_code)[0] + "xx"
 
     metrics["requests"].labels(
-        method=method, path_template=path_template, status_code=status_code
+        method=method,
+        path_template=path_template,
+        status_code=status_code,
+        status_code_family=status_code_family,
     ).inc()
 
-    status_code_family = str(status_code)[0] + "xx"
     metrics["requests_duration"].labels(
         method=method,
         path_template=path_template,

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -150,61 +150,71 @@ def test_init_metrics_labels(dbsession, client_id_and_secret, registry, metrics)
     assert ("GET", "/ctms/{email_id}", client_id, "4xx") in api_labels
 
 
+def assert_request_metric_inc(
+    metrics_registry: CollectorRegistry,
+    method: str,
+    path_template: str,
+    status_code: int,
+    count: int = 1,
+):
+    """Assert ctms_requests_total with given labels was incremented"""
+    labels = {
+        "method": method,
+        "path_template": path_template,
+        "status_code": str(status_code),
+    }
+    assert metrics_registry.get_sample_value("ctms_requests_total", labels) == count
+
+
+def assert_duration_metric_obs(
+    metrics_registry: CollectorRegistry,
+    method: str,
+    path_template: str,
+    status_code_family: str,
+    limit: float = 0.1,
+    count: int = 1,
+):
+    """Assert ctms_requests_duration_seconds with given labels was observed"""
+    base_name = "ctms_requests_duration_seconds"
+    labels = {
+        "method": method,
+        "path_template": path_template,
+        "status_code_family": status_code_family,
+    }
+    bucket_labels = labels.copy()
+    bucket_labels["le"] = str(limit)
+    assert (
+        metrics_registry.get_sample_value(f"{base_name}_bucket", bucket_labels) == count
+    )
+    assert metrics_registry.get_sample_value(f"{base_name}_count", labels) == count
+    assert metrics_registry.get_sample_value(f"{base_name}_sum", labels) < limit
+
+
+def assert_api_request_metric_inc(
+    metrics_registry: CollectorRegistry,
+    method: str,
+    path_template: str,
+    client_id: str,
+    status_code_family: str,
+    count: int = 1,
+):
+    """Assert ctms_api_requests_total with given labels was incremented"""
+    labels = {
+        "method": method,
+        "path_template": path_template,
+        "client_id": client_id,
+        "status_code_family": status_code_family,
+    }
+    assert metrics_registry.get_sample_value("ctms_api_requests_total", labels) == count
+
+
 def test_homepage_request(anon_client, registry):
     """A homepage request emits metrics for / and /docs"""
     anon_client.get("/")
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_total",
-            {"method": "GET", "path_template": "/", "status_code": "307"},
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_total",
-            {"method": "GET", "path_template": "/docs", "status_code": "200"},
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_duration_seconds_bucket",
-            {
-                "method": "GET",
-                "path_template": "/",
-                "status_code_family": "3xx",
-                "le": "0.1",
-            },
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_duration_seconds_count",
-            {"method": "GET", "path_template": "/", "status_code_family": "3xx"},
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_duration_seconds_sum",
-            {"method": "GET", "path_template": "/", "status_code_family": "3xx"},
-        )
-        < 0.1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_duration_seconds_bucket",
-            {
-                "method": "GET",
-                "path_template": "/docs",
-                "status_code_family": "2xx",
-                "le": "0.1",
-            },
-        )
-        == 1
-    )
+    assert_request_metric_inc(registry, "GET", "/", 307)
+    assert_request_metric_inc(registry, "GET", "/docs", 200)
+    assert_duration_metric_obs(registry, "GET", "/", "3xx")
+    assert_duration_metric_obs(registry, "GET", "/docs", "2xx")
 
 
 def test_api_request(client, minimal_contact, registry):
@@ -212,51 +222,9 @@ def test_api_request(client, minimal_contact, registry):
     email_id = minimal_contact.email.email_id
     client.get(f"/ctms/{email_id}")
     path = "/ctms/{email_id}"
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_total",
-            {"method": "GET", "path_template": path, "status_code": "200"},
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_duration_seconds_bucket",
-            {
-                "method": "GET",
-                "path_template": path,
-                "status_code_family": "2xx",
-                "le": "0.1",
-            },
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_duration_seconds_count",
-            {"method": "GET", "path_template": path, "status_code_family": "2xx"},
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_duration_seconds_sum",
-            {"method": "GET", "path_template": path, "status_code_family": "2xx"},
-        )
-        < 0.1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_api_requests_total",
-            {
-                "method": "GET",
-                "path_template": path,
-                "client_id": "test_client",
-                "status_code_family": "2xx",
-            },
-        )
-        == 1
-    )
+    assert_request_metric_inc(registry, "GET", path, 200)
+    assert_duration_metric_obs(registry, "GET", path, "2xx")
+    assert_api_request_metric_inc(registry, "GET", path, "test_client", "2xx")
 
 
 @pytest.mark.parametrize(
@@ -271,24 +239,10 @@ def test_bad_api_request(client, dbsession, registry, email_id, status_code):
     resp = client.get(f"/ctms/{email_id}")
     assert resp.status_code == status_code
     path = "/ctms/{email_id}"
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_total",
-            {"method": "GET", "path_template": path, "status_code": str(status_code)},
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_api_requests_total",
-            {
-                "method": "GET",
-                "path_template": path,
-                "client_id": "test_client",
-                "status_code_family": str(status_code)[0] + "xx",
-            },
-        )
-        == 1
+    assert_request_metric_inc(registry, "GET", path, status_code)
+    status_code_family = str(status_code)[0] + "xx"
+    assert_api_request_metric_inc(
+        registry, "GET", path, "test_client", status_code_family
     )
 
 
@@ -297,25 +251,8 @@ def test_crash_request(client, dbsession, registry):
     path = "/__crash__"
     with pytest.raises(RuntimeError):
         client.get(path)
-    assert (
-        registry.get_sample_value(
-            "ctms_requests_total",
-            {"method": "GET", "path_template": path, "status_code": "500"},
-        )
-        == 1
-    )
-    assert (
-        registry.get_sample_value(
-            "ctms_api_requests_total",
-            {
-                "method": "GET",
-                "path_template": path,
-                "client_id": "test_client",
-                "status_code_family": "5xx",
-            },
-        )
-        == 1
-    )
+    assert_request_metric_inc(registry, "GET", path, 500)
+    assert_api_request_metric_inc(registry, "GET", path, "test_client", "5xx")
 
 
 def test_unknown_path(anon_client, dbsession, registry):

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -162,6 +162,7 @@ def assert_request_metric_inc(
         "method": method,
         "path_template": path_template,
         "status_code": str(status_code),
+        "status_code_family": str(status_code)[0] + "xx",
     }
     assert metrics_registry.get_sample_value("ctms_requests_total", labels) == count
 


### PR DESCRIPTION
Add some test functions like ``assert_request_metric_inc``. This reduces the lines of code in the test functions themselves, making it a bit clearer what metrics are being tested. It also makes it a one-line test change for the metric change.

Add ``status_code_family`` label, like ``2xx`` and ``4xx`` to the ``ctms_requests_total`` metric. This already has ``status_code`` as a label, so the new label does not increase the cardinality. This will help when cross-referencing
against the Application Load Balancer (ALB) metrics, or when comparing success / failure ratios.

This is the last item for issue #124, adding metrics to the web app.