### PR TITLE
Convert pre-commit to use Poetry environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: pylint
+        entry: poetry run pylint
         language: system
         exclude: ^migrations/
         types: [python]
@@ -23,33 +23,45 @@ repos:
         ]
         exclude: 'k8s/secret.json'
       - id: trailing-whitespace
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
+  - repo: local
     hooks:
       - id: mypy
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.2
+        name: mypy
+        entry: poetry run mypy
+        language: system
+        types: [python]
+  - repo: local
     hooks:
       - id: bandit
+        name: bandit
+        entry: poetry run bandit
         args: [-lll, --recursive]
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v0.14.3
+        language: system
+  - repo: local
     hooks:
       - id: detect-secrets
+        name: detect-secrets
+        entry: poetry run detect-secrets-hook
         args: ['--baseline', '.secrets.baseline']
         exclude: "poetry.lock"
+        language: system
   - repo: https://github.com/asottile/seed-isort-config
     rev: v1.9.3
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/PyCQA/isort
-    rev: 4.3.21
+  - repo: local
     hooks:
       - id: isort
-        additional_dependencies: [pyproject, toml]
+        name: isort
+        entry: poetry run isort
         args: ["--recursive", "--settings-path", "./pyproject.toml", "."]
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
+        language: system
+        types: [python]
+  - repo: local
     hooks:
       - id: black
+        name: black
+        entry: poetry run black
         args: ["--config","./pyproject.toml", "."]
+        types: [python]
+        language: system

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "(poetry.lock$)|(htmlcov/)",
     "lines": null
   },
-  "generated_at": "2021-04-21T19:10:03Z",
+  "generated_at": "2021-10-25T18:35:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
       {
         "hashed_secret": "5089246737bcae6ebd14c2548a8360bc548cf0db",
         "is_verified": false,
-        "line_number": 215,
+        "line_number": 233,
         "type": "Secret Keyword"
       }
     ]

--- a/guides/developer_setup.md
+++ b/guides/developer_setup.md
@@ -85,8 +85,7 @@ The command `deactivate` might not work to full disengage the poetry shell as it
 Using poetry (pre-commit is located in the [pyproject.toml](../pyproject.toml) )
 
 ```sh
-poetry shell
-pre-commit install
+poetry run pre-commit install
 ```
 
 You should get the following response after installing pre-commit into the githooks:
@@ -102,13 +101,17 @@ When you commit in git, the pre-commit hooks will engage and perform the outline
 
 ### Force Run on the Entire Codebase (Optional)
 
-Run the following command where you installed pre-commit.
+Run the following to check all files
 ```sh
-pre-commit run --all-files
+poetry run pre-commit run --all-files
 ```
 
 ### Bypass Hook (Not Recommended)
-The option `--no-verify` should allow a committer to bypass the hooks when committing.
+The option `--no-verify` allows a committer to bypass the hooks when committing:
+
+```sh
+git commit --no-verify
+```
 
 ---
 ## Docker


### PR DESCRIPTION
Run pre-commit steps with `poetry run`, so that the Poetry configuration is the source for tool versions. The project [pronovic/apologies](https://github.com/pronovic/apologies/blob/master/.pre-commit-config.yaml) and the blog post [Consistent Python environments with Poetry and pre-commit hooks](https://objectpartners.com/2020/06/15/consistent-python-environments-with-poetry-and-pre-commit-hooks/) were my inspiration, we may want to grab more ideas.

These are still installed by pre-commit:
* https://github.com/pre-commit/pre-commit-hooks - Seems appropriate to let pre-commit manage these
* https://github.com/asottile/seed-isort-config - Deprecated, "this is no longer needed as of isort>=5". We're on isort 4.3.21.

This requires that ``poetry install`` is run first, to get the package versions:

```sh
poetry install
poetry run pre-commit install 
```

To test out these changes:
```sh
# Remove previously installed packages
poetry run pre-commit clean

# Install packages and check project
poetry run pre-commit run --all-files
```

