### PR TITLE
Follow #475: update secrets baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ build
 reports/
 .coverage
 htmlcov/
-.isort.cfg
 docs/_build
 .env

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,20 +1,18 @@
 {
-  "custom_plugin_paths": [],
-  "exclude": {
-    "files": "(poetry.lock$)|(htmlcov/)",
-    "lines": null
-  },
-  "generated_at": "2021-12-07T21:46:42Z",
+  "version": "1.4.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -23,8 +21,14 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -36,14 +40,20 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
@@ -52,45 +62,142 @@
       "name": "SoftlayerDetector"
     },
     {
+      "name": "SquareOAuthDetector"
+    },
+    {
       "name": "StripeDetector"
     },
     {
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "(poetry.lock$)|(htmlcov/)"
+      ]
+    }
+  ],
   "results": {
     ".github/workflows/test-build.yaml": [
       {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/test-build.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 13,
-        "type": "Secret Keyword"
+        "line_number": 13
       },
       {
+        "type": "Basic Auth Credentials",
+        "filename": ".github/workflows/test-build.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 45,
-        "type": "Basic Auth Credentials"
+        "line_number": 52
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/test-build.yaml",
+        "hashed_secret": "a2490b1a07aa4a72606afe91f2de20f8c524d779",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "docker/config/local_dev.env": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker/config/local_dev.env",
+        "hashed_secret": "9f33da7ed96322c0564596c334a5d7b3cc440621",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "docker/lint.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker/lint.sh",
+        "hashed_secret": "fd336c21216d202878615f06d5fd8528d187f37e",
+        "is_verified": false,
+        "line_number": 14
       }
     ],
     "docs/developer_setup.md": [
       {
-        "hashed_secret": "457130ffb195a6fc7693cc447d1d03c8e0ef28d6",
+        "type": "Secret Keyword",
+        "filename": "docs/developer_setup.md",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 208,
-        "type": "Secret Keyword"
+        "line_number": 208
+      }
+    ],
+    "tests/unit/test_acoustic_service.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_acoustic_service.py",
+        "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests/unit/test_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_auth.py",
+        "hashed_secret": "187bdfbab92356d7b8f2444e9c6253c0536cbde7",
+        "is_verified": false,
+        "line_number": 37
       },
       {
-        "hashed_secret": "5089246737bcae6ebd14c2548a8360bc548cf0db",
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_auth.py",
+        "hashed_secret": "b32224ba01e706962030343e7d3d964b9db7034f",
         "is_verified": false,
-        "line_number": 278,
-        "type": "Secret Keyword"
+        "line_number": 230
+      }
+    ],
+    "tests/unit/test_sync.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_sync.py",
+        "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
+        "is_verified": false,
+        "line_number": 16
       }
     ]
   },
-  "version": "0.14.3",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2022-11-29T14:01:53Z"
 }

--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -15,7 +15,7 @@ if [ -n "$HAS_GIT" ]; then
     detect-secrets-hook $SECRETS_TO_SCAN --baseline .secrets.baseline
 fi
 
-isort --settings-path ./pyproject.toml --check-only "${BASE_DIR}"
+isort --check-only "${BASE_DIR}"
 black --check "${BASE_DIR}"
 mypy "${BASE_DIR}/ctms"
 pylint "${BASE_DIR}/ctms" "${BASE_DIR}/tests/unit"

--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -15,7 +15,7 @@ if [ -n "$HAS_GIT" ]; then
     detect-secrets-hook $SECRETS_TO_SCAN --baseline .secrets.baseline
 fi
 
-isort --check-only "${BASE_DIR}"
+isort --settings-path ./pyproject.toml --check-only "${BASE_DIR}"
 black --check "${BASE_DIR}"
 mypy "${BASE_DIR}/ctms"
 pylint "${BASE_DIR}/ctms" "${BASE_DIR}/tests/unit"


### PR DESCRIPTION
Follow up of #475 

Since Docker on my machine is insupportably painful (like right now I run `make lint` and I get some errors like `docker.errors.DockerException: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))` while I just want to LINT MY LOCAL FILES!!!)

I tried to run linting with:

```
poetry install
poetry shell
./docker/lint.sh
```
> which would be my preferred way for `make lint`, but out of scope here

There are errors about secrets. So I ran:

```
./scripts/update_baseline.sh
git add .secrets.baseline
```

But then about `isort` isn't happy about the formatting of imports/wrapping.
Which are fixed by specifying the config file (`profile = "black"`).

Why don't we have these errors when running `./docker/lint.sh` from the container ???


