### PR TITLE
Add a timeout (default 5s) to Acoustic requests

### DIFF
--- a/ctms/bin/acoustic_sync.py
+++ b/ctms/bin/acoustic_sync.py
@@ -38,6 +38,7 @@ def main(db, settings):
         batch_limit=settings.acoustic_batch_limit,
         is_acoustic_enabled=settings.acoustic_integration_feature_flag,
         metric_service=metric_service,
+        acoustic_timeout=settings.acoustic_timeout_s,
     )
     prev = monotonic()
     while settings.acoustic_sync_feature_flag:

--- a/ctms/config.py
+++ b/ctms/config.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
     prometheus_pushgateway_url: Optional[str] = None
     background_healthcheck_path: Optional[str] = None
     background_healthcheck_age_s: Optional[int] = None
+    acoustic_timeout_s: float = 5.0
 
     class Config:
         env_prefix = "ctms_"

--- a/ctms/sync.py
+++ b/ctms/sync.py
@@ -31,12 +31,14 @@ class CTMSToAcousticSync:
         batch_limit=20,
         is_acoustic_enabled=True,
         metric_service: BackgroundMetricService = None,
+        acoustic_timeout=5.0,
     ):
         acoustic_client = Acoustic(
             client_id=client_id,
             client_secret=client_secret,
             refresh_token=refresh_token,
             server_number=server_number,
+            timeout=acoustic_timeout,
         )
         self.ctms_to_acoustic = CTMSToAcousticService(
             acoustic_client=acoustic_client,

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -24,6 +24,7 @@ def acoustic_client():
             client_secret=ctms_acoustic_client_secret,
             refresh_token=ctms_acoustic_refresh_token,
             server_number=6,
+            timeout=1.0,
         )
 
 


### PR DESCRIPTION
This adds a timeout (default 5s) to the ``POST`` to the Acoustic API. Never-completing API calls may have been a cause of the background task getting stuck in the past.  With this change, when a request takes longer than 5 seconds, a `Timeout` exception is logged and the contact is retried. To change the timeout, ``CTMS_BACKGROUND_ACOUSTIC_TIMEOUT_S`` can be set to the new timeout.

Looking at server metrics, in production 98% of 1.4 million requests complete in 0.5s, and 99.9986% complete in 5.0s, with 19 requests taking longer. Stage has been running for a shorter period without a metrics reset. In 400 requests, 63% complete in 0.5s, and 99.5% in 5.0s, with 2 requests taking longer. 



