### PR TITLE
Convert all Acoustic values to strings

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -341,17 +341,19 @@ class CTMSToAcousticService:
                     "product_id": product.product_id,
                     "segment": product.segment,
                     "changed": to_ts(product.changed),
-                    "sub_count": product.sub_count,
+                    "sub_count": str(product.sub_count),
                     "payment_service": product.payment_service,
                     "payment_type": product.payment_type or "",
                     "card_brand": product.card_brand or "",
                     "card_last4": product.card_last4 or "",
                     "currency": product.currency or "",
-                    "amount": -1 if product.amount is None else product.amount,
+                    "amount": "-1" if product.amount is None else str(product.amount),
                     "billing_country": product.billing_country or "",
                     "status": product.status or "",
                     "interval_count": (
-                        -1 if product.interval_count is None else product.interval_count
+                        "-1"
+                        if product.interval_count is None
+                        else str(product.interval_count)
                     ),
                     "interval": product.interval or "",
                     "created": to_ts(product.created),

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -143,7 +143,7 @@ def test_ctms_to_acoustic_with_subscription(
         table_id=CTMS_ACOUSTIC_PRODUCT_TABLE_ID, rows=_product
     )
     for name, value in _product[0].items():
-        assert isinstance(value, (str, int)), name
+        assert isinstance(value, str), name
 
 
 def test_ctms_to_acoustic_with_subscription_and_metrics(


### PR DESCRIPTION
Integers also fail to convert to XML:

```
cannot serialize 1 (type int)
```

Convert all Acoustic values to strings, and test that they are all strings.