### PR TITLE
Update to Python 3.9, Debian 11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Creating a python base with shared environment variables
-FROM python:3.8.12-slim as python-base
+FROM python:3.9.7-slim as python-base
 ENV PYTHONPATH=/app \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
The [``python:*-slim`` Docker images](https://hub.docker.com/_/python/) are now based on Debian 11 (bullseye), which [shipped with Python 3.9](https://www.debian.org/releases/bullseye/amd64/release-notes/ch-whats-new.en.html#major-packages). Use Python 3.9.7, the latest in the 3.9 series.