### PR TITLE
Force UTC at SQLAlchemy client/session level

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -86,7 +86,11 @@ def engine(pytestconfig):
         create_database(test_db_url)
 
     echo = Settings().log_sqlalchemy or pytestconfig.getoption("verbose") > 2
-    test_engine = create_engine(test_db_url, echo=echo)
+    test_engine = create_engine(
+        test_db_url,
+        echo=echo,
+        connect_args={"options": "-c timezone=utc"},
+    )
 
     cfg = alembic_config.Config(os.path.join(APP_FOLDER, "alembic.ini"))
     with test_engine.begin() as cnx:


### PR DESCRIPTION
My tests were failing when running locally.

I tried several things at the DB level ([1](https://stackoverflow.com/a/51697579/141895), [2](https://github.com/Kinto/kinto/blob/af30f2d066d5b007bfac15510843b93e66e7c8cf/docs/community.rst#L127)), and apparently setting `TZ=UTC` in `bin/test.sh` for the client was not enough. 

This patch solves it for me, since it forces the timezone at connection... 🤷 