### PR TITLE
Add `sub_waitlist_<name>` column to Acoustic sync

### DIFF
--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -74,6 +74,19 @@ In order to add, list, or remove certain mappings, use the `acoustic_newsletters
 
 See `python ctms/bin/acoustic_newsletters_mapping.py --help` for usage details.
 
+
+## How to onboard a new waitlist
+
+1. Create the waitlist in Basket. In Basket, waitlists are newsletters with a special flag. By convention, suffix the name with `-waitlist` (eg. `shield-waitlist`).
+1. By default extra fields won't be validated and all values will be accepted. In order to enforce typing and consistency, a specific schema must be added in `schemas/waitlists.py`. See ADR `waitlists_relationships.md` for more details.
+1. Create the necessary columns in Acoustic (eg. `sub_shield_waitlist`, `shield_waitlist_geo`, `shield_waitlist_age`).
+1. By default, CTMS does not synchronize any column. Fields have to be marked explicitly using the `python ctms/bin/acoustic_fields.py` command (see above).
+
+Possible Acoustic columns are:
+- `sub_<name>_waitlist` (bool), like newsletters
+- `<name>_waitlist_source` (str)
+- `<name>_waitlist_<field>` (type depends on schema)
+
 ## Logging
 
 When the environment variable ``CTMS_USE_MOZLOG`` is set to true or unset, then

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -131,6 +131,23 @@ def test_ctms_to_acoustic_waitlists_maximal(
     assert main["relay_waitlist_geo"] == "cn"
 
 
+def test_ctms_to_acoustic_waitlists_sends_a_sub_column(
+    base_ctms_acoustic_service,
+    minimal_contact,
+    maximal_contact,
+    acoustic_newsletters_mapping,
+):
+    (main, _, _,) = base_ctms_acoustic_service.convert_ctms_to_acoustic(
+        minimal_contact, {"sub_vpn_waitlist"}, acoustic_newsletters_mapping
+    )
+    assert main["sub_vpn_waitlist"] is None
+
+    (main, _, _,) = base_ctms_acoustic_service.convert_ctms_to_acoustic(
+        maximal_contact, {"sub_vpn_waitlist"}, acoustic_newsletters_mapping
+    )
+    assert main["sub_vpn_waitlist"] == "1"
+
+
 def test_ctms_to_acoustic_minimal_fields(
     base_ctms_acoustic_service,
     minimal_contact,

--- a/tests/unit/test_api_patch.py
+++ b/tests/unit/test_api_patch.py
@@ -481,7 +481,9 @@ def test_patch_will_validate_waitlist_fields(client, maximal_contact):
 def test_patch_to_add_a_waitlist(client, maximal_contact):
     """PATCH can add a single waitlist."""
     email_id = maximal_contact.email.email_id
-    patch_data = {"waitlists": [{"name": "future-tech", "fields": {"geo": "es"}}]}
+    patch_data = {
+        "waitlists": [{"name": "future-tech", "fields": {"geo": "es", "pi": 3.14}}]
+    }
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 200
     actual = resp.json()
@@ -489,7 +491,7 @@ def test_patch_to_add_a_waitlist(client, maximal_contact):
     assert actual["waitlists"][-1] == {
         "name": "future-tech",
         "source": None,
-        "fields": {"geo": "es"},
+        "fields": {"geo": "es", "pi": 3.14},
     }
 
 


### PR DESCRIPTION
In order to target waitlists subscriptions, let's add an explicit column, like for newsletters. 

In the current setup, subscriptions are tracked using the `<name>_waitlist_geo` column, but since not all waitlists will have a `geo` field, having a `sub_*`  column can be handy.

This PR also adds a few lines of docs to onboard waitlists