### PR TITLE
Log Stripe ingest actions, and delete existing customer on FxA ID conflict

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -921,8 +921,8 @@ def _process_stripe_object(
     - Other errors (ValueError, KeyError) if the Stripe object has unexpected
       data for keys that CTMS examines. Extra data is ignored.
     """
+    obj, actions = ingest_stripe_object(db_session, data)
     try:
-        obj, actions = ingest_stripe_object(db_session, data)
         db_session.commit()
     except IntegrityError as e:
         db_session.rollback()

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -700,6 +700,23 @@ get_stripe_subscription_by_stripe_id = partial(_get_stripe, StripeSubscription)
 get_stripe_subscription_item_by_stripe_id = partial(_get_stripe, StripeSubscriptionItem)
 
 
+def get_stripe_customer_by_fxa_id(
+    db_session: Session,
+    fxa_id: str,
+    for_update: bool = False,
+) -> Optional[StripeCustomer]:
+    """
+    Get a StripeCustomer by FxA ID, or None if not found.
+
+    If for_update is True (default False), the row will be locked for update.
+    """
+    query = db_session.query(StripeCustomer)
+    if for_update:
+        query = query.with_for_update()
+    obj = query.filter(StripeCustomer.fxa_id == fxa_id).one_or_none()
+    return cast(Optional[StripeCustomer], obj)
+
+
 def get_stripe_products(email: Email) -> List[ProductBaseSchema]:
     """Return a list of Stripe products for the contact, if any."""
     if not email.stripe_customer:

--- a/ctms/ingest_stripe.py
+++ b/ctms/ingest_stripe.py
@@ -17,7 +17,7 @@ an expanded object, so that it is flexible for FxA request changes.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, Tuple, cast
 
 from ctms.crud import (
     create_stripe_customer,
@@ -56,6 +56,10 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
+# What actions were taken by an ingester
+StripeIngestActions = Dict[str, Set]
+
+
 def from_ts(timestamp: Optional[int]) -> datetime:
     """Convert from a (possibly None) timestamp to a UTC datetime."""
     if not timestamp:
@@ -89,7 +93,7 @@ class StripeIngestFxAIdConflict(StripeIngestError):
 
 def ingest_stripe_customer(
     db_session: Session, data: Dict[str, Any]
-) -> Optional[StripeCustomer]:
+) -> Tuple[Optional[StripeCustomer], StripeIngestActions]:
     """
     Ingest a Stripe Customer object.
 
@@ -127,11 +131,19 @@ def ingest_stripe_customer(
             customer.default_source_id = data["default_source"]
             _dpm = data["invoice_settings"]["default_payment_method"]
             customer.invoice_settings_default_payment_method_id = _dpm
-        return customer
+        return customer, {
+            "updated": {
+                f"{data['object']}:{customer_id}",
+            }
+        }
 
     if is_deleted:
         # Do not create records for deleted Customer records.
-        return None
+        return None, {
+            "skipped": {
+                f"{data['object']}:{customer_id}",
+            }
+        }
 
     _dpm = data["invoice_settings"]["default_payment_method"]
     schema = StripeCustomerCreateSchema(
@@ -142,12 +154,16 @@ def ingest_stripe_customer(
         default_source_id=data["default_source"],
         invoice_settings_default_payment_method_id=_dpm,
     )
-    return create_stripe_customer(db_session, schema)
+    return create_stripe_customer(db_session, schema), {
+        "created": {
+            f"{data['object']}:{customer_id}",
+        }
+    }
 
 
 def ingest_stripe_subscription(
     db_session: Session, data: Dict[str, Any]
-) -> StripeSubscription:
+) -> Tuple[StripeSubscription, StripeIngestActions]:
     """
     Ingest a Stripe Subscription object.
 
@@ -163,6 +179,7 @@ def ingest_stripe_subscription(
         db_session, subscription_id, for_update=True
     )
     if subscription:
+        action = "updated"
         subscription.stripe_created = from_ts(data["created"])
         subscription.stripe_customer_id = data["customer"]
         subscription.default_payment_method_id = data["default_payment_method"]
@@ -187,6 +204,7 @@ def ingest_stripe_subscription(
             )
         }
     else:
+        action = "created"
         schema = StripeSubscriptionCreateSchema(
             stripe_id=subscription_id,
             stripe_created=data["created"],
@@ -203,10 +221,17 @@ def ingest_stripe_subscription(
         )
         subscription = create_stripe_subscription(db_session, schema)
         sub_items_to_delete = set()
+    actions = {
+        action: {
+            f"{data['object']}:{data['id']}",
+        }
+    }
 
     for item_data in data["items"]["data"]:
         sub_items_to_delete.discard(item_data["id"])
-        ingest_stripe_subscription_item(db_session, item_data)
+        _, item_actions = ingest_stripe_subscription_item(db_session, item_data)
+        for key, values in item_actions.items():
+            actions.setdefault(key, set()).update(cast(set, values))
 
     # Remove any orphaned subscription items
     if sub_items_to_delete:
@@ -215,28 +240,33 @@ def ingest_stripe_subscription(
             .filter(StripeSubscriptionItem.stripe_id.in_(sub_items_to_delete))
             .delete(synchronize_session=False)
         )
+        actions.setdefault("deleted", set()).update(
+            {f"subscription_item:{item_id}" for item_id in sub_items_to_delete}
+        )
 
-    return subscription
+    return subscription, actions
 
 
 def ingest_stripe_subscription_item(
     db_session: Session, data: Dict[str, Any]
-) -> StripeSubscriptionItem:
+) -> Tuple[StripeSubscriptionItem, StripeIngestActions]:
     """Ingest a Stripe Subscription Item object."""
     assert data["object"] == "subscription_item", data.get("object", "[MISSING]")
 
     # Price is always included, and should be created first if new
-    price = ingest_stripe_price(db_session, data["price"])
+    price, actions = ingest_stripe_price(db_session, data["price"])
 
     subscription_item_id = data["id"]
     subscription_item = get_stripe_subscription_item_by_stripe_id(
         db_session, subscription_item_id, for_update=True
     )
     if subscription_item:
+        action = "updated"
         subscription_item.stripe_created = from_ts(data["created"])
         subscription_item.stripe_price_id = price.stripe_id
         subscription_item.stripe_subscription_id = data["subscription"]
     else:
+        action = "created"
         schema = StripeSubscriptionItemCreateSchema(
             stripe_id=subscription_item_id,
             stripe_created=data["created"],
@@ -245,10 +275,13 @@ def ingest_stripe_subscription_item(
         )
         subscription_item = create_stripe_subscription_item(db_session, schema)
 
-    return subscription_item
+    actions.setdefault(action, set()).add(f"{data['object']}:{data['id']}")
+    return subscription_item, actions
 
 
-def ingest_stripe_price(db_session: Session, data: Dict[str, Any]) -> StripePrice:
+def ingest_stripe_price(
+    db_session: Session, data: Dict[str, Any]
+) -> Tuple[StripePrice, StripeIngestActions]:
     """
     Ingest a Stripe Price object.
 
@@ -259,6 +292,7 @@ def ingest_stripe_price(db_session: Session, data: Dict[str, Any]) -> StripePric
     recurring = data.get("recurring", {})
     price = get_stripe_price_by_stripe_id(db_session, price_id, for_update=True)
     if price:
+        action = "updated"
         price.stripe_created = from_ts(data["created"])
         price.stripe_product_id = data["product"]
         price.active = data["active"]
@@ -267,6 +301,7 @@ def ingest_stripe_price(db_session: Session, data: Dict[str, Any]) -> StripePric
         price.recurring_interval_count = recurring.get("interval_count")
         price.unit_amount = data.get("unit_amount")
     else:
+        action = "created"
         schema = StripePriceCreateSchema(
             stripe_id=price_id,
             stripe_created=data["created"],
@@ -278,10 +313,16 @@ def ingest_stripe_price(db_session: Session, data: Dict[str, Any]) -> StripePric
             unit_amount=data.get("unit_amount"),
         )
         price = create_stripe_price(db_session, schema)
-    return price
+    return price, {
+        action: {
+            f"{data['object']}:{data['id']}",
+        }
+    }
 
 
-def ingest_stripe_invoice(db_session: Session, data: Dict[str, Any]) -> StripeInvoice:
+def ingest_stripe_invoice(
+    db_session: Session, data: Dict[str, Any]
+) -> Tuple[StripeInvoice, StripeIngestActions]:
     """
     Ingest a Stripe Invoice object.
 
@@ -294,6 +335,7 @@ def ingest_stripe_invoice(db_session: Session, data: Dict[str, Any]) -> StripeIn
     invoice_id = data["id"]
     invoice = get_stripe_invoice_by_stripe_id(db_session, invoice_id, for_update=True)
     if invoice:
+        action = "updated"
         invoice.stripe_created = from_ts(data["created"])
         invoice.stripe_customer_id = data["customer"]
         invoice.currency = data["currency"]
@@ -311,6 +353,7 @@ def ingest_stripe_invoice(db_session: Session, data: Dict[str, Any]) -> StripeIn
             )
         }
     else:
+        action = "created"
         schema = StripeInvoiceCreateSchema(
             stripe_id=invoice_id,
             stripe_created=data["created"],
@@ -323,10 +366,19 @@ def ingest_stripe_invoice(db_session: Session, data: Dict[str, Any]) -> StripeIn
         )
         invoice = create_stripe_invoice(db_session, schema)
         lines_to_delete = set()
+    actions = {
+        action: {
+            f"{data['object']}:{data['id']}",
+        }
+    }
 
     for line_data in data["lines"]["data"]:
         lines_to_delete.discard(line_data["id"])
-        ingest_stripe_invoice_line_item(db_session, invoice_id, line_data)
+        _, items_actions = ingest_stripe_invoice_line_item(
+            db_session, invoice_id, line_data
+        )
+        for key, values in items_actions.items():
+            actions.setdefault(key, set()).update(values)
 
     # Remove any orphaned invoice items
     if lines_to_delete:
@@ -335,24 +387,28 @@ def ingest_stripe_invoice(db_session: Session, data: Dict[str, Any]) -> StripeIn
             .filter(StripeInvoiceLineItem.stripe_id.in_(lines_to_delete))
             .delete(synchronize_session=False)
         )
+        actions.setdefault("deleted", set()).update(
+            {f"line_item:{item_id}" for item_id in lines_to_delete}
+        )
 
-    return invoice
+    return invoice, actions
 
 
 def ingest_stripe_invoice_line_item(
     db_session: Session, invoice_id: str, data: Dict[str, Any]
-) -> StripeInvoiceLineItem:
+) -> Tuple[StripeInvoiceLineItem, StripeIngestActions]:
     """Ingest a Stripe Line Item object."""
     assert data["object"] == "line_item", data.get("object", "[MISSING]")
 
     # Price is always included, and should be created first if new
-    price = ingest_stripe_price(db_session, data["price"])
+    price, actions = ingest_stripe_price(db_session, data["price"])
 
     invoice_line_item_id = data["id"]
     invoice_line_item = get_stripe_invoice_line_item_by_stripe_id(
         db_session, invoice_line_item_id, for_update=True
     )
     if invoice_line_item:
+        action = "updated"
         invoice_line_item.stripe_type = data["type"]
         invoice_line_item.stripe_price_id = price.stripe_id
         invoice_line_item.stripe_invoice_item_id = data.get("invoice_item")
@@ -361,6 +417,7 @@ def ingest_stripe_invoice_line_item(
         invoice_line_item.amount = data["amount"]
         invoice_line_item.currency = data["currency"]
     else:
+        action = "created"
         schema = StripeInvoiceLineItemCreateSchema(
             stripe_id=invoice_line_item_id,
             stripe_type=data["type"],
@@ -374,10 +431,13 @@ def ingest_stripe_invoice_line_item(
         )
         invoice_line_item = create_stripe_invoice_line_item(db_session, schema)
 
-    return invoice_line_item
+    actions.setdefault(action, set()).add(f"{data['object']}:{data['id']}")
+    return invoice_line_item, actions
 
 
-INGESTERS: Dict[str, Callable[[Session, Dict[str, Any]], StripeBase]] = {
+INGESTERS: Dict[
+    str, Callable[[Session, Dict[str, Any]], Tuple[StripeBase, StripeIngestActions]]
+] = {
     "customer": ingest_stripe_customer,
     "invoice": ingest_stripe_invoice,
     "subscription": ingest_stripe_subscription,
@@ -399,20 +459,23 @@ class StripeIngestBadObjectError(StripeIngestError):
 
 
 class StripeIngestUnknownObjectError(StripeIngestError):
-    def __init__(self, object_value, *args, **kwargs):
+    def __init__(self, object_value, object_id, *args, **kwargs):
         self.object_value = object_value
+        self.object_id = object_id
         StripeIngestError.__init__(self, *args, **kwargs)
 
     def __str__(self):
-        return f"Unknown Stripe object {self.object_value!r}."
+        return (
+            f"Unknown Stripe object {self.object_value!r} with ID {self.object_id!r}."
+        )
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.object_value!r})"
+        return f"{self.__class__.__name__}({self.object_value!r}, {self.object_id!r})"
 
 
 def ingest_stripe_object(
     db_session: Session, data: Dict[str, Any]
-) -> Optional[StripeBase]:
+) -> Tuple[Optional[StripeBase], StripeIngestActions]:
 
     try:
         object_type = data["object"]
@@ -422,6 +485,6 @@ def ingest_stripe_object(
     try:
         ingester = INGESTERS[object_type]
     except KeyError as exception:
-        raise StripeIngestUnknownObjectError(object_type) from exception
+        raise StripeIngestUnknownObjectError(object_type, data["id"]) from exception
 
     return ingester(db_session, data)

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -129,7 +129,14 @@ traceback) are logged at ``ERROR`` level (Severity 3). Some of the fields are:
 * ``client_id``: Name of the API client, such as ``"id_test"``
 * ``duration_s``: How long the request took in seconds, rounded to the
   millisecond
+* ``fxa_id_conflict``: If a Stripe API ingested a Customer whose Firefox
+  Account ID conflicted with an existing Customer, this is the conflicting
+  FxA ID (or list of comma-separated IDs). The existing customer will be
+  deleted, and will appears in ``ingest_actions``.
 * ``headers`` - Dictionary of header names (lower-cased) to header values
+* ``ingest_actions`` - For Stripe APIs, a dictionary of actions (`"created"`,
+  `"updated"`, `"deleted"`, `"skipped"`, `"no_change"`) to a list of objects
+  (formatted as `"object_type:ID"`, like `"customer:cust_abc123"`).
 * ``method`` - HTTP method, such as `"GET"`, `"POST"`, or `"PATCH"`.
 * ``msg`` - A summary line for the request, modelled after the uvicorn log
   message format.

--- a/tests/unit/test_api_stripe.py
+++ b/tests/unit/test_api_stripe.py
@@ -112,8 +112,10 @@ def test_api_post_stripe_trace_customer(client, dbsession, example_contact):
     par = dbsession.query(PendingAcousticRecord).one_or_none()
     assert par.email.stripe_customer.stripe_id == data["id"]
     assert len(caplog) == 1
-    assert caplog[0]["trace"] == email
-    assert caplog[0]["trace_json"] == data
+    log = caplog[0]
+    assert log["trace"] == email
+    assert log["trace_json"] == data
+    assert log["ingest_actions"] == {"created": [f"customer:{data['id']}"]}
 
 
 def test_api_post_stripe_from_pubsub_customer(
@@ -207,7 +209,7 @@ def test_api_post_pubsub_unknown_stripe_object(dbsession, pubsub_client):
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 0}
     assert len(cap_logs) == 1
-    assert cap_logs[0]["stripe_unknown_objects"] == ["payment_method"]
+    assert cap_logs[0]["ingest_actions"] == {"skipped": ["payment_method:pm_ABC123"]}
 
 
 def test_api_post_pubsub_trace_customer(dbsession, pubsub_client):
@@ -221,6 +223,7 @@ def test_api_post_pubsub_trace_customer(dbsession, pubsub_client):
     assert len(caplog) == 1
     assert caplog[0]["trace"] == email
     assert caplog[0]["trace_json"] == data
+    assert caplog[0]["ingest_actions"] == {"created": [f"customer:{data['id']}"]}
 
 
 def test_api_post_pubsub_integrity_error_is_409(dbsession, pubsub_client):

--- a/tests/unit/test_api_stripe.py
+++ b/tests/unit/test_api_stripe.py
@@ -232,8 +232,8 @@ def test_api_post_pubsub_integrity_error_is_409(dbsession, pubsub_client):
     err = IntegrityError(
         "INSERT INTO...", {"stripe_id": data["id"]}, "Duplicate key value"
     )
-    with capture_logs() as caplog, mock.patch(
-        "ctms.ingest_stripe.create_stripe_customer", side_effect=err
+    with capture_logs() as caplog, mock.patch.object(
+        dbsession, "commit", side_effect=err
     ):
         resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 409
@@ -251,8 +251,8 @@ def test_api_post_pubsub_deadlock_is_409(dbsession, pubsub_client):
     """A deadlock is turned into a 409 Conflict"""
     data = stripe_customer_data()
     err = OperationalError("INSERT INTO...", {"stripe_id": data["id"]}, "Deadlock")
-    with capture_logs() as caplog, mock.patch(
-        "ctms.ingest_stripe.create_stripe_customer", side_effect=err
+    with capture_logs() as caplog, mock.patch.object(
+        dbsession, "commit", side_effect=err
     ):
         resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 409


### PR DESCRIPTION
This should fix issue #343, where PubSub is sending a new Stripe customer with the same FxA ID as an existing customer. This is seen on stage, and appears to be due to a bug or direct interaction with the Stripe console. We currently return a 409 Conflict to the FxA PubSub push request, which means it is tried again a few milliseconds later.  Because the FxA Firestore indexes customers by FxA ID, it handles conflicts by overwriting the existing customer. This PR changes the behavior to delete the existing customer (mirroring the overwrite in FxA Firestore) and then import the new customer.

The first part detects the conflicting FxA ID in the application (``ingest_stripe_customer``) rather than during the database commit. For new customers, an extra ``SELECT`` is executed to find matching rows by FxA ID. For updated customers, the ``SELECT`` is only executed if the FxA ID changed. When this happens, ``ingest_stripe_customer`` raises a new exception, ``StripeIngestFxAIDConflict``.

The second part is to handle this exception. This is done in the shared code for the ``/stripe`` and ``/stripe_from_pubsub`` handlers. The existing customer is deleted, and ``ingest_stripe_customer`` is called again, to ingest the new stripe customer without conflict. Stripe data related to the deleted customer, such as subscriptions and invoices, is **not** deleted, due to our data model of weak relations between Stripe objects.

To report on this new action, there are two new items in the log context for Stripe API calls (``/stripe`` and ``/stripe_from_pubsub``), ``fxa_id_conflict`` and ``ingest_actions``.

The first is ``fxa_id_conflict``, which is set when a new Stripe customer has the same FxA ID (in the ``description`` field) as an existing customer.  If there is no conflict, this item is omitted.

The second is ``ingest_actions``, a dictionary of actions to a list of objects. For example, a subscription update may look like: 

```json
{
  "created": [
    "price:plan_XZY",
    "subscription:sub_abc123",
    "subscription_item:si_abc123_xzy"
  ]
}
```
The possible actions are:

* ``created``: A new object was ingested
* ``updated``: An existing object was updated
* ``no_change``: An existing object was ingested, but no changes in the data CTMS cares about
* ``deleted``: An existing object was deleted
* ``skipped``: The ingested object was skipped and not added to the database. One example is a new customer that is marked as deleted in Stripe - CTMS does not bother creating the customer row.

The log context ``stripe_unknown_objects``, which listed unknown Stripe object types, is removed. Instead, these are logged under ``ingest_actions["skipped"]``.

``ingest_actions`` gives a way to identify the conflicting customer records. The existing one will be listed under ``ingest_actions["deleted"]``, and the new one under ``ingest_actions["created"]``.  This also gives some insight into the PubSub push messages, so we can see what kind of data is in a request, and what is in a sequence of requests. Getting the ingest actions up to the application required changing the return values of ingest functions like ``ingest_stripe_customer``, so there are many repetitive changes. If it wasn't so late in the year, I'd refactor this feature into its own PR.

The ``ingest_actions["no_change"]`` items are implemented by looking at the ORM objects before and after the update, and determining if any of the fields changed. This exposed some bugs in updating that are fixed:

* The unfortunately named [datetime.utcfromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) returns a timezone naive ``datetime``, causing all changes to look like updates. This switches to ``datetime.fromtimestamp(timestamp, tz=timezone.utc)``. I think we got burned in a similar way with ``datetime.utcnow()``. Thanks to the blog post [Stop using utcnow and utcfromtimestamp](https://blog.ganssle.io/articles/2019/11/utcnow.html).
* Fix update of ``invoice.default_source_id``.
* Fix update of ``invoice_line_item.stripe_subscription_item_id``.


