### PR TITLE
Adding environment variable for sql_alchemy create_engine call pool_recycle: `db_pool_recycle_in_seconds`

### DIFF
--- a/ctms/config.py
+++ b/ctms/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     db_pool_size: int = 5  # Default value from sqlalchemy
     db_max_overflow: int = 10  # Default value from sqlalchemy
     db_pool_timeout_in_seconds: int = 30  # Default value from sqlalchemy
+    db_pool_recycle_in_seconds: int = 300  # 5 minutes
     secret_key: str
     token_expiration: timedelta = timedelta(minutes=60)
     server_prefix: str = "http://localhost:8000"

--- a/ctms/database.py
+++ b/ctms/database.py
@@ -11,6 +11,7 @@ def get_db_engine(settings: config.Settings):
         pool_size=settings.db_pool_size,
         max_overflow=settings.db_max_overflow,
         pool_timeout=settings.db_pool_timeout_in_seconds,
+        pool_recycle=settings.db_pool_recycle_in_seconds,
     )
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     return engine, SessionLocal


### PR DESCRIPTION
https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_recycle

Adding this param to create_engine; with default of 5min. 