### PR TITLE
Add the param "table" to background metrics

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -395,7 +395,11 @@ class CTMSToAcousticService:
             finally:
                 duration = time.monotonic() - start_time
                 duration_s = round(duration, 3)
-                metric_params = {"method": "add_recipient", "status": status}
+                metric_params = {
+                    "method": "add_recipient",
+                    "status": status,
+                    "table": "main",
+                }
                 self.metric_service.inc_acoustic_request_total(**metric_params)
                 metric_params.update({"duration_s": duration_s})
                 self.metric_service.observe_acoustic_request_duration(**metric_params)

--- a/ctms/background_metrics.py
+++ b/ctms/background_metrics.py
@@ -79,20 +79,22 @@ class BackgroundMetricService:  # pylint: disable=too-many-instance-attributes
         self.pushgateway_url = pushgateway_url
         self.job_name = "prometheus-pushgateway"
 
-    def inc_acoustic_request_total(self, method, status):
+    def inc_acoustic_request_total(self, method, status, table):
         self.requests.labels(
             method=method,
             status=status,
+            table=table,
             app_kubernetes_io_component=self.app_kubernetes_io_component,
             app_kubernetes_io_instance=self.app_kubernetes_io_instance,
             app_kubernetes_io_name=self.app_kubernetes_io_name,
         ).inc()
         self.logger.debug("METRICS: Incrementing acoustic request")
 
-    def observe_acoustic_request_duration(self, method, status, duration_s):
+    def observe_acoustic_request_duration(self, method, status, table, duration_s):
         self.requests_duration.labels(
             method=method,
             status=status,
+            table=table,
             app_kubernetes_io_component=self.app_kubernetes_io_component,
             app_kubernetes_io_instance=self.app_kubernetes_io_instance,
             app_kubernetes_io_name=self.app_kubernetes_io_name,


### PR DESCRIPTION
Two calls need the parameter:

* ``inc_acoustic_request_total``
* ``observe_acoustic_request_duration``

These are already used by the relational database updater. The main contact table adds ``table="main"`` now as well.

Metrics in the background service are untested, and will be in the next PR.