### PR TITLE
Switch ContactSchema to Config.fields

### DIFF
--- a/ctms/schemas/contact.py
+++ b/ctms/schemas/contact.py
@@ -26,12 +26,16 @@ class ContactSchema(ComparableBase):
     email: EmailSchema
     fxa: Optional[FirefoxAccountsSchema] = None
     mofo: Optional[MozillaFoundationSchema] = None
-    newsletters: List[NewsletterSchema] = Field(
-        default=[],
-        description="List of newsletters for which the contact is or was subscribed",
-        example=([{"name": "firefox-welcome"}, {"name": "mozilla-welcome"}]),
-    )
+    newsletters: List[NewsletterSchema] = []
     vpn_waitlist: Optional[VpnWaitlistSchema] = None
+
+    class Config:
+        fields = {
+            "newsletters": {
+                "description": "List of newsletters for which the contact is or was subscribed",
+                "example": [{"name": "firefox-welcome"}, {"name": "mozilla-welcome"}],
+            }
+        }
 
     def as_identity_response(self) -> "IdentityResponse":
         """Return the identities of a contact"""
@@ -74,12 +78,16 @@ class ContactInBase(ComparableBase):
     email: EmailBase
     fxa: Optional[FirefoxAccountsInSchema] = None
     mofo: Optional[MozillaFoundationInSchema] = None
-    newsletters: List[NewsletterInSchema] = Field(
-        default=[],
-        description="List of newsletters for which the contact is or was subscribed",
-        example=([{"name": "firefox-welcome"}, {"name": "mozilla-welcome"}]),
-    )
+    newsletters: List[NewsletterInSchema] = []
     vpn_waitlist: Optional[VpnWaitlistInSchema] = None
+
+    class Config:
+        fields = {
+            "newsletters": {
+                "description": "List of newsletters for which the contact is or was subscribed",
+                "example": [{"name": "firefox-welcome"}, {"name": "mozilla-welcome"}],
+            }
+        }
 
     def idempotent_equal(self, other):
         def _noneify(field):


### PR DESCRIPTION
Switch ``ContactSchema`` from defining ``newsletter`` metadata in a ``Field`` to the ``ContactSchema.Config.fields``. This lets ``pylint`` see it as an iterable and removes a few ``pylint`` issues from `make lint`.

Related to issue #173.

Here's the error I see on main:

```
#28 7.855 ************* Module ctms.schemas.contact                                                                                                                                                                                
#28 7.855 ctms/schemas/contact.py:65:39: E1133: Non-iterable value self.newsletters is used in an iterating context (not-an-iterable)                                                                                              
#28 9.677 ************* Module tests.unit.test_bin_load_sample_csv                                                                                                                                                                 
#28 9.677 tests/unit/test_bin_load_sample_csv.py:45:58: E1133: Non-iterable value contact.newsletters is used in an iterating context (not-an-iterable)
#28 9.692 tests/unit/test_bin_load_sample_csv.py:74:58: E1133: Non-iterable value contact.newsletters is used in an iterating context (not-an-iterable)
#28 12.00 
#28 12.00 -----------------------------------
#28 12.00 Your code has been rated at 9.96/10
#28 12.00 
```