### PR TITLE
Set `price_id` in Acoustic relational table, and test the row format

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -339,6 +339,7 @@ class CTMSToAcousticService:
                 {
                     "product_name": product.product_name or "",
                     "product_id": product.product_id,
+                    "price_id": product.price_id,
                     "segment": product.segment.value,
                     "changed": to_ts(product.changed),
                     "sub_count": str(product.sub_count),

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -178,6 +178,7 @@ def test_ctms_to_acoustic_with_subscription_and_metrics(
         "interval_count": "1",
         "payment_service": "stripe",
         "payment_type": "",
+        "price_id": "price_cHJpY2U",
         "product_id": "prod_cHJvZHVjdA",
         "product_name": "",
         "segment": "active",


### PR DESCRIPTION
In stage Acoustic, product subscription created via Acoustic sync did not have the `price_id` column set. This is desired to target a particular plan, such as VPN Monthly versus VPN Yearly subscriptions.

Add a test that checks the row format of the product relational table. The data is static between test runs, and alphabetized to make it easy to cross-check against the table display in Acoustic, and making it easier to check if there are missing columns (there was just `price_id`)

Add some typing to set the row as a dictionary of strings to strings, and specifically convert the enumerations to their string values.

Finally, populate the `price_id` and adjust the test.