### PR TITLE
Fix #545: allow empty string in waitlist platform field

### DIFF
--- a/ctms/schemas/waitlist.py
+++ b/ctms/schemas/waitlist.py
@@ -128,7 +128,6 @@ def validate_waitlist_fields(name: str, fields: dict):
             )
             platform: Optional[str] = Field(
                 default=None,
-                min_length=1,
                 max_length=100,
                 description="VPN waitlist platforms as comma-separated list",
                 example="ios,mac",

--- a/tests/unit/test_schema_waitlist.py
+++ b/tests/unit/test_schema_waitlist.py
@@ -44,7 +44,6 @@ def test_waitlist_with_invalid_input_data(data):
         # VPN
         {"name": "vpn", "fields": {"geo": None}},
         {"name": "vpn", "fields": {"platform": "linux"}},
-        {"name": "vpn", "fields": {"geo": "b", "platform": ""}},
         {"name": "vpn", "fields": {"geo": "b", "platform": "win64", "extra": "boom"}},
         # Relay
         {"name": "relay"},
@@ -64,6 +63,7 @@ def test_relay_and_vpn_waitlist_invalid_data(data):
         # VPN
         {"name": "vpn", "fields": {"geo": "b"}},
         {"name": "vpn", "fields": {"geo": ""}},
+        {"name": "vpn", "fields": {"geo": "b", "platform": ""}},
         {"name": "vpn", "fields": {"geo": "b", "platform": None}},
         {"name": "vpn", "fields": {"geo": "b", "platform": "win64"}},
         # Relay


### PR DESCRIPTION
Fix #545

In v1.9.1 https://github.com/mozilla-it/ctms-api/blob/c17ae6911a33a7760e86e0554a3ec5ffb2f9472a/ctms/schemas/vpn.py#L23-L31 the platform field did not have any min length.

This PR restores the original behaviour.