### PR TITLE
Implement weak link to Stripe Customer, part 2 - Populate the FxA ID in code

### DIFF
--- a/ctms/ingest_stripe.py
+++ b/ctms/ingest_stripe.py
@@ -97,6 +97,7 @@ def ingest_stripe_customer(
         else:
             # Update existing customer
             customer.created = from_ts(data["created"])
+            customer.fxa_id = data["description"]
             customer.default_source_id = data["default_source"]
             _dpm = data["invoice_settings"]["default_payment_method"]
             customer.invoice_settings_default_payment_method_id = _dpm
@@ -135,6 +136,7 @@ def ingest_stripe_customer(
         stripe_id=customer_id,
         stripe_created=data["created"],
         email_id=email_id,
+        fxa_id=fxa_id,
         deleted=data.get("deleted", False),
         default_source_id=data["default_source"],
         invoice_settings_default_payment_method_id=_dpm,

--- a/ctms/schemas/stripe_customer.py
+++ b/ctms/schemas/stripe_customer.py
@@ -17,9 +17,8 @@ class StripeCustomerBase(ComparableBase):
     See https://stripe.com/docs/api/customers.
 
     Relations:
-    * A Customer (should have) exactly one FxA user. In Stripe, the
-      "description" field is used to store the FxA ID, and in this
-      database, it is related through the email_id.
+    * A Customer has 0 or 1 FxA users. In Stripe, the "description" field is
+      used to store the FxA ID.
     * A Customer has 0 or more Subscriptions
     * A Customer has 0 or 1 default Payment Methods
     * A Customer has 0 or 1 default Sources (Older API, can be viewed as
@@ -30,6 +29,7 @@ class StripeCustomerBase(ComparableBase):
     stripe_id: Optional[str]
     stripe_created: Optional[datetime]
     email_id: Optional[UUID4]
+    fxa_id: Optional[str]
     deleted: Optional[bool]
     default_source_id: Optional[str]
     invoice_settings_default_payment_method_id: Optional[str]
@@ -47,6 +47,10 @@ class StripeCustomerBase(ComparableBase):
             "email_id": {
                 "description": EMAIL_ID_DESCRIPTION,
                 "example": EMAIL_ID_EXAMPLE,
+            },
+            "fxa_id": {
+                "description": "The Firefox Account ID",
+                "example": "6eb6ed6ac3b64259968aa490c6c0b9df",  # pragma: allowlist secret
             },
             "deleted": {
                 "description": "Has the customer has been deleted in Stripe?",
@@ -71,6 +75,7 @@ class StripeCustomerCreateSchema(StripeCustomerBase):
     stripe_id: str
     stripe_created: datetime
     email_id: UUID4
+    fxa_id: str
     deleted: bool = False
 
 

--- a/tests/unit/sample_data.py
+++ b/tests/unit/sample_data.py
@@ -216,6 +216,7 @@ SAMPLE_STRIPE_DATA = {
         "stripe_id": FAKE_STRIPE_ID["Customer"],
         "stripe_created": datetime(2021, 10, 25, 15, 34, tzinfo=timezone.utc),
         "email_id": SAMPLE_EXAMPLE.email.email_id,
+        "fxa_id": SAMPLE_EXAMPLE.fxa.fxa_id,
         "default_source_id": None,
         "invoice_settings_default_payment_method_id": FAKE_STRIPE_ID["Payment Method"],
     },

--- a/tests/unit/test_ingest_stripe.py
+++ b/tests/unit/test_ingest_stripe.py
@@ -241,6 +241,7 @@ def test_ingest_existing_contact(dbsession, example_contact):
         == FAKE_STRIPE_ID["Payment Method"]
     )
     assert customer.email_id == example_contact.email.email_id
+    assert customer.fxa_id == example_contact.fxa.fxa_id
     assert customer.get_email_id() == example_contact.email.email_id
 
 


### PR DESCRIPTION
Populate both the ``email_id`` and ``fxa_id`` for Stripe Customers, supporting the current use of ``email_id`` to link to contacts (which may be created at the same time) as well as the future usage of ``fxa_id`` to link to contacts (which may not exist but will be created in the future).

This code continues to create new contacts, so issue #286 is still present. 

While this deploys, the existing code will continue running, but will leave ``fxa_id`` as ``null``. These will be handled by a data migration in part 3. See PR #290 for the full set of changes.