### PR TITLE
Modifying engine params back to defaults from SQLAlchemy. 

### DIFF
--- a/ctms/config.py
+++ b/ctms/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     db_url: PostgresDsn
     db_pool_size: int = 5  # Default value from sqlalchemy
     db_max_overflow: int = 10  # Default value from sqlalchemy
-    db_pool_timeout_in_seconds: int = 45
+    db_pool_timeout_in_seconds: int = 30  # Default value from sqlalchemy
     secret_key: str
     token_expiration: timedelta = timedelta(minutes=60)
     server_prefix: str = "http://localhost:8000"


### PR DESCRIPTION
_Does/should the ACK time-limit in GCP need to be adjsuted too?_

(It's currently set to 20s)