### PR TITLE
Delete all but latest duplicate customers

### DIFF
--- a/migrations/versions/20211116_47c59393f5d8_empty.py
+++ b/migrations/versions/20211116_47c59393f5d8_empty.py
@@ -1,0 +1,25 @@
+"""(Empty Revision, moved to ad4a8f10e344)
+
+Revision ID: 47c59393f5d8
+Revises: 1ef38317ff85
+Create Date: 2021-11-16 23:39:28.095851
+
+"""
+# pylint: disable=no-member invalid-name
+# no-member is triggered by alembic.op, which has dynamically added functions
+# invalid-name is triggered by migration file names with a date prefix
+# invalid-name is triggered by top-level alembic constants like revision instead of REVISION
+
+# revision identifiers, used by Alembic.
+revision = "47c59393f5d8"  # pragma: allowlist secret
+down_revision = "1ef38317ff85"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/migrations/versions/20211118_4eed7a83e324_remove_duplicate_stripe_customers.py
+++ b/migrations/versions/20211118_4eed7a83e324_remove_duplicate_stripe_customers.py
@@ -1,0 +1,62 @@
+"""Remove duplicate Stripe Customers
+
+Revision ID: 4eed7a83e324
+Revises: 47c59393f5d8
+Create Date: 2021-11-18 22:14:33.853594
+
+"""
+# pylint: disable=no-member invalid-name
+# no-member is triggered by alembic.op, which has dynamically added functions
+# invalid-name is triggered by migration file names with a date prefix
+# invalid-name is triggered by top-level alembic constants like revision instead of REVISION
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4eed7a83e324"  # pragma: allowlist secret
+down_revision = "47c59393f5d8"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Find stripe_customers with the same email_id, order them by
+    stripe_created, and delete all but the most recent one.
+
+    One path for these duplicates are that a Stripe Customer
+    and related FxA account can be rapidly deleted if an invalid
+    payment is provided.
+    """
+
+    op.execute(
+        """
+    WITH duplicated AS (
+      SELECT email_id, count(*)
+      FROM stripe_customer
+      WHERE email_id IS NOT NULL
+      GROUP BY email_id
+      HAVING count(*) > 1),
+    ordered AS (
+      SELECT sc.email_id,
+        stripe_created,
+        rank() OVER (partition BY sc.email_id ORDER BY sc.stripe_created) as rnk
+      FROM stripe_customer sc
+      JOIN duplicated d on d.email_id = sc.email_id),
+    to_delete AS (
+      SELECT email_id, stripe_created
+      FROM ordered
+      WHERE rnk >= 2
+    )
+    DELETE
+    FROM stripe_customer
+    USING to_delete
+    WHERE stripe_customer.email_id = to_delete.email_id
+      AND stripe_customer.stripe_created = to_delete.stripe_created;
+    """
+    )
+
+
+def downgrade():
+    # Non-reversible migration
+    pass

--- a/migrations/versions/20211118_ad4a8f10e344_populate_stripe_customer_fxa_id.py
+++ b/migrations/versions/20211118_ad4a8f10e344_populate_stripe_customer_fxa_id.py
@@ -1,8 +1,8 @@
-"""Populate stripe_customer.fxa_id
+"""Populate stripe_customer.fxa_id (was 47c59393f5d8)
 
-Revision ID: 47c59393f5d8
-Revises: 1ef38317ff85
-Create Date: 2021-11-16 23:39:28.095851
+Revision ID: ad4a8f10e344
+Revises: 4eed7a83e324
+Create Date: 2021-11-18 22:20:37.154955
 
 """
 # pylint: disable=no-member invalid-name
@@ -13,8 +13,8 @@ Create Date: 2021-11-16 23:39:28.095851
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "47c59393f5d8"  # pragma: allowlist secret
-down_revision = "1ef38317ff85"  # pragma: allowlist secret
+revision = "ad4a8f10e344"  # pragma: allowlist secret
+down_revision = "4eed7a83e324"  # pragma: allowlist secret
 branch_labels = None
 depends_on = None
 
@@ -26,6 +26,7 @@ def upgrade():
     SET fxa_id=(
        SELECT fxa_id FROM fxa WHERE fxa.email_id=stripe_customer.email_id
     )
+    WHERE email_id IS NOT NULL
     """
     )
     op.execute("UPDATE stripe_customer SET email_id=NULL")
@@ -38,6 +39,7 @@ def downgrade():
     SET email_id=(
        SELECT email_id FROM fxa WHERE fxa.fxa_id=stripe_customer.fxa_id
     )
+    WHERE FXA_ID IS NOT NULL
     """
     )
     op.execute("UPDATE stripe_customer SET fxa_id=NULL")


### PR DESCRIPTION
Turn the failing migration ``47c59393f5d8`` into an empty migration, and then add two migrations.

The first looks for ``stripe_customer``s with duplicate ``email_id``s, ranks them by Stripe creation time, and deletes all but the most recent one.

The second is the same as the failed migration, but avoids nulled columns. This may not be necessary.