### PR TITLE
Initial commit for enabling case-insensitivity, calling 'lower()' on primary_email's.

### DIFF
--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -198,7 +198,9 @@ def get_emails_by_any_id(
     if email_id is not None:
         statement = statement.filter(Email.email_id == email_id)
     if primary_email is not None:
-        statement = statement.filter(Email.primary_email == primary_email)
+        statement = statement.filter_by(
+            primary_email_insensitive_comparator=primary_email
+        )
     if basket_token is not None:
         statement = statement.filter(Email.basket_token == str(basket_token))
     if sfdc_id is not None:
@@ -216,8 +218,8 @@ def get_emails_by_any_id(
     if fxa_id is not None:
         statement = statement.join(Email.fxa).filter(FirefoxAccount.fxa_id == fxa_id)
     if fxa_primary_email is not None:
-        statement = statement.join(Email.fxa).filter(
-            FirefoxAccount.primary_email == fxa_primary_email
+        statement = statement.join(Email.fxa).filter_by(
+            fxa_primary_email_insensitive_comparator=fxa_primary_email
         )
     return cast(List[Email], statement.all())
 

--- a/migrations/versions/20210520_37edf9c48404_adding_lower_indexes.py
+++ b/migrations/versions/20210520_37edf9c48404_adding_lower_indexes.py
@@ -1,0 +1,42 @@
+"""Adding lower-indexes
+
+Revision ID: 37edf9c48404
+Revises: cad3c933830b
+Create Date: 2021-05-20 00:28:25.950122
+
+"""
+# pylint: disable=no-member invalid-name
+# no-member is triggered by alembic.op, which has dynamically added functions
+# invalid-name is triggered by migration file names with a date prefix
+# invalid-name is triggered by top-level alembic constants like revision instead of REVISION
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "37edf9c48404"  # pragma: allowlist secret
+down_revision = "cad3c933830b"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # UserWarning: autogenerate skipping functional index idx_email_primary_email_lower; not supported by SQLAlchemy reflection
+    op.create_index(
+        "idx_email_primary_email_lower",
+        "emails",
+        [sa.text("lower(primary_email)")],
+        unique=True,
+    )
+    # UserWarning: autogenerate skipping functional index idx_fxa_primary_email_lower; not supported by SQLAlchemy reflection
+    op.create_index(
+        "idx_fxa_primary_email_lower",
+        "fxa",
+        [sa.text("lower(primary_email)")],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index("idx_email_primary_email_lower", table_name="emails")
+    op.drop_index("idx_fxa_primary_email_lower", table_name="fxa")


### PR DESCRIPTION
Previous solution: Use @validator decorators to convert incoming values to lowercase, so they are lowercase in the DB.

New solution: Don't modify default or validation logic, just add comparators for LC comparison on DB