### PR TITLE
Pass log level names to configure_logging

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -108,7 +108,7 @@ if "pytest" not in sys.argv[0]:  # pragma: no cover
 def startup_event():  # pragma: no cover
     global SessionLocal, METRICS  # pylint:disable = W0603
     settings = get_settings()
-    configure_logging(settings.use_mozlog, settings.logging_level)
+    configure_logging(settings.use_mozlog, settings.logging_level.name)
     _, SessionLocal = get_db_engine(get_settings())
     METRICS = init_metrics(METRICS_REGISTRY)
     init_metrics_labels(SessionLocal(), app, METRICS)

--- a/ctms/bin/acoustic_sync.py
+++ b/ctms/bin/acoustic_sync.py
@@ -16,7 +16,7 @@ LOGGER = None
 
 
 def _setup_logging(settings):
-    configure_logging(logging_level=settings.logging_level)
+    configure_logging(logging_level=settings.logging_level.name)
     return logging.getLogger(__name__)
 
 


### PR DESCRIPTION
The changes in PR #288 included refactoring ``logging_level`` to an enumeration. However, this passed the log level as (for example) "LogLevel.INFO" instead of "INFO". This keeps the enumeration but passes the previous string to ``configure_logging``.