### PR TITLE
Fail heartbeat when Acoustic backlogs are over (optional) limits

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -1,4 +1,5 @@
 """The CTMS application, including middleware and routes."""
+# pylint:disable = too-many-lines
 import json
 import re
 import sys
@@ -839,6 +840,16 @@ def heartbeat(request: Request, db: Session, settings: config.Settings):
     status_code = 200
     if not data["database"]["up"]:
         status_code = 503
+    if "acoustic" in data["database"]:
+        backlog = data["database"]["acoustic"]["backlog"]
+        retry_backlog = data["database"]["acoustic"]["retry_backlog"]
+        max_backlog = data["database"]["acoustic"]["max_backlog"]
+        max_retry_backlog = data["database"]["acoustic"]["max_retry_backlog"]
+
+        if max_backlog is not None and max_backlog > backlog:
+            status_code = 503
+        if max_retry_backlog is not None and max_retry_backlog > retry_backlog:
+            status_code = 503
     return JSONResponse(content=data, status_code=status_code)
 
 

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -39,6 +39,8 @@ class Settings(BaseSettings):
     acoustic_batch_limit: int = 20
     acoustic_server_number: int = 6
     acoustic_loop_min_secs: int = 5
+    acoustic_max_backlog: Optional[int] = None
+    acoustic_max_retry_backlog: Optional[int] = None
 
     # Background settings, optional for API
     acoustic_client_id: Optional[str] = None

--- a/ctms/monitor.py
+++ b/ctms/monitor.py
@@ -42,7 +42,9 @@ def check_database(db_session, settings):
     status["acoustic"] = {
         "success": acoustic_success,
         "backlog": count,
+        "max_backlog": settings.acoustic_max_backlog,
         "retry_backlog": retry_count,
+        "max_retry_backlog": settings.acoustic_max_retry_backlog,
         "retry_limit": retry_limit,
         "batch_limit": settings.acoustic_batch_limit,
         "loop_min_sec": settings.acoustic_loop_min_secs,


### PR DESCRIPTION
Adjust settings so that Acoustic settings are readable by the API service. Settings like the Acoustic database IDs are optional for the API and required for the backend.

Add key Acoustic settings like the ``retry_limit`` to the ``__heartbeat__`` response.

Allow setting maximum backlog sizes, that will make ``__heartbeat__`` return 503 when exceeded:

* ``CTMS_ACOUSTIC_MAX_BACKLOG``
* ``CTMS_ACOUSTIC_MAX_RETRY_BACKLOG``

Both default to unset, meaning there is no maximum. 