### PR TITLE
Handle POST of new deleted customer

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -961,7 +961,7 @@ def _process_stripe_object(
             status_code=409, detail="Deadlock or other issue, try again"
         ) from e
 
-    email_id = obj.get_email_id()
+    email_id = obj.get_email_id() if obj else None
     if data["object"] == "customer" and re_trace_email.match(data.get("email", "")):
         trace_email = data["email"]
     else:

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -87,7 +87,7 @@ from .schemas import (
 app = FastAPI(
     title="ConTact Management System (CTMS)",
     description="CTMS API (work in progress)",
-    version="1.1.2",
+    version="1.1.3",
 )
 SessionLocal = None
 METRICS_REGISTRY = CollectorRegistry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "ctms"
-version = "1.1.2"
+version = "1.1.3"
 description = "Contact Management System API"
 authors = [
     "Brian Stack <bstack@mozilla.com>",


### PR DESCRIPTION
Handle the case where a new Stripe customer starts out deleted. The ingest is successful (doesn't raise `StripeIngestUnknownObjectError`), but no object is created and the object returned is `None`.

Fixes #350. Since this is a production issue, also preparing for next release.