### PR TITLE
Release 1.1.2 - Improve /stripe_from_pubsub ingest

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -87,7 +87,7 @@ from .schemas import (
 app = FastAPI(
     title="ConTact Management System (CTMS)",
     description="CTMS API (work in progress)",
-    version="1.1.1",
+    version="1.1.2",
 )
 SessionLocal = None
 METRICS_REGISTRY = CollectorRegistry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "ctms"
-version = "1.1.1"
+version = "1.1.2"
 description = "Contact Management System API"
 authors = [
     "Brian Stack <bstack@mozilla.com>",


### PR DESCRIPTION
* Use ``SELECT ... FOR UPDATE`` to avoid (some) database conflicts
* Improve updating logic to avoid needless updates
* Database conflicts (``IntegrityError``s and deadlocks and others) are returned as ``409 Conflict`` instead of ``500 Server Error``
* Handle duplicate FxA IDs in Stripe customers by deleting the existing customer record (seen in stage)
* Add details of Stripe objects in the request logs
* Update lxml from 4.6.4 to 4.7.1