### PR TITLE
Only push Docker images on commits to `main` branch

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,7 +1,12 @@
 name: Build Docker image
 
-on: [ push, pull_request ]
-
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - stg-[0-9a-f]{6,10} 
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -25,6 +25,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      
+      - name: Verify production image builds
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}-test-build
 
       - name: Build test image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
This PR modifies our Actions so that we only upload built containers to the container registry on pushes to `main` (usually during PR merges or pushed tags).

This is (among other things) so that Dependabot PRs can pass CI. They're currently failing because they don't have access to our AWS creds, but we don't _need_ to login and push the containers when we run the test suite.