### PR TITLE
Add log tracing for emails with "+trace-me-mozilla-"

### DIFF
--- a/tests/unit/test_api_get_by_alt_id.py
+++ b/tests/unit/test_api_get_by_alt_id.py
@@ -1,6 +1,10 @@
 """Unit tests for GET /ctms?alt_id=value, returning list of contacts"""
+from uuid import uuid4
 
 import pytest
+from structlog.testing import capture_logs
+
+from ctms.models import AmoAccount, Email, MozillaFoundationContact
 
 
 @pytest.mark.parametrize(
@@ -67,3 +71,87 @@ def test_get_ctms_by_alt_id_none_found(client, dbsession, alt_id_name, alt_id_va
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 0
+
+
+def test_get_not_traced(client, example_contact):
+    """Most CTMS contacts are not traced."""
+    params = {"primary_email": example_contact.email.primary_email}
+    with capture_logs() as caplog:
+        resp = client.get("/ctms", params=params)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert len(caplog) == 1
+    assert "trace" not in caplog[0]
+
+
+def test_get_with_tracing(client, dbsession, maximal_contact):
+    """The log parameter trace is set when a traced email is requested."""
+    email_id = uuid4()
+    mofo_contact_id = maximal_contact.mofo.mofo_contact_id
+    email = "test+trace-me-mozilla-123@example.com"
+    record = Email(
+        email_id=email_id,
+        primary_email=email,
+        double_opt_in=False,
+        email_format="T",
+        has_opted_out_of_email=False,
+    )
+    mofo = MozillaFoundationContact(
+        email_id=email_id,
+        mofo_relevant=True,
+        mofo_contact_id=mofo_contact_id,
+        mofo_email_id=uuid4(),
+    )
+    dbsession.add(record)
+    dbsession.add(mofo)
+    dbsession.commit()
+    with capture_logs() as caplog:
+        resp = client.get("/ctms", params={"mofo_contact_id": str(mofo_contact_id)})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert len(caplog) == 1
+    assert caplog[0]["trace"] == email
+    assert "trace_json" not in caplog[0]
+
+
+def test_get_multiple_with_tracing(client, dbsession):
+    """Multiple traced emails are comma-joined."""
+    email_id1 = uuid4()
+    email1 = "test+trace-me-mozilla-1@example.com"
+    dbsession.add(
+        Email(
+            email_id=email_id1,
+            primary_email=email1,
+            double_opt_in=False,
+            email_format="T",
+            has_opted_out_of_email=False,
+        )
+    )
+    dbsession.add(
+        AmoAccount(email_id=email_id1, user_id="amo123", email_opt_in=False, user=True)
+    )
+    email_id2 = uuid4()
+    email2 = "test+trace-me-mozilla-2@example.com"
+    dbsession.add(
+        Email(
+            email_id=email_id2,
+            primary_email=email2,
+            double_opt_in=False,
+            email_format="T",
+            has_opted_out_of_email=False,
+        )
+    )
+    dbsession.add(
+        AmoAccount(email_id=email_id2, user_id="amo123", email_opt_in=True, user=True)
+    )
+    dbsession.commit()
+    with capture_logs() as caplog:
+        resp = client.get("/ctms", params={"amo_user_id": "amo123"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert len(caplog) == 1
+    assert caplog[0]["trace"] == f"{email1},{email2}"
+    assert "trace_json" not in caplog[0]

--- a/tests/unit/test_api_patch.py
+++ b/tests/unit/test_api_patch.py
@@ -3,6 +3,7 @@ import json
 from uuid import uuid4
 
 import pytest
+from structlog.testing import capture_logs
 
 from ctms.crud import create_contact, get_email
 from ctms.schemas import (
@@ -454,3 +455,26 @@ def test_patch_to_delete_deleted_group(client, minimal_contact):
     actual = resp.json()
     default_mofo = MozillaFoundationSchema().dict()
     assert actual["mofo"] == default_mofo
+
+
+def test_patch_no_trace(client, minimal_contact):
+    """PATCH does not trace most contacts"""
+    email_id = minimal_contact.email.email_id
+    patch_data = {"email": {"first_name": "Jeff"}}
+    with capture_logs() as caplogs:
+        resp = client.patch(f"/ctms/{email_id}", json=patch_data)
+    assert resp.status_code == 200
+    assert len(caplogs) == 1
+    assert "trace" not in caplogs[0]
+
+
+def test_patch_with_trace(client, minimal_contact):
+    """PATCH traces by email"""
+    email_id = minimal_contact.email.email_id
+    patch_data = {"email": {"primary_email": "jeff+trace-me-mozilla-1@example.com"}}
+    with capture_logs() as caplogs:
+        resp = client.patch(f"/ctms/{email_id}", json=patch_data)
+    assert resp.status_code == 200
+    assert len(caplogs) == 1
+    assert caplogs[0]["trace"] == "jeff+trace-me-mozilla-1@example.com"
+    assert caplogs[0]["trace_json"] == patch_data

--- a/tests/unit/test_api_put.py
+++ b/tests/unit/test_api_put.py
@@ -1,7 +1,9 @@
 """Unit tests for PUT /ctms/{email_id} (Create or update)"""
-from uuid import UUID
+import json
+from uuid import UUID, uuid4
 
 import pytest
+from structlog.testing import capture_logs
 
 from tests.unit.sample_data import SAMPLE_CONTACTS
 from tests.unit.test_api import _compare_written_contacts
@@ -113,3 +115,73 @@ def test_create_or_update_with_email_collision(put_contact):
 
     saved_contacts, _, _ = put_contact(modifier=_change_primary_email, code=409)
     _compare_written_contacts(saved_contacts[0], orig_sample, email_id)
+
+
+def test_put_create_no_trace(client, dbsession):
+    """PUT does not trace most new contacts"""
+    email_id = str(uuid4())
+    data = {
+        "email": {"email_id": email_id, "primary_email": "test+no-trace@example.com"}
+    }
+    with capture_logs() as caplogs:
+        resp = client.put(f"/ctms/{email_id}", json=data)
+    assert resp.status_code == 201
+    assert len(caplogs) == 1
+    assert "trace" not in caplogs[0]
+
+
+def test_put_replace_no_trace(client, minimal_contact):
+    """PUT does not trace most replaced contacts"""
+    email_id = minimal_contact.email.email_id
+    data = json.loads(minimal_contact.json())
+    data["email"]["first_name"] = "Jeff"
+    with capture_logs() as caplogs:
+        resp = client.put(f"/ctms/{email_id}", json=data)
+    assert resp.status_code == 201
+    assert len(caplogs) == 1
+    assert "trace" not in caplogs[0]
+
+
+def test_put_with_not_json_is_error(client, dbsession):
+    """Calling PUT with a text body is a 422 validation error."""
+    email_id = str(uuid4())
+    data = "make a contact please"
+    with capture_logs() as caplogs:
+        resp = client.put(f"/ctms/{email_id}", data=data)
+    assert resp.status_code == 422
+    assert (
+        resp.json()["detail"][0]["msg"] == "Expecting value: line 1 column 1 (char 0)"
+    )
+    assert len(caplogs) == 1
+    assert "trace" not in caplogs[0]
+
+
+def test_put_create_with_trace(client, dbsession):
+    """PUT traces new contacts by email address"""
+    email_id = str(uuid4())
+    data = {
+        "email": {
+            "email_id": email_id,
+            "primary_email": "test+trace-me-mozilla-2021-05-13@example.com",
+        }
+    }
+    with capture_logs() as caplogs:
+        resp = client.put(f"/ctms/{email_id}", json=data)
+    assert resp.status_code == 201
+    assert len(caplogs) == 1
+    assert caplogs[0]["trace"] == "test+trace-me-mozilla-2021-05-13@example.com"
+    assert caplogs[0]["trace_json"] == data
+
+
+def test_put_replace_with_trace(client, minimal_contact):
+    """PUT traces replaced contacts by email"""
+    email_id = minimal_contact.email.email_id
+    data = json.loads(minimal_contact.json())
+    data["email"]["first_name"] = "Jeff"
+    data["email"]["primary_email"] = "test+trace-me-mozilla-2021-05-13@example.com"
+    with capture_logs() as caplogs:
+        resp = client.put(f"/ctms/{email_id}", json=data)
+    assert resp.status_code == 201
+    assert len(caplogs) == 1
+    assert caplogs[0]["trace"] == "test+trace-me-mozilla-2021-05-13@example.com"
+    assert caplogs[0]["trace_json"] == data


### PR DESCRIPTION
As suggested in issue #211, add a feature that traces requests if contact's primary email has the string ``+trace-me-mozilla-``, such as ``test+trace-me-mozilla-1@example.com``. The contact itself is examined, so the string does not need to appear in the request body.

Tracing is enabled for these API endpoints:

* ``GET /ctms``
* ``POST /ctms``
* ``GET /ctms/{email_id}``
* ``PUT /ctms/{email_id}``
* ``PATCH /ctms/{email_id}``

When active, two items are added to the log:

* ``trace={email}``, placing the email in the log. For ``GET /ctms``, if multiple emails are traced, the value is a comma-separated list of the traced emails
* ``trace_json={request_json}``, when the request has a JSON body (``POST``, ``PUT``, ``PATCH``)

The purpose is to allow debugging requests from an integrated service, such as Basket or Mozilla Foundation systems. The string was chosen for the very small chance of adding it by accident, and because of the implied consent to tracing implied by the text.

~~This is built on PR #214, and adds two more commits. I can rebase to make reviewing this one easier.~~ Merged and rebased

 