### PR TITLE
Add init_sentry to acoustic_sync

### DIFF
--- a/ctms/bin/acoustic_sync.py
+++ b/ctms/bin/acoustic_sync.py
@@ -5,6 +5,7 @@ from time import monotonic, sleep
 
 from ctms import config
 from ctms.database import get_db_engine
+from ctms.exception_capture import init_sentry
 from ctms.log import configure_logging
 from ctms.sync import CTMSToAcousticSync
 
@@ -39,6 +40,7 @@ def main(db, settings):
 
 
 if __name__ == "__main__":
+    init_sentry()
     config_settings = config.BackgroundSettings()
     LOGGER = _setup_logging(config_settings)
     engine, session_factory = get_db_engine(config_settings)

--- a/ctms/exception_capture.py
+++ b/ctms/exception_capture.py
@@ -1,0 +1,34 @@
+"""Capture exceptions with Sentry"""
+
+import sentry_sdk
+from pydantic import ValidationError
+from sentry_sdk.integrations.logging import ignore_logger
+
+from ctms import config
+from ctms.monitor import get_version
+
+
+def init_sentry():
+    """
+    Initialize Sentry integrations for capturing exceptions.
+
+    Because FastAPI uses threads to integrate async and sync code, this needs
+    to be called at module import.
+
+    sentry_sdk.init needs a data source name (DSN) URL, which it reads from the
+    environment variable SENTRY_DSN.
+    """
+    try:
+        settings = config.Settings()
+        sentry_debug = settings.sentry_debug
+    except ValidationError:
+        sentry_debug = False
+
+    # pylint: disable=abstract-class-instantiated
+    sentry_sdk.init(
+        release=get_version().get("commit", None),
+        debug=sentry_debug,
+        send_default_pii=False,
+    )
+    ignore_logger("uvicorn.error")
+    ignore_logger("ctms.web")


### PR DESCRIPTION
Move ``init_sentry`` from ``app.py`` to new file ``exception_capture.py``, and call it during startup for ``acoustic_sync.py``.

I think this is enough for Sentry integration, and will process any uncaught exceptions. There's currently one exception handler:

https://github.com/mozilla-it/ctms-api/blob/9a38b4fdb3f0c48c0d6565f93a574de303b36fab/ctms/acoustic_service.py#L328-L331

The Sentry [logging integration](https://docs.sentry.io/platforms/python/guides/logging/) will capture the stack trace from ``logger.exception``.