### PR TITLE
Rewrite and expand the deployment docs, etc.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "(poetry.lock$)|(htmlcov/)",
     "lines": null
   },
-  "generated_at": "2021-12-01T20:29:44Z",
+  "generated_at": "2021-12-07T21:46:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,13 +77,13 @@
       {
         "hashed_secret": "457130ffb195a6fc7693cc447d1d03c8e0ef28d6",
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 208,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "5089246737bcae6ebd14c2548a8360bc548cf0db",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 278,
         "type": "Secret Keyword"
       }
     ]

--- a/ctms/sync.py
+++ b/ctms/sync.py
@@ -116,7 +116,7 @@ class CTMSToAcousticSync:
             context["sync_backlog"] = all_acoustic_records_count
             self.metric_service.gauge_acoustic_sync_backlog(all_acoustic_records_count)
             all_retry_records_count: int = get_all_acoustic_retries_count(db=db)
-            context["retry_backlog"] = all_acoustic_records_count
+            context["retry_backlog"] = all_retry_records_count
             self.metric_service.gauge_acoustic_retry_backlog(all_retry_records_count)
         # Get all Records before current time
         all_acoustic_records_before_now: List[

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -8,22 +8,39 @@
 
 ## Deployment
 
-We use a variety of technologies to get this code into production.  Starting from this repo and going outwards:
+We use a variety of technologies to get this code into production.  Starting
+from this repo and going outwards:
 
-1. github actions builds and deploys a docker container to ecr
-    1. prs and pushes to this repo will build and push a 'short-sha' container to AWS' ECR. The build details are written to ``/app/version.json``.
-    1. Code merged to main will trigger a build that prefixes the short sha with literal 'stg-'
-    1. Code pushed to a tag with the form v{semver} (for example, v0.0.1) will get published with that tag to ecr
-    1. Code released with a good version tag should get released to prod (this is to be determined, does not work, but is plan of record)
-1. A helm release is configured in ctms-infra
-    1. https://github.com/mozilla-it/ctms-infra/tree/main/k8s
-    1. We can trigger a release by updating the correct files there (For helm chart or helm chart value changes)
-    1. by default we will also configure new images in the ECR to trigger a build
-      1. the images tagged with stg- are configured to deploy to the staging cluster
-      1. the images with v{semver} will automatically be deployed to prod
-1. The eks clusters in the ess account are configured with fluxcd/helm operator to watch those helm release files
-1. terraform defines the eks clusters, and any databases we may require (https://github.com/mozilla-it/ctms-infra/tree/main/terraform)
+1. [GitHub Actions](https://github.com/mozilla-it/ctms-api/actions) builds and
+   deploys a docker image to [AWS's Elastic Container Registry](https://aws.amazon.com/ecr/) (ECR)
+    1. Pull requests and pushes to this repo will build and push a "short-sha"
+       image to AWS' ECR. The build details are written to
+       ``/app/version.json``.
+    1. Code merged to main will trigger a build that prefixes the "short sha"
+       with literal ``stg-``.
+    1. Code pushed to a tag with the form ``v{semver}`` (for example,
+       ``v0.0.1``) will get published with that tag to ECR.
+1. The helm configuration, which describes the CTMS cluster, is in the repo
+   [mozilla-it/helm-charts](https://github.com/mozilla-it/helm-charts/tree/main/charts/ctms).
+1. A helm release is configured in
+   [mozilla-it/ctms-infra](https://github.com/mozilla-it/ctms-infra/tree/main/k8s) (*private*).
+   We can trigger a release by updating the correct files there (for helm chart
+   or helm chart value changes).
+1. The [Amazon Elastic Kubernetes Service](https://aws.amazon.com/eks/) (EKS)
+   clusters are configured with a
+   [fluxcd](https://www.weave.works/oss/flux/)/helm operator to deploy on releases.
+   1. CTMS-API images tagged with ``stg-`` automatically deploy to the
+      staging cluster.
+   1. CTMS-API images tagged with ``v{semver}`` automatically deploy to prod
+   1. Helm chart tags are deployed to both
+   1. Flux-triggered releases appear as commits in ``mozilla-it/ctms-infra``.
+1. [Terraform](https://www.terraform.io/) defines the EKS clusters, and any
+   databases we may require. The
+   [Terraform files](https://github.com/mozilla-it/ctms-infra/tree/main/terraform)
+   are in the `mozilla-it/ctms-infra` private repo as well.
 
+More information about CTMS operations is available on the
+[ESS-CTMS Mana page](https://mana.mozilla.org/wiki/x/KIyXC) (*private*).
 
 ## Logging
 

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -309,7 +309,7 @@ CTMS metrics are presented on two dashboards:
 
 * [CTMS - dashboard](https://earthangel-b40313e5.influxcloud.net/d/UFbHzGCMz/ctms-dashboard?orgId=1):
   Operational metrics for production and staging.
-* [CTMS Alerts](https://earthangel-b40313e5.influxcloud.net/d/UFbHzGCMz/ctms-dashboard?orgId=1):
+* [CTMS Alerts](https://earthangel-b40313e5.influxcloud.net/d/UqluYyc7k/ctms-alerts?orgId=1):
   Operational metrics with triggers to alert on-call staff.
 
 ## Docker

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -46,51 +46,42 @@ More information about CTMS operations is available on the
 
 When the environment variable ``CTMS_USE_MOZLOG`` is set to true or unset, then
 the [MozLog JSON format](https://wiki.mozilla.org/Firefox/Services/Logging) is
-used for logging.
+used for logging. Logs are aggregated to [Papertrail](https://www.papertrail.com/),
+and are useful for debugging issues with deployments.
 
 ### Example
 
-Here's what a single log line from development looks like, formatted as
-multi-line JSON for clarity:
+Here's what a single log line may looks like, formatted as multi-line JSON for
+clarity:
 
 ```json
 {
-  "Timestamp": 1618616777743526400,
-  "Type": "uvicorn.access",
+  "Timestamp": 1638907127116059400,
+  "Type": "ctms.web",
   "Logger": "ctms",
-  "Hostname": "a-random-docker-hostname",
+  "Hostname": "ctms-web-1234abcd56-asdfg",
   "EnvVersion": "2.0",
   "Severity": 6,
-  "Pid": 207,
+  "Pid": 10,
   "Fields": {
-    "status_code": 200,
-    "type": "http",
-    "http_version": "1.1",
-    "scheme": "http",
-    "method": "GET",
-    "root_path": "",
+    "client_host": "172.16.255.255",
+    "method": "POST",
     "path": "/ctms",
-    "raw_path": "/ctms",
-    "query": {
-        "primary_email": "[OMITTED]",
-    },
+    "path_template": "/ctms",
     "headers": {
-      "host": "localhost:8000",
+      "host": "ctms.prod.mozilla-ess.mozit.cloud",
+      "content-length": "522",
+      "user-agent": "python-requests/2.25.1",
       "accept-encoding": "gzip, deflate",
-      "cookie": "[OMITTED]",
-      "connection": "keep-alive",
-      "accept": "application/json",
-      "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15",
+      "accept": "*/*",
       "authorization": "[OMITTED]",
-      "referer": "http://localhost:8000/docs",
-      "accept-language": "en-us"
+      "content-type": "application/json"
     },
     "client_allowed": true,
-    "client_id": "id_test",
-    "duration_s": 0.102,
-    "endpoint": "read_ctms_by_any_id",
-    "path_params": {},
-    "msg": "172.19.0.1:57428 - \"GET /ctms?primary_email=test%40example.com HTTP/1.1\" 200"
+    "client_id": "id_ctms-key",
+    "status_code": 201,
+    "duration_s": 0.063,
+    "msg": "172.16.255.255:54321 id_ctms-key 'POST /ctms HTTP/1.1' 201"
   }
 }
 ```
@@ -98,50 +89,122 @@ multi-line JSON for clarity:
 ### Logging Fields
 The MozLog format allows for per-application data in the ``Fields`` parameter.
 
-Several fields are injected by [uvicorn](https://www.uvicorn.org), the ASGI
-server.
-
-Some of these, such as `raw_path` and the headers, are originally
-bytestrings, but the logger attempts to decode them as ASCII to unicode strings,
-and falls back to ``repr()`` to convert to a string, such as ``"b'byte string'"``.
-
 Some headers contain security sensitive information, such as client credentials and
 access token. These values are replaced by ``[OMITTED]``. Similar replacement
-removes emails from the querystring (when parsed).
+removes emails from the query string (when parsed).
 
-The fields added by uvicorn are:
+If tracing by email is desired, a tester can trace their activity in the system
+by adding the text ``+trace_me_mozilla_`` to their email, such as
+``test+trace_me_mozilla_20211207@example.com``. This works with the
+[plus-sign trick](https://gmail.googleblog.com/2008/03/2-hidden-ways-to-get-more-from-your.html)
+in Gmail and other email providers to create a unique email address.
+This causes the email to appear in logs, along with further request context
+for some endpoints.
 
-* ``headers`` - Dictionary of header names (lowercased) to header values
-* ``http_version`` - HTTP version, such as "1.0" or "1.1"
-* ``method`` - HTTP method, such as "GET" or "POST"
-* ``msg`` - A request summary suitable for humans
-* ``path`` - Path portion of URL, such as "/ctms"
-* ``query_string`` - Querystring portion of URL, if not decoded and parse
-* ``query`` - Query parameters, if decoded and parsed
-* ``scheme`` - Scheme, such as "http" or "https"
-* ``status_code`` - HTTP status code as integer, such as 200 or 404
-* ``type`` - Type of request, such as "http"
+### API Logging Fields
 
-Others are added by FastAPI:
-
-* ``endpoint`` - The name of the function handling the endpoint
-* ``path_params`` - A dictionary of parameters such as ``email_id`` extracted from
-  the path
-
-CTMS adds fields for some requests:
+Requests to the API are logged with Type `ctms.web`. Most are logged at
+``INFO`` level (``"Severity": 6``). Application errors (the request and the
+traceback) are logged at ``ERROR`` level (Severity 3). Some of the fields are:
 
 * ``auth_fail``: The reason authentication failed for an endpoint requiring an
   OAuth2 access token
 * ``client_allowed``: ``true`` if API credentials were accepted for an endpoint
   requiring credentials, ``false`` if rejected
-* ``client_id``: Name of the API client, such as "id_test"
-* ``duration_s``: How long the request took in seconds, rounded to the millisecond
-* ``token_cred_from``: For ``/token``, if the credentials were read from the
+* ``client_host`` - The internal IP of the ingress NGINX server. See the
+  headers, such as `x-forwarded-for`, for the client's IP address.
+* ``client_id``: Name of the API client, such as ``"id_test"``
+* ``duration_s``: How long the request took in seconds, rounded to the
+  millisecond
+* ``headers`` - Dictionary of header names (lower-cased) to header values
+* ``method`` - HTTP method, such as `"GET"`, `"POST"`, or `"PATCH"`.
+* ``msg`` - A summary line for the request, modelled after the uvicorn log
+  message format.
+* ``path_params`` - A dictionary of URL parameters, if the endpoint is
+  parametrized.
+* ``path_template`` - A standardized path, such as `"/ctms/{email_id}"`, to
+  identify endpoints that take URL parameters.
+* ``path`` - Path portion of URL, such as `"/ctms"`.
+* ``pubsub_*``: Values parsed from the Javascript Web Token (JWT) claim set for
+  ``POST``s to ``/stripe_from_pubsub`` from a Google Pub/Sub push subscription.
+* ``status_code``: The returned HTTP status code
+* ``token_creds_from``: For ``/token``, if the credentials were read from the
   ``Authentication`` header ("header") or from the form-encoded body ("form")
 * ``token_fail``: For ``/token``, why the token request failed
+* ``trace_json``: The request payload if tracing via the email address is
+  requested.
+* ``trace``: An email matching the trace pattern, such as
+  ``test+trace_me_mozilla_2021@example.com``
+* ``trivial``: `true` if a request is a monitoring request, such as
+  ``GET /__lbheartbeat__``. These can be excluded to focus on the "non-trivial"
+  requests.
+
+### Acoustic Sync Process Logging Fields
+
+The Acoustic Sync Process is a long-running process that processes a batch of
+contacts from a queue in the database, and then sleeps for a bit if it detects
+the queue was fully processed. The queue is populated by requests to the API
+that update contacts.
+
+On process start, a log message at ``INFO`` level (Severity 6) is emitted, with
+type ``"ctms.bin.acoustic_sync"`` and these fields:
+
+* ``sync_feature_flag``: ``true`` if syncing is enabled. If ``false``, the
+  database will be cleared without sending to Acoustic.
+* ``msg``: The message ``"Setting up sync_service."``
+
+One per batch, a log message at ``INFO`` level (Severity 6) is emitted, with
+type ``"ctms.bin.acoustic_sync"`` and these fields:
+
+* ``batch_limit``: The current batch size.
+* ``count_exception``: The number of contacts failed due to an exception (omitted if 0).
+* ``count_retry``: The number of contacts queued to retry (omitted if 0).
+* ``count_skipped``: The number of contacts skipped due to ``sync_feature_flag==false`` (omitted if 0).
+* ``count_synced``: The number of contacts successfully synced (omitted if 0).
+* ``count_total``: The number of contacts processed.
+* ``end_time``: A time stamp for the latest contact update time to sync, or ``"now"`` to get the latest.
+* ``loop_duration_s``: The time to sync records, in seconds rounded to milliseconds.
+* ``loop_sleep_s``: The planned time to sleep, in seconds rounded to milliseconds.
+* ``msg``: The message ``"sync_service cycle complete"``
+* ``retry_backlog``: The number of contacts in the retry backlog, including those past the ``retry_limit``.
+* ``retry_limit``: The number of times to retry syncing a contact before giving up.
+* ``sync_backlog``: The number of contacts in the backlog before syncing.
+* ``trivial``: ``true`` if no contacts processed, omitted if some processed.
+
+For each contact, a log message at ``DEBUG`` level (Severity 7) is emitted, or
+at ``ERROR`` level (Severity 3) on exceptions, with type
+``"ctms.acoustic_service"`` and these fields:
+
+* ``email_id``: The email_id of the contact
+* ``exception``: The traceback, if an exception was raised, or omitted on
+  success.
+* ``fxa_created_date_converted``: ``"success"`` if the FxA creation date was
+  parsed as a ``datetime``, ``"failure"`` if not, and ``"skipped"`` if not a
+  string.
+* ``fxa_created_date_type``: The type of the FxA creation date if not a string.
+* ``main_duration_s``: The time to sync to the main contact table, in seconds
+  rounded to the millisecond.
+* ``main_status``: ``"success"`` if sync to main contact table succeeded, or
+  ``"failure"``.
+* ``newsletter_count``: The number of newsletter subscriptions synced.
+* ``newsletter_duration_s``: The time to sync to the newsletter relational
+  table, in seconds rounded to the millisecond.
+* ``newsletter_status``: ``"success"`` if sync to the newsletter relational
+  table succeeded, or ``"failure"``.
+* ``newsletters_skipped``: A list of newsletter slugs not synced to Acoustic.
+* ``product_count``: The number of product subscriptions synced.
+* ``product_duration_s``: The time to sync to the product relational table, in
+  seconds rounded to the millisecond (omitted if no products synced).
+* ``product_status``: ``"success"`` if sync to the product relational table
+  succeeded, or ``"failure"`` (omitted if no products synced).
+* ``skipped_fields``: A list of unexpected contact fields not synced to
+  Acoustic.
+* ``success``: ``true`` if successfully synced, ``false`` if not
+* ``trace``: The email, if the contact email has the ``+trace_me_mozilla_``
+  pattern.
 
 ## Docker
-View about docker in the [developer_setup](developer_setup.md) guide.
+See the [developer_setup_guide](developer_setup.md#docker) for more information about Docker.
 
 ---
 [View All Docs](./)

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -66,6 +66,35 @@ Add new dependencies in pyproject.toml through poetry:
 poetry add {pypi-package}
 ```
 
+### Updating Dependencies
+To update a dependency to the latest version:
+
+```sh
+poetry add {pypi-package}@latest
+```
+
+This can also be used to update via constraint:
+
+```sh
+poetry add {pypi-package}@^2.1.0
+poetry add {pypi-package}>=2.0.0,<3.0.0
+```
+
+Using ``poetry add`` will also update ``pyproject.toml``, which is easier for a
+human to parse than ``poetry.lock``.
+
+To update all dependencies in ``poetry.lock``, but not ``pyproject.toml``:
+
+```sh
+poetry update
+```
+
+To update a single dependency in ``poetry.lock``:
+
+```sh
+poetry update {pypi-package}
+```
+
 ### Exiting Poetry Shell
 
 Run the following command to exit `poetry shell` while in a shell.

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -92,7 +92,7 @@ def test_sync_acoustic_record_retry_path(dbsession, sync_obj, maximal_contact):
 
     # Metrics adds two DB queries (total records and retries)
     assert watcher.count == 6
-    expected_context["retry_backlog"] = 1
+    expected_context["retry_backlog"] = 0
     expected_context["sync_backlog"] = 1
     assert context == expected_context
 
@@ -141,7 +141,7 @@ def test_sync_acoustic_record_delete_path(
 
     # Metrics adds two DB queries (total records and retries)
     assert watcher.count == 6
-    expected_context["retry_backlog"] = 1
+    expected_context["retry_backlog"] = 0
     expected_context["sync_backlog"] = 1
     assert context == expected_context
 


### PR DESCRIPTION
I added a section to the development docs for updating dependencies, which took me too long to figure out.
 
The deployment docs now have these sections:

* Overview - deployment URLs and notable paths
* Deployment - updated with some of the details of automated deployments
* Logging - refreshed with current API logging and the 1.1.x background process logging
  * Example - Recreated from production
  * Logging Fields - Overview of structured logging format
  * API Logging Fields - The fields that can appear in API request logs
  * Acoustic Sync Process Logging Fields - The log types and fields from the background process
 * Metrics - new section for emitted metrics
   * API metrics
   * Acoustic Sync Service Metrics
 * Dashboards - new, links to Graphana
 
When writing the logging documentation, I noticed that the ``retry_backlog`` was the same as the ``sync_backlog``. This PR fixes that bug.
 
    