### PR TITLE
Modifying migration

### DIFF
--- a/ctms/models.py
+++ b/ctms/models.py
@@ -73,7 +73,7 @@ class Email(Base):
     # Indexes
     __table_args__ = (
         Index("bulk_read_index", "update_timestamp", "email_id"),
-        Index("idx_email_primary_email_lower", func.lower(primary_email), unique=True),
+        Index("idx_email_primary_email_lower", func.lower(primary_email)),
     )
 
 

--- a/migrations/versions/20210520_37edf9c48404_adding_lower_indexes.py
+++ b/migrations/versions/20210520_37edf9c48404_adding_lower_indexes.py
@@ -26,7 +26,7 @@ def upgrade():
         "idx_email_primary_email_lower",
         "emails",
         [sa.text("lower(primary_email)")],
-        unique=True,
+        unique=False,
     )
     # UserWarning: autogenerate skipping functional index idx_fxa_primary_email_lower; not supported by SQLAlchemy reflection
     op.create_index(


### PR DESCRIPTION
> alembic current reports cad3c933830b (head)

Since the prior migration failed and RB'd to the previous revision, this PR removes the uniqueness element to the func.lower(primary_email) index