### PR TITLE
Minor log context added for email ids

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -1013,6 +1013,7 @@ def stripe_pubsub(
             if trace_email:
                 trace = trace_email
 
+    request.state.log_context["email_ids"] = email_ids
     if email_ids:
         for email_id in email_ids:
             schedule_acoustic_record(db_session, email_id)


### PR DESCRIPTION
_Not sure if adding this to the log context would be helpful to determine we're getting the right id's scheduled._