### PR TITLE
chore(stripe): Set for_update to False on price query

### DIFF
--- a/ctms/ingest_stripe.py
+++ b/ctms/ingest_stripe.py
@@ -294,7 +294,7 @@ def ingest_stripe_price(
     assert data["object"] == "price", data.get("object", "[MISSING]")
     price_id = data["id"]
     recurring = data.get("recurring", {})
-    price = get_stripe_price_by_stripe_id(db_session, price_id, for_update=True)
+    price = get_stripe_price_by_stripe_id(db_session, price_id, for_update=False)
     if price:
         orig_dict = price.__dict__.copy()
         price.stripe_created = from_ts(data["created"])

--- a/tests/unit/test_ingest_stripe.py
+++ b/tests/unit/test_ingest_stripe.py
@@ -397,7 +397,6 @@ def test_ingest_new_subscription(dbsession):
     assert stmt1.endswith(" FOR UPDATE"), stmt1
     model2 = "stripe_price"
     assert stmt2.startswith(f"SELECT {model2}."), stmt2
-    assert stmt2.endswith(" FOR UPDATE"), stmt2
     model3 = "stripe_subscription_item"
     assert stmt3.startswith(f"SELECT {model3}."), stmt3
     assert stmt3.endswith(" FOR UPDATE"), stmt3
@@ -498,7 +497,6 @@ def test_ingest_update_subscription(dbsession, stripe_subscription):
     # Load item 1
     # Can't eager load items with FOR UPDATE, need to query twice
     assert stmt3.startswith("SELECT stripe_price."), stmt3
-    assert stmt3.endswith(" FOR UPDATE"), stmt3
     assert stmt4.startswith("SELECT stripe_subscription_item."), stmt4
     assert stmt4.endswith(" FOR UPDATE"), stmt4
     # Delete old item
@@ -654,7 +652,6 @@ def test_ingest_new_invoice(dbsession):
     assert stmt1.startswith("SELECT stripe_invoice."), stmt1
     assert stmt1.endswith(" FOR UPDATE"), stmt1
     assert stmt2.startswith("SELECT stripe_price."), stmt2
-    assert stmt2.endswith(" FOR UPDATE"), stmt2
     assert stmt3.startswith("SELECT stripe_invoice_line_item."), stmt3
     assert stmt3.endswith(" FOR UPDATE"), stmt3
     # Insert order could be swapped
@@ -724,7 +721,6 @@ def test_ingest_updated_invoice(dbsession, stripe_invoice):
     # Load line item 1
     # Can't eager load items with FOR UPDATE, need to query twice
     assert stmt3.startswith("SELECT stripe_price."), stmt3
-    assert stmt3.endswith(" FOR UPDATE"), stmt3
     assert stmt4.startswith("SELECT stripe_invoice_line_item."), stmt4
     assert stmt4.endswith(" FOR UPDATE"), stmt4
     # Updates invoice


### PR DESCRIPTION
This data should not change very often and we are locking multiple times causing the entire application to lock up.