### PR TITLE
If 'other' reset segment-prefix to blank

### DIFF
--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -760,6 +760,7 @@ def get_stripe_products(email: Email) -> List[ProductBaseSchema]:
             segment = "canceled"
             changed = latest["ended_at"]
         else:
+            segment_prefix = ""
             segment = "other"
             changed = latest["created"]
 


### PR DESCRIPTION
Whenever we receive a `segment` that results in "other" reset the `segment_prefix` to ""