### PR TITLE
Enhancing logging with background job. Adding argument -log/--log to set log level. Default to debug for visibility into running job.

### DIFF
--- a/ctms/bin/acoustic_sync.py
+++ b/ctms/bin/acoustic_sync.py
@@ -30,7 +30,6 @@ def _setup_args():
         "debug": logging.DEBUG,
     }
     level = levels.get(options.log.lower())
-    print("here")
     if level is None:
         raise ValueError(
             f"log level given: {options.log}"

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -40,3 +40,6 @@ class BackgroundSettings(Settings):
     acoustic_refresh_token: str
     acoustic_main_table_id: int
     acoustic_newsletter_table_id: int
+    logging_level: Literal[
+        "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"
+    ] = "DEBUG"  # Overloaded Default for Background Job


### PR DESCRIPTION
Enhance logging for background job.

It seemed that logs were lacking visibility. I added basiclogging, and use of argument parser to allow this to be provided at runtime, but default to debug.

`log level given:  -- must be one of: critical | error | warn | warning | info | debug`