### PR TITLE
Add healthcheck file and script for sync service

### DIFF
--- a/ctms/bin/healthcheck_sync.py
+++ b/ctms/bin/healthcheck_sync.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Check that the healthcheck file updated by acoustic_sync.py was updated recently."""
+import sys
+
+import structlog
+
+from ctms import config
+from ctms.log import configure_logging
+from ctms.sync import check_healthcheck
+
+
+def main(settings):
+    """
+    Check the timestamp in the healthcheck file.
+
+    This is written by ctms/bin/acoustic_sync.py
+    Return is the exit code, 0 for success, 1 for failure
+    """
+    logger = structlog.get_logger("ctms.bin.acoustic_sync")
+    healthcheck_path = settings.background_healthcheck_path
+    healthcheck_age_s = settings.background_healthcheck_age_s
+
+    try:
+        age = check_healthcheck(healthcheck_path, healthcheck_age_s)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Healthcheck failed")
+        return 1
+    logger.debug("Healthcheck passed", age=age)
+    return 0
+
+
+if __name__ == "__main__":
+    config_settings = config.BackgroundSettings()
+    configure_logging(logging_level=config_settings.logging_level.name)
+    sys.exit(main(config_settings))

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -54,6 +54,8 @@ class Settings(BaseSettings):
     acoustic_newsletter_table_id: Optional[int] = None
     acoustic_product_subscriptions_id: Optional[int] = None
     prometheus_pushgateway_url: Optional[str] = None
+    background_healthcheck_path: Optional[str] = None
+    background_healthcheck_age_s: Optional[int] = None
 
     class Config:
         env_prefix = "ctms_"

--- a/tests/unit/test_bin_healthcheck_sync.py
+++ b/tests/unit/test_bin_healthcheck_sync.py
@@ -1,0 +1,49 @@
+"""Check ctms/bin/healthcheck_sync.py"""
+
+from datetime import datetime, timedelta, timezone
+
+from structlog.testing import capture_logs
+
+from ctms.bin.healthcheck_sync import main
+from ctms.config import Settings
+from ctms.sync import update_healthcheck
+
+
+def test_main_recent_update(tmp_path):
+    """healthcheck_sync succeeds on recent update."""
+    health_path = tmp_path / "healthcheck"
+    update_healthcheck(health_path)
+    settings = Settings(
+        background_healthcheck_path=str(health_path),
+        background_healthcheck_age_s=30,
+    )
+    with capture_logs() as caplogs:
+        exit_code = main(settings)
+    assert exit_code == 0
+    assert len(caplogs) == 1
+    log = caplogs[0]
+    assert log["event"] == "Healthcheck passed"
+    assert log["age"] < 0.1
+
+
+def test_main_old_update(tmp_path):
+    """healthcheck_sync fails on old update."""
+    health_path = tmp_path / "healthcheck"
+    old_date = datetime.now(tz=timezone.utc) - timedelta(seconds=120)
+    old_date_iso = old_date.isoformat()
+    with open(health_path, "w", encoding="utf8") as health_file:
+        health_file.write(old_date_iso)
+    settings = Settings(
+        background_healthcheck_path=str(health_file),
+        background_healthcheck_age_s=30,
+    )
+    with capture_logs() as caplogs:
+        exit_code = main(settings)
+    assert exit_code == 1
+    assert len(caplogs) == 1
+    log = caplogs[0]
+    assert log == {
+        "event": "Healthcheck failed",
+        "exc_info": True,
+        "log_level": "error",
+    }


### PR DESCRIPTION
Support two optional environment variables:

* ``BACKGROUND_HEALTHCHECK_PATH`` - path to a healthcheck file, like ``"/tmp/sync_timestamp"``
* ``BACKGROUND_HEALTHCHECK_AGE_S`` - maximum age in seconds, like ``60``

If the path is configured, the ``acoustic_sync.py`` script will write the current time in Python's ISO 8601 format.

The new ``healthcheck_sync.py`` script will read this file and check how long ago the timestamp was written. If it is recent enough, it exits with code 0. If anything goes wrong, it logs an exception and exits with code 1.

This is designed to work as a "liveness" check for Kubernetes, see [docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).