### PR TITLE
Update stripe objects more carefully

### DIFF
--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -682,14 +682,14 @@ def _get_stripe(
     """
     Get a Stripe object by its ID, or None if not found.
 
-    If for_update is True (default False), the row will be locked for update and
-    the identity_map will be refreshed.
+    If for_update is True (default False), the row will be locked for update.
     """
     query = db_session.query(model)
     if for_update:
-        query = query.populate_existing().with_for_update()
-
-    return cast(Optional[StripeModel], query.get(stripe_id))
+        query = query.with_for_update()
+    return cast(
+        Optional[StripeModel], query.filter(model.stripe_id == stripe_id).one_or_none()
+    )
 
 
 get_stripe_customer_by_stripe_id = partial(_get_stripe, StripeCustomer)

--- a/tests/unit/test_ingest_stripe.py
+++ b/tests/unit/test_ingest_stripe.py
@@ -41,6 +41,7 @@ from ctms.schemas import (
     StripeSubscriptionItemCreateSchema,
 )
 from tests.unit.sample_data import FAKE_STRIPE_ID, SAMPLE_STRIPE_DATA, fake_stripe_id
+from tests.unit.test_crud import StatementWatcher
 
 
 def unix_timestamp(the_time: Optional[datetime] = None) -> int:
@@ -226,9 +227,17 @@ def test_ingest_existing_contact(dbsession, example_contact):
     data = stripe_customer_data()
     data["description"] = example_contact.fxa.fxa_id
     data["email"] = example_contact.fxa.primary_email
-    customer = ingest_stripe_customer(dbsession, data)
-    dbsession.commit()
-    dbsession.refresh(customer)
+
+    with StatementWatcher(dbsession.connection()) as watcher:
+        customer = ingest_stripe_customer(dbsession, data)
+        dbsession.commit()
+    assert watcher.count == 2
+    stmt1 = watcher.statements[0][0]
+    assert stmt1.startswith("SELECT stripe_customer."), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    stmt2 = watcher.statements[1][0]
+    assert stmt2.startswith("INSERT INTO stripe_customer "), stmt2
+
     assert customer.stripe_id == FAKE_STRIPE_ID["Customer"]
     assert not customer.deleted
     assert customer.default_source_id is None
@@ -268,9 +277,16 @@ def test_ingest_update_customer(dbsession, stripe_customer):
     data["default_source"] = new_source_id
     data["invoice_settings"]["default_payment_method"] = None
 
-    customer = ingest_stripe_customer(dbsession, data)
-    dbsession.commit()
-    dbsession.refresh(customer)
+    with StatementWatcher(dbsession.connection()) as watcher:
+        customer = ingest_stripe_customer(dbsession, data)
+        dbsession.commit()
+    assert watcher.count == 2
+    stmt1 = watcher.statements[0][0]
+    assert stmt1.startswith("SELECT stripe_customer."), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    stmt2 = watcher.statements[1][0]
+    assert stmt2.startswith("UPDATE stripe_customer SET "), stmt2
+
     assert customer.default_source_id == new_source_id
     assert customer.invoice_settings_default_payment_method_id is None
 
@@ -301,9 +317,23 @@ def test_ingest_existing_but_deleted_customer(
 def test_ingest_new_subscription(dbsession):
     """A new Stripe Subscription is ingested."""
     data = stripe_subscription_data()
-    subscription = ingest_stripe_subscription(dbsession, data)
-    dbsession.commit()
-    dbsession.refresh(subscription)
+
+    with StatementWatcher(dbsession.connection()) as watcher:
+        subscription = ingest_stripe_subscription(dbsession, data)
+        dbsession.commit()
+    assert watcher.count == 6
+    stmt1, stmt2, stmt3, stmt4, stmt5, stmt6 = [pair[0] for pair in watcher.statements]
+    assert stmt1.startswith("SELECT stripe_subscription."), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    assert stmt2.startswith("SELECT stripe_price."), stmt2
+    assert stmt2.endswith(" FOR UPDATE"), stmt2
+    assert stmt3.startswith("SELECT stripe_subscription_item."), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
+    # Insert order could be swapped
+    assert stmt4.startswith("INSERT INTO stripe_"), stmt4
+    assert stmt5.startswith("INSERT INTO stripe_"), stmt5
+    assert stmt6.startswith("INSERT INTO stripe_"), stmt6
+
     assert subscription.stripe_id == FAKE_STRIPE_ID["Subscription"]
     assert subscription.stripe_created == datetime(2021, 9, 27, tzinfo=timezone.utc)
     assert subscription.stripe_customer_id == FAKE_STRIPE_ID["Customer"]
@@ -370,9 +400,33 @@ def test_ingest_update_subscription(dbsession, stripe_subscription):
     }
     data["default_payment_method"] = fake_stripe_id("pm", "my new credit card")
 
-    subscription = ingest_stripe_subscription(dbsession, data)
-    dbsession.commit()
-    dbsession.refresh(subscription)
+    with StatementWatcher(dbsession.connection()) as watcher:
+        subscription = ingest_stripe_subscription(dbsession, data)
+        dbsession.commit()
+    assert watcher.count == 8
+    stmt1, stmt2, stmt3, stmt4, stmt5, stmt6, stmt7, stmt8 = [
+        pair[0] for pair in watcher.statements
+    ]
+    assert stmt1.startswith("SELECT stripe_subscription."), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # Get all IDs
+    assert stmt2.startswith("SELECT stripe_subscription_item.stripe_id "), stmt2
+    assert stmt2.endswith(" FOR UPDATE"), stmt2
+    # Load item 1
+    # Can't eager load items with FOR UPDATE, need to query twice
+    assert stmt3.startswith("SELECT stripe_price."), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
+    assert stmt4.startswith("SELECT stripe_subscription_item."), stmt4
+    assert stmt4.endswith(" FOR UPDATE"), stmt4
+    # Delete old item
+    assert stmt5.startswith("DELETE FROM stripe_subscription_item "), stmt5
+    # Insert order could be swapped
+    insert = "INSERT INTO stripe_"
+    update = "UPDATE stripe_subscription SET "
+    assert stmt6.startswith(insert) or stmt6.startswith(update), stmt6
+    assert stmt7.startswith(insert) or stmt7.startswith(update), stmt7
+    assert stmt8.startswith(insert) or stmt8.startswith(update), stmt8
+
     assert subscription.current_period_end == current_period_end
     assert subscription.default_payment_method_id == data["default_payment_method"]
 
@@ -462,8 +516,23 @@ def test_ingest_non_recurring_price(dbsession):
 def test_ingest_new_invoice(dbsession):
     """A new Stripe Invoice is ingested."""
     data = stripe_invoice_data()
-    invoice = ingest_stripe_invoice(dbsession, data)
-    dbsession.commit()
+
+    with StatementWatcher(dbsession.connection()) as watcher:
+        invoice = ingest_stripe_invoice(dbsession, data)
+        dbsession.commit()
+    assert watcher.count == 6
+    stmt1, stmt2, stmt3, stmt4, stmt5, stmt6 = [pair[0] for pair in watcher.statements]
+    assert stmt1.startswith("SELECT stripe_invoice."), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    assert stmt2.startswith("SELECT stripe_price."), stmt2
+    assert stmt2.endswith(" FOR UPDATE"), stmt2
+    assert stmt3.startswith("SELECT stripe_invoice_line_item."), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
+    # Insert order could be swapped
+    assert stmt4.startswith("INSERT INTO stripe_"), stmt4
+    assert stmt5.startswith("INSERT INTO stripe_"), stmt5
+    assert stmt6.startswith("INSERT INTO stripe_"), stmt6
+
     assert invoice.stripe_id == FAKE_STRIPE_ID["Invoice"]
     assert invoice.stripe_created == datetime(2021, 10, 28, tzinfo=timezone.utc)
     assert invoice.stripe_customer_id == FAKE_STRIPE_ID["Customer"]
@@ -505,8 +574,26 @@ def test_ingest_updated_invoice(dbsession, stripe_invoice):
     assert stripe_invoice.status == "open"
     data = stripe_invoice_data()
     data["status"] = "void"
-    invoice = ingest_stripe_invoice(dbsession, data)
-    dbsession.commit()
+    with StatementWatcher(dbsession.connection()) as watcher:
+        invoice = ingest_stripe_invoice(dbsession, data)
+        dbsession.commit()
+    assert watcher.count == 6
+    stmt1, stmt2, stmt3, stmt4, stmt5, stmt6 = [pair[0] for pair in watcher.statements]
+    assert stmt1.startswith("SELECT stripe_invoice."), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # Get all IDs
+    assert stmt2.startswith("SELECT stripe_invoice_line_item.stripe_id "), stmt2
+    assert stmt2.endswith(" FOR UPDATE"), stmt2
+    # Load line item 1
+    # Can't eager load items with FOR UPDATE, need to query twice
+    assert stmt3.startswith("SELECT stripe_price."), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
+    assert stmt4.startswith("SELECT stripe_invoice_line_item."), stmt4
+    assert stmt4.endswith(" FOR UPDATE"), stmt4
+    # Updates price, invoice, in unknown order
+    assert stmt5.startswith("UPDATE stripe_"), stmt5
+    assert stmt6.startswith("UPDATE stripe_"), stmt6
+
     assert invoice.status == "void"
     assert len(invoice.line_items) == 1
 


### PR DESCRIPTION
Changes for issue #340:

* Use ``SELECT ... FOR UPDATE``, to try to ensure one writer at a time updates a Stripe row. This is done in the generic ``_get_stripe()`` function, as well as when getting the IDs of subscription items and invoice line items, to detect deletions.
* Use ``filter().one_or_none()`` instead of ``.get()``, to avoid the identity map cache
* Catch ``IntegrityError`` and ``OperationalError`` (deadlocks and other issues), log the exception, and return a 409, instead of a 500.