### PR TITLE
Temporarily disable / comment out "For Update" in SQL queries

### DIFF
--- a/ctms/ingest_stripe.py
+++ b/ctms/ingest_stripe.py
@@ -111,13 +111,13 @@ def ingest_stripe_customer(
     is_deleted = data.get("deleted", False)
 
     customer = get_stripe_customer_by_stripe_id(
-        db_session, customer_id, for_update=True
+        db_session, customer_id, for_update=False
     )
 
     # Detect duplicate FxA ID
     fxa_check = fxa_id and ((customer is None) or (customer.fxa_id != fxa_id))
     if fxa_check:
-        by_fxa = get_stripe_customer_by_fxa_id(db_session, fxa_id, for_update=True)
+        by_fxa = get_stripe_customer_by_fxa_id(db_session, fxa_id, for_update=False)
         if by_fxa is not None:
             raise StripeIngestFxAIdConflict(by_fxa.stripe_id, fxa_id)
 
@@ -180,7 +180,7 @@ def ingest_stripe_subscription(
     subscription_id = data["id"]
 
     subscription = get_stripe_subscription_by_stripe_id(
-        db_session, subscription_id, for_update=True
+        db_session, subscription_id, for_update=False
     )
     if subscription:
         orig_dict = subscription.__dict__.copy()
@@ -263,7 +263,7 @@ def ingest_stripe_subscription_item(
 
     subscription_item_id = data["id"]
     subscription_item = get_stripe_subscription_item_by_stripe_id(
-        db_session, subscription_item_id, for_update=True
+        db_session, subscription_item_id, for_update=False
     )
     if subscription_item:
         orig_dict = subscription_item.__dict__.copy()
@@ -340,7 +340,7 @@ def ingest_stripe_invoice(
     """
     assert data["object"] == "invoice", data.get("object", "[MISSING]")
     invoice_id = data["id"]
-    invoice = get_stripe_invoice_by_stripe_id(db_session, invoice_id, for_update=True)
+    invoice = get_stripe_invoice_by_stripe_id(db_session, invoice_id, for_update=False)
     if invoice:
         orig_dict = invoice.__dict__.copy()
         invoice.stripe_created = from_ts(data["created"])
@@ -413,7 +413,7 @@ def ingest_stripe_invoice_line_item(
 
     invoice_line_item_id = data["id"]
     invoice_line_item = get_stripe_invoice_line_item_by_stripe_id(
-        db_session, invoice_line_item_id, for_update=True
+        db_session, invoice_line_item_id, for_update=False
     )
     if invoice_line_item:
         orig_dict = invoice_line_item.__dict__.copy()

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -861,10 +861,10 @@ def test_get_stripe_customer_by_fxa_id(
 
     assert watcher.count == 1
     stmt = watcher.statements[0][0]
-    if with_lock == "for_update":
-        assert stmt.endswith("FOR UPDATE")
-    else:
-        assert not stmt.endswith("FOR UPDATE")
+    # if with_lock == "for_update":
+    # assert stmt.endswith("FOR UPDATE")
+    # else:
+    # assert not stmt.endswith("FOR UPDATE")
 
 
 @pytest.fixture()

--- a/tests/unit/test_ingest_stripe.py
+++ b/tests/unit/test_ingest_stripe.py
@@ -237,10 +237,10 @@ def test_ingest_existing_contact(dbsession, example_contact):
     assert watcher.count == 3
     stmt1 = watcher.statements[0][0]
     assert stmt1.startswith("SELECT stripe_customer."), stmt1
-    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # assert stmt1.endswith(" FOR UPDATE"), stmt1
     stmt2 = watcher.statements[1][0]
     assert stmt2.startswith("SELECT stripe_customer."), stmt2
-    assert stmt2.endswith(" FOR UPDATE"), stmt2
+    # assert stmt2.endswith(" FOR UPDATE"), stmt2
     stmt3 = watcher.statements[2][0]
     assert stmt3.startswith("INSERT INTO stripe_customer "), stmt3
 
@@ -304,7 +304,7 @@ def test_ingest_update_customer(dbsession, stripe_customer):
     assert watcher.count == 2
     stmt1 = watcher.statements[0][0]
     assert stmt1.startswith("SELECT stripe_customer."), stmt1
-    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # assert stmt1.endswith(" FOR UPDATE"), stmt1
     stmt2 = watcher.statements[1][0]
     assert stmt2.startswith("UPDATE stripe_customer SET "), stmt2
 
@@ -396,12 +396,12 @@ def test_ingest_new_subscription(dbsession):
     stmt1, stmt2, stmt3, stmt4, stmt5, stmt6 = [pair[0] for pair in watcher.statements]
     model1 = "stripe_subscription"
     assert stmt1.startswith(f"SELECT {model1}."), stmt1
-    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # assert stmt1.endswith(" FOR UPDATE"), stmt1
     model2 = "stripe_price"
     assert stmt2.startswith(f"SELECT {model2}."), stmt2
     model3 = "stripe_subscription_item"
     assert stmt3.startswith(f"SELECT {model3}."), stmt3
-    assert stmt3.endswith(" FOR UPDATE"), stmt3
+    # assert stmt3.endswith(" FOR UPDATE"), stmt3
     # Insert order could be swapped
     assert stmt4.startswith("INSERT INTO stripe_"), stmt4
     assert stmt5.startswith("INSERT INTO stripe_"), stmt5
@@ -492,15 +492,15 @@ def test_ingest_update_subscription(dbsession, stripe_subscription):
         pair[0] for pair in watcher.statements
     ]
     assert stmt1.startswith("SELECT stripe_subscription."), stmt1
-    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # assert stmt1.endswith(" FOR UPDATE"), stmt1
     # Get all IDs
     assert stmt2.startswith("SELECT stripe_subscription_item.stripe_id "), stmt2
-    assert stmt2.endswith(" FOR UPDATE"), stmt2
+    # assert stmt2.endswith(" FOR UPDATE"), stmt2
     # Load item 1
     # Can't eager load items with FOR UPDATE, need to query twice
     assert stmt3.startswith("SELECT stripe_price."), stmt3
     assert stmt4.startswith("SELECT stripe_subscription_item."), stmt4
-    assert stmt4.endswith(" FOR UPDATE"), stmt4
+    # assert stmt4.endswith(" FOR UPDATE"), stmt4
     # Delete old item
     assert stmt5.startswith("DELETE FROM stripe_subscription_item "), stmt5
     # Insert order could be swapped
@@ -652,10 +652,10 @@ def test_ingest_new_invoice(dbsession):
     assert watcher.count == 6
     stmt1, stmt2, stmt3, stmt4, stmt5, stmt6 = [pair[0] for pair in watcher.statements]
     assert stmt1.startswith("SELECT stripe_invoice."), stmt1
-    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # assert stmt1.endswith(" FOR UPDATE"), stmt1
     assert stmt2.startswith("SELECT stripe_price."), stmt2
     assert stmt3.startswith("SELECT stripe_invoice_line_item."), stmt3
-    assert stmt3.endswith(" FOR UPDATE"), stmt3
+    # assert stmt3.endswith(" FOR UPDATE"), stmt3
     # Insert order could be swapped
     assert stmt4.startswith("INSERT INTO stripe_"), stmt4
     assert stmt5.startswith("INSERT INTO stripe_"), stmt5
@@ -716,15 +716,15 @@ def test_ingest_updated_invoice(dbsession, stripe_invoice):
     assert watcher.count == 5
     stmt1, stmt2, stmt3, stmt4, stmt5 = [pair[0] for pair in watcher.statements]
     assert stmt1.startswith("SELECT stripe_invoice."), stmt1
-    assert stmt1.endswith(" FOR UPDATE"), stmt1
+    # assert stmt1.endswith(" FOR UPDATE"), stmt1
     # Get all IDs
     assert stmt2.startswith("SELECT stripe_invoice_line_item.stripe_id "), stmt2
-    assert stmt2.endswith(" FOR UPDATE"), stmt2
+    # assert stmt2.endswith(" FOR UPDATE"), stmt2
     # Load line item 1
     # Can't eager load items with FOR UPDATE, need to query twice
     assert stmt3.startswith("SELECT stripe_price."), stmt3
     assert stmt4.startswith("SELECT stripe_invoice_line_item."), stmt4
-    assert stmt4.endswith(" FOR UPDATE"), stmt4
+    # assert stmt4.endswith(" FOR UPDATE"), stmt4
     # Updates invoice
     assert stmt5.startswith("UPDATE stripe_invoice "), stmt5
 


### PR DESCRIPTION
This is only to clear the pubsub queue we're seeing on staging.  This should be reverted when the issue is resolved.