### PR TITLE
 Ref #565: delete relational rows in Acoustic before inserting new ones 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1537,14 +1537,19 @@ description = "Python wrapper for Acoustic (formerly Silverpop)."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-files = [
-    {file = "pysilverpop-0.2.6.tar.gz", hash = "sha256:27d08fd7823ece74a21e70ae9becded12d25c480bcdba9e8bd37e02ecb0f53e1"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 requests = "*"
 requests_oauthlib = "*"
 six = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/leplatrem/pysilverpop.git"
+reference = "add-delete-relational-table-data"
+resolved_reference = "6b3729a0f8b3340d6a932d2f933ac2aeb871d85e"
 
 [[package]]
 name = "pytest"
@@ -2485,4 +2490,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11.1"
-content-hash = "1d6ddc95450c66e88aa6f0b06516eb85f579cdc44d4bc1cb8cc51bcd237aac6e"
+content-hash = "ae4fe981b933d646c0ea18cfc700fe816f4a37916106a2b1e620e3a05143dd25"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2484,5 +2484,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "~3.11"
-content-hash = "18a6a95189ff1a67501f9a8d16f74763439b94a00a8be8b731bbcd428aa22a19"
+python-versions = "~3.11.1"
+content-hash = "1d6ddc95450c66e88aa6f0b06516eb85f579cdc44d4bc1cb8cc51bcd237aac6e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = ["CTMS Reviewers <@mozilla-it/ctms-reviewers>"]
 
 [tool.poetry.dependencies]
 # These packages are mandatory and form the core of this package’s distribution.
-python = "3.11.1"
+python = "~3.11.1"
 fastapi = "^0.84.0"
 starlette = "^0.19.1"
 requests = "^2.28.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ passlib = {extras = ["argon2"], version = "^1.7.4"}
 python-dateutil = "^2.8.1"
 dockerflow = "^2022.8.0"
 sentry-sdk = "^1.14.0"
-pysilverpop = "^0.2.6"
+pysilverpop = {git = "https://github.com/leplatrem/pysilverpop.git", rev = "add-delete-relational-table-data"}
 lxml = "^4.9.2"
 prometheus-client = "0.16.0"
 structlog = "^22.3.0"

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -197,6 +197,7 @@ def test_ctms_to_acoustic_mocked(
         )
     assert results  # success
     acoustic_mock.add_recipient.assert_called()
+    acoustic_mock.delete_relational_table_data.assert_called()
     acoustic_mock.insert_update_relational_table.assert_called()
 
     acoustic_mock.add_recipient.assert_called_with(
@@ -206,6 +207,15 @@ def test_ctms_to_acoustic_mocked(
         allow_html=False,
         sync_fields={"email_id": _main["email_id"]},
         columns=_main,
+    )
+
+    acoustic_mock.delete_relational_table_data.assert_any_call(
+        table_id=CTMS_ACOUSTIC_PRODUCT_TABLE_ID,
+        rows=[{"email_id": str(maximal_contact.email.email_id)}],
+    )
+    acoustic_mock.delete_relational_table_data.assert_any_call(
+        table_id=CTMS_ACOUSTIC_NEWSLETTER_TABLE_ID,
+        rows=[{"email_id": str(maximal_contact.email.email_id)}],
     )
 
     acoustic_mock.insert_update_relational_table.assert_called_with(
@@ -323,6 +333,11 @@ def test_ctms_to_acoustic_with_subscription_and_metrics(
         )
     assert results  # success
 
+    acoustic_mock.delete_relational_table_data.assert_called_with(
+        table_id=CTMS_ACOUSTIC_PRODUCT_TABLE_ID,
+        rows=[{"email_id": str(contact_with_stripe_subscription.email.email_id)}],
+    )
+
     acoustic_mock.insert_update_relational_table.assert_called_with(
         table_id=CTMS_ACOUSTIC_PRODUCT_TABLE_ID, rows=_product
     )
@@ -358,6 +373,9 @@ def test_ctms_to_acoustic_with_subscription_and_metrics(
             "product_status": "success",
             "main_duration_s": log["main_duration_s"],
             "product_duration_s": log["product_duration_s"],
+            # We also deleted existing RT data for newsletters.
+            "newsletter_duration_s": log["newsletter_duration_s"],
+            "newsletter_status": "success",
         }
     )
     assert log == expected_log


### PR DESCRIPTION
Ref #565

Acoustic should contain more data than CTMS does.

The relational table data should not be a "history trail".

Ideally, it should not contain more data than what is required for marketing to craft audience queries.
For now, start by adding a step that deletes from the relational table before inserting rows.