### PR TITLE
Fix "changed" conversion, and test payload

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -340,7 +340,7 @@ class CTMSToAcousticService:
                     "product_name": product.product_name or "",
                     "product_id": product.product_id,
                     "segment": product.segment,
-                    "changed": product.changed,
+                    "changed": to_ts(product.changed),
                     "sub_count": product.sub_count,
                     "payment_service": product.payment_service,
                     "payment_type": product.payment_type or "",

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -142,6 +142,8 @@ def test_ctms_to_acoustic_with_subscription(
     acoustic_mock.insert_update_relational_table.assert_called_with(
         table_id=CTMS_ACOUSTIC_PRODUCT_TABLE_ID, rows=_product
     )
+    for name, value in _product[0].items():
+        assert isinstance(value, (str, int)), name
 
 
 def test_ctms_to_acoustic_with_subscription_and_metrics(


### PR DESCRIPTION
The Acoustic sync is failing when converting the payload to XML:

```
cannot serialize datetime.datetime(2021, 11, 11, 2, 38, 23, tzinfo=datetime.timezone.utc) (type datetime)
```

This is due to the ``changed`` column not being converted to the Acoustic timestamp format. Fix this, and add a test that all columns are string or integer types.