### PR TITLE
Removing 'of' param in call to 'with_for_update'

### DIFF
--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -724,7 +724,7 @@ def _get_stripe(
     """
     query = db_session.query(model)
     if for_update:
-        query = query.with_for_update(of=StripeBase)
+        query = query.with_for_update()
     return cast(
         Optional[StripeModel], query.filter(model.stripe_id == stripe_id).one_or_none()
     )

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -724,7 +724,7 @@ def _get_stripe(
     """
     query = db_session.query(model)
     if for_update:
-        query = query.with_for_update(of=model)
+        query = query.with_for_update(of=StripeBase)
     return cast(
         Optional[StripeModel], query.filter(model.stripe_id == stripe_id).one_or_none()
     )

--- a/tests/unit/test_ingest_stripe.py
+++ b/tests/unit/test_ingest_stripe.py
@@ -235,7 +235,7 @@ def test_ingest_existing_contact(dbsession, example_contact):
     assert watcher.count == 3
     stmt1 = watcher.statements[0][0]
     assert stmt1.startswith("SELECT stripe_customer."), stmt1
-    assert stmt1.endswith(" FOR UPDATE OF stripe_customer"), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
     stmt2 = watcher.statements[1][0]
     assert stmt2.startswith("SELECT stripe_customer."), stmt2
     assert stmt2.endswith(" FOR UPDATE"), stmt2
@@ -302,7 +302,7 @@ def test_ingest_update_customer(dbsession, stripe_customer):
     assert watcher.count == 2
     stmt1 = watcher.statements[0][0]
     assert stmt1.startswith("SELECT stripe_customer."), stmt1
-    assert stmt1.endswith(" FOR UPDATE OF stripe_customer"), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
     stmt2 = watcher.statements[1][0]
     assert stmt2.startswith("UPDATE stripe_customer SET "), stmt2
 
@@ -394,13 +394,13 @@ def test_ingest_new_subscription(dbsession):
     stmt1, stmt2, stmt3, stmt4, stmt5, stmt6 = [pair[0] for pair in watcher.statements]
     model1 = "stripe_subscription"
     assert stmt1.startswith(f"SELECT {model1}."), stmt1
-    assert stmt1.endswith(f" FOR UPDATE OF {model1}"), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
     model2 = "stripe_price"
     assert stmt2.startswith(f"SELECT {model2}."), stmt2
-    assert stmt2.endswith(f" FOR UPDATE OF {model2}"), stmt2
+    assert stmt2.endswith(" FOR UPDATE"), stmt2
     model3 = "stripe_subscription_item"
     assert stmt3.startswith(f"SELECT {model3}."), stmt3
-    assert stmt3.endswith(f" FOR UPDATE OF {model3}"), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
     # Insert order could be swapped
     assert stmt4.startswith("INSERT INTO stripe_"), stmt4
     assert stmt5.startswith("INSERT INTO stripe_"), stmt5
@@ -491,16 +491,16 @@ def test_ingest_update_subscription(dbsession, stripe_subscription):
         pair[0] for pair in watcher.statements
     ]
     assert stmt1.startswith("SELECT stripe_subscription."), stmt1
-    assert stmt1.endswith(" FOR UPDATE OF stripe_subscription"), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
     # Get all IDs
     assert stmt2.startswith("SELECT stripe_subscription_item.stripe_id "), stmt2
     assert stmt2.endswith(" FOR UPDATE"), stmt2
     # Load item 1
     # Can't eager load items with FOR UPDATE, need to query twice
     assert stmt3.startswith("SELECT stripe_price."), stmt3
-    assert stmt3.endswith(" FOR UPDATE OF stripe_price"), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
     assert stmt4.startswith("SELECT stripe_subscription_item."), stmt4
-    assert stmt4.endswith(" FOR UPDATE OF stripe_subscription_item"), stmt4
+    assert stmt4.endswith(" FOR UPDATE"), stmt4
     # Delete old item
     assert stmt5.startswith("DELETE FROM stripe_subscription_item "), stmt5
     # Insert order could be swapped
@@ -652,11 +652,11 @@ def test_ingest_new_invoice(dbsession):
     assert watcher.count == 6
     stmt1, stmt2, stmt3, stmt4, stmt5, stmt6 = [pair[0] for pair in watcher.statements]
     assert stmt1.startswith("SELECT stripe_invoice."), stmt1
-    assert stmt1.endswith(" FOR UPDATE OF stripe_invoice"), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
     assert stmt2.startswith("SELECT stripe_price."), stmt2
-    assert stmt2.endswith(" FOR UPDATE OF stripe_price"), stmt2
+    assert stmt2.endswith(" FOR UPDATE"), stmt2
     assert stmt3.startswith("SELECT stripe_invoice_line_item."), stmt3
-    assert stmt3.endswith(" FOR UPDATE OF stripe_invoice_line_item"), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
     # Insert order could be swapped
     assert stmt4.startswith("INSERT INTO stripe_"), stmt4
     assert stmt5.startswith("INSERT INTO stripe_"), stmt5
@@ -717,16 +717,16 @@ def test_ingest_updated_invoice(dbsession, stripe_invoice):
     assert watcher.count == 5
     stmt1, stmt2, stmt3, stmt4, stmt5 = [pair[0] for pair in watcher.statements]
     assert stmt1.startswith("SELECT stripe_invoice."), stmt1
-    assert stmt1.endswith(" FOR UPDATE OF stripe_invoice"), stmt1
+    assert stmt1.endswith(" FOR UPDATE"), stmt1
     # Get all IDs
     assert stmt2.startswith("SELECT stripe_invoice_line_item.stripe_id "), stmt2
     assert stmt2.endswith(" FOR UPDATE"), stmt2
     # Load line item 1
     # Can't eager load items with FOR UPDATE, need to query twice
     assert stmt3.startswith("SELECT stripe_price."), stmt3
-    assert stmt3.endswith(" FOR UPDATE OF stripe_price"), stmt3
+    assert stmt3.endswith(" FOR UPDATE"), stmt3
     assert stmt4.startswith("SELECT stripe_invoice_line_item."), stmt4
-    assert stmt4.endswith(" FOR UPDATE OF stripe_invoice_line_item"), stmt4
+    assert stmt4.endswith(" FOR UPDATE"), stmt4
     # Updates invoice
     assert stmt5.startswith("UPDATE stripe_invoice "), stmt5
 


### PR DESCRIPTION
Modifying parameters used during the locking of rows.

https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.with_for_update