### PR TITLE
Add step to check lint in pull requests

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -25,7 +25,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      
+
+      - name: Check code lint
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          target: "lint"
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}-lint
+
       - name: Verify production image builds
         uses: docker/build-push-action@v2
         with:

--- a/ctms/bin/acoustic_fields.py
+++ b/ctms/bin/acoustic_fields.py
@@ -56,7 +56,7 @@ def main(dbsession, args=None) -> int:
         )
         if not row:
             print(f"Unknown field '{args.tablename}.{args.field}'. Give up.")
-            return os.EX_NOTFOUND
+            return os.EX_DATAERR
         dbsession.delete(row)
         dbsession.commit()
         print("Removed.")


### PR DESCRIPTION
The way linting is done is different than what I'm used to, and find it confusing. 

This PR adds an explicit step in the pull-request workflow. 

But there could be another way to fix it, by figuring out why:
- all targets are built here https://github.com/mozilla-it/ctms-api/blob/f49c740f466b819ca54e6f348eee9e9eed152aa9/.github/workflows/build-image.yaml#L79
- only the production target is built here https://github.com/mozilla-it/ctms-api/blob/f49c740f466b819ca54e6f348eee9e9eed152aa9/.github/workflows/test-build.yaml#L29-L35

Other things could be re-arranged, but not in this PR, like for example:
- duplicated lint commands between `lint.sh` and `Dockerfile`
- `lint.sh` is not used anywhere
- a dedicated dockerflow file for lint?