### PR TITLE
Implement weak link to Stripe Customer, part 4 - Drop stripe_customer.email_id

### DIFF
--- a/ctms/models.py
+++ b/ctms/models.py
@@ -268,10 +268,8 @@ class StripeBase(Base):
 class StripeCustomer(StripeBase):
     __tablename__ = "stripe_customer"
 
-    # TODO - remove column with migration
-    # email_id = Column(UUID(as_uuid=True), ForeignKey(Email.email_id), nullable=True)
     stripe_id = Column(String(255), nullable=False, primary_key=True)
-    fxa_id = Column(String(255), nullable=True, unique=True, index=True)
+    fxa_id = Column(String(255), nullable=False, unique=True, index=True)
     default_source_id = Column(String(255), nullable=True)
     invoice_settings_default_payment_method_id = Column(String(255), nullable=True)
 

--- a/migrations/versions/20211118_52382ae22fc8_delete_stripe_customer_fxa_id_is_null.py
+++ b/migrations/versions/20211118_52382ae22fc8_delete_stripe_customer_fxa_id_is_null.py
@@ -1,0 +1,28 @@
+"""Delete stripe_customer.fxa_id is NULL
+
+Revision ID: 52382ae22fc8
+Revises: ad4a8f10e344
+Create Date: 2021-11-18 23:42:11.649087
+
+"""
+# pylint: disable=no-member invalid-name
+# no-member is triggered by alembic.op, which has dynamically added functions
+# invalid-name is triggered by migration file names with a date prefix
+# invalid-name is triggered by top-level alembic constants like revision instead of REVISION
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "52382ae22fc8"  # pragma: allowlist secret
+down_revision = "ad4a8f10e344"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DELETE FROM stripe_customer WHERE stripe_customer.fxa_id IS NULL")
+
+
+def downgrade():
+    # Non-reversible migration
+    pass

--- a/migrations/versions/20211118_d1a16865b051_drop_stripe_customer_email_id.py
+++ b/migrations/versions/20211118_d1a16865b051_drop_stripe_customer_email_id.py
@@ -1,0 +1,51 @@
+"""Drop stripe_customer.email_id
+
+Revision ID: d1a16865b051
+Revises: 52382ae22fc8
+Create Date: 2021-11-18 23:44:58.435343
+
+"""
+# pylint: disable=no-member invalid-name
+# no-member is triggered by alembic.op, which has dynamically added functions
+# invalid-name is triggered by migration file names with a date prefix
+# invalid-name is triggered by top-level alembic constants like revision instead of REVISION
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "d1a16865b051"  # pragma: allowlist secret
+down_revision = "52382ae22fc8"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "stripe_customer",
+        "fxa_id",
+        existing_type=sa.VARCHAR(length=255),
+        nullable=False,
+    )
+    op.drop_constraint(
+        "stripe_customer_email_id_fkey", "stripe_customer", type_="foreignkey"
+    )
+    op.drop_column("stripe_customer", "email_id")
+
+
+def downgrade():
+    op.add_column(
+        "stripe_customer",
+        sa.Column("email_id", postgresql.UUID(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        "stripe_customer_email_id_fkey",
+        "stripe_customer",
+        "emails",
+        ["email_id"],
+        ["email_id"],
+    )
+    op.alter_column(
+        "stripe_customer", "fxa_id", existing_type=sa.VARCHAR(length=255), nullable=True
+    )


### PR DESCRIPTION
Also, make stripe_customer.fxa_id non-nullable.

During deployment, the existing code has stopped looking at ``.email_id``, so it should be OK with this change.

This is the last bit of PR #290, and finishes work for issue #286 (hopefully!).