### PR TITLE
Updating from ISO to MM/DD/YYYY

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -299,9 +299,9 @@ class CTMSToAcousticService:
             return "0"
         if isinstance(data, datetime.datetime):
             # Acoustic doesn't have timestamps, so make timestamps into dates.
-            return data.date().isoformat()
+            data = data.date()
         if isinstance(data, datetime.date):
-            return data.isoformat()
+            return data.strftime("%m/%d/%Y")
         if isinstance(data, UUID):
             return str(data)
         return data

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -107,20 +107,36 @@ def test_transform_field(base_ctms_acoustic_service):
     assert is_true == "1"
     is_false = base_ctms_acoustic_service.transform_field_for_acoustic(False)
     assert is_false == "0"
-    is_datetime = base_ctms_acoustic_service.transform_field_for_acoustic(
+    transformed_from_datetime = base_ctms_acoustic_service.transform_field_for_acoustic(
         datetime.datetime.now()
     )
-    assert is_datetime is not None
-    is_date = base_ctms_acoustic_service.transform_field_for_acoustic(
+    assert (
+        transformed_from_datetime is not None
+    ), "Error when using method to transform datetime object"
+    transformed_from_date = base_ctms_acoustic_service.transform_field_for_acoustic(
         datetime.date.today()
     )
-    assert is_date is not None
+    assert (
+        transformed_from_date is not None
+    ), "Error when using method to transform date object"
 
     try:
-        is_datetime = datetime.date.fromisoformat(is_datetime)
-        assert isinstance(is_datetime, datetime.date)
-        is_date = datetime.date.fromisoformat(is_date)
-        assert isinstance(is_date, datetime.date)
+        assert transformed_from_datetime == transformed_from_date, (
+            "The result of the transformation process of a "
+            "date and datetime should be identical, "
+            "when starting values are equivalent in date "
+        )
+
+        is_datetime_parsed = datetime.datetime.strptime(
+            transformed_from_datetime, "%m/%d/%Y"
+        )
+        assert isinstance(
+            is_datetime_parsed, datetime.date
+        ), "The result should be in MM/DD/YYYY format, to be able to be processed to a date"
+        is_date_parsed = datetime.datetime.strptime(transformed_from_date, "%m/%d/%Y")
+        assert isinstance(
+            is_date_parsed, datetime.date
+        ), "The result should be in MM/DD/YYYY format, to be able to be processed to a date"
     except:  # pylint: disable=W0702
         assert False, "Failure with timestamp validation"
 


### PR DESCRIPTION
Related:
> To follow-up tomorrow: possibly none of the dates we're sending from C->A are in a format that Acoustic likes. We're sending YYYY-MM-DD but Acoustic might need MM/DD/YYYY (ref: https://help.goacoustic.com/hc/en-us/articles/360043349433-Work-with-database-fields)
> Should be a(nother) simple change to the C->A script
> ...https://mozilla.slack.com/archives/G01BEQJFWS3/p1624593115185800

