### PR TITLE
Setup multiprocessing metrics registry in ``/metrics`` endpoint

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -11,7 +11,7 @@ import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Path, Request, Response
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from pydantic import ValidationError
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.logging import ignore_logger
@@ -42,9 +42,9 @@ from .database import get_db_engine
 from .log import configure_logging, context_from_request, get_log_line
 from .metrics import (
     emit_response_metrics,
+    get_metrics_reporting_registry,
     init_metrics,
     init_metrics_labels,
-    init_metrics_registry,
 )
 from .models import Email
 from .monitor import check_database, get_version
@@ -76,7 +76,7 @@ app = FastAPI(
     version="0.8.0",
 )
 SessionLocal = None
-METRICS_REGISTRY = None
+METRICS_REGISTRY = CollectorRegistry()
 METRICS = None
 get_metrics_registry = lambda: METRICS_REGISTRY
 get_metrics = lambda: METRICS
@@ -120,7 +120,6 @@ def init_sentry():
 if "pytest" not in sys.argv[0]:
     init_sentry()
     app.add_middleware(SentryAsgiMiddleware)
-    METRICS_REGISTRY = init_metrics_registry()
 
 
 @app.on_event("startup")
@@ -795,9 +794,8 @@ def metrics(request: Request):
     if agent.startswith("Prometheus/"):
         request.state.log_context["trivial_code"] = 200
     headers = {"Content-Type": CONTENT_TYPE_LATEST}
-    return Response(
-        generate_latest(get_metrics_registry()), status_code=200, headers=headers
-    )
+    registry = get_metrics_reporting_registry(get_metrics_registry())
+    return Response(generate_latest(registry), status_code=200, headers=headers)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For each process, use a separate ``CollectorRegistry`` initialized at startup.

For the ``/metrics`` view, use this collecter in single-process mode, but use a fresh ``CollectorRegistry`` with 
``MultiProcessCollector`` in multiprocess under ``gunicorn``. This should avoid duplicate metric exports (one for multiprocess, one for the process serving the request).

This was based off of reading [starlette_explorer](https://github.com/stephenhillier/starlette_exporter)'s middleware and view, as well as finally understanding this line of the [multiprocessing docs](https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn):

> It is a best practice to create this registry inside the context of a request to avoid metrics registering themselves to a collector used by a ``MultiProcessCollector``. If a registry with metrics registered is used by a ``MultiProcessCollector`` duplicate metrics may be exported, one for multiprocess, and one for the process serving the request.

This suggests that in the stage metrics, the requests counts jump around because the metrics are the group metrics plus those collected by that process.

<img width="1050" alt="CTMS jumping metrics" src="https://user-images.githubusercontent.com/286017/118499395-8122a300-b6ec-11eb-84ba-3bcef7e15434.png">

I verified the issue and the solution with a temporary PID-based metric, see https://github.com/mozilla-it/ctms-api/commit/310228408c6d27f2becba8adab7de70695448315 for code.
