### PR TITLE
Migrate `SAMPLE_STRIPE_DATA` to pytest fixtures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -174,14 +174,14 @@
         "filename": "tests/unit/test_auth.py",
         "hashed_secret": "187bdfbab92356d7b8f2444e9c6253c0536cbde7",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 36
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_auth.py",
         "hashed_secret": "b32224ba01e706962030343e7d3d964b9db7034f",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 227
       }
     ],
     "tests/unit/test_sync.py": [
@@ -194,5 +194,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-09T15:51:29Z"
+  "generated_at": "2023-04-12T11:30:34Z"
 }

--- a/tests/unit/sample_data.py
+++ b/tests/unit/sample_data.py
@@ -1,5 +1,4 @@
 from base64 import b64encode
-from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -19,66 +18,4 @@ FAKE_STRIPE_ID = {
     "Product": fake_stripe_id("prod", "product"),
     "Subscription": fake_stripe_id("sub", "subscription"),
     "Subscription Item": fake_stripe_id("si", "subscription_item"),
-}
-
-# Sample data to pass to Stripe[Object]CreateSchema
-SAMPLE_STRIPE_DATA = {
-    "Customer": {
-        "stripe_id": FAKE_STRIPE_ID["Customer"],
-        "stripe_created": datetime(2021, 10, 25, 15, 34, tzinfo=timezone.utc),
-        # TODO magic string from fxa schema
-        "fxa_id": "6eb6ed6ac3b64259968aa490c6c0b9df",
-        "default_source_id": None,
-        "invoice_settings_default_payment_method_id": FAKE_STRIPE_ID["Payment Method"],
-    },
-    "Subscription": {
-        "stripe_id": FAKE_STRIPE_ID["Subscription"],
-        "stripe_created": datetime(2021, 9, 27, tzinfo=timezone.utc),
-        "stripe_customer_id": FAKE_STRIPE_ID["Customer"],
-        "default_source_id": None,
-        "default_payment_method_id": None,
-        "cancel_at_period_end": False,
-        "canceled_at": None,
-        "current_period_start": datetime(2021, 10, 27, tzinfo=timezone.utc),
-        "current_period_end": datetime(2021, 11, 27, tzinfo=timezone.utc),
-        "ended_at": None,
-        "start_date": datetime(2021, 9, 27, tzinfo=timezone.utc),
-        "status": "active",
-    },
-    "SubscriptionItem": {
-        "stripe_id": FAKE_STRIPE_ID["Subscription Item"],
-        "stripe_created": datetime(2021, 9, 27, tzinfo=timezone.utc),
-        "stripe_subscription_id": FAKE_STRIPE_ID["Subscription"],
-        "stripe_price_id": FAKE_STRIPE_ID["Price"],
-    },
-    "Price": {
-        "stripe_id": FAKE_STRIPE_ID["Price"],
-        "stripe_created": datetime(2020, 10, 27, 10, 45, tzinfo=timezone.utc),
-        "stripe_product_id": FAKE_STRIPE_ID["Product"],
-        "active": True,
-        "currency": "usd",
-        "recurring_interval": "month",
-        "recurring_interval_count": 1,
-        "unit_amount": 999,
-    },
-    "Invoice": {
-        "stripe_id": FAKE_STRIPE_ID["Invoice"],
-        "stripe_created": datetime(2021, 10, 28, tzinfo=timezone.utc),
-        "stripe_customer_id": FAKE_STRIPE_ID["Customer"],
-        "default_source_id": None,
-        "default_payment_method_id": None,
-        "currency": "usd",
-        "total": 1000,
-        "status": "open",
-    },
-    "InvoiceLineItem": {
-        "stripe_id": FAKE_STRIPE_ID["(Invoice) Line Item"],
-        "stripe_price_id": FAKE_STRIPE_ID["Price"],
-        "stripe_invoice_id": FAKE_STRIPE_ID["Invoice"],
-        "stripe_subscription_id": FAKE_STRIPE_ID["Subscription"],
-        "stripe_subscription_item_id": FAKE_STRIPE_ID["Subscription Item"],
-        "stripe_type": "subscription",
-        "amount": 1000,
-        "currency": "usd",
-    },
 }

--- a/tests/unit/test_api_stripe.py
+++ b/tests/unit/test_api_stripe.py
@@ -12,11 +12,6 @@ from structlog.testing import capture_logs
 from ctms.app import app, get_pubsub_claim
 from ctms.models import PendingAcousticRecord
 from tests.unit.sample_data import fake_stripe_id
-from tests.unit.test_ingest_stripe import (
-    stripe_customer_data,
-    stripe_invoice_data,
-    stripe_subscription_data,
-)
 
 
 def pubsub_wrap(data):
@@ -61,18 +56,22 @@ def pubsub_client(anon_client):
     del app.dependency_overrides[get_pubsub_claim]
 
 
-def test_api_post_stripe_customer(client, dbsession, example_contact):
+def test_api_post_stripe_customer(
+    client, dbsession, example_contact, raw_stripe_customer_data
+):
     """Stripe customer data can be imported."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     resp = client.post("/stripe", json=data)
     assert resp.status_code == 200
     par = dbsession.query(PendingAcousticRecord).one_or_none()
     assert par.email.stripe_customer.stripe_id == data["id"]
 
 
-def test_api_post_stripe_customer_without_contact(client, dbsession):
+def test_api_post_stripe_customer_without_contact(
+    client, dbsession, raw_stripe_customer_data
+):
     """Stripe customer data without a related contact can be imported."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     resp = client.post("/stripe", json=data)
     assert resp.status_code == 200
     par = dbsession.query(PendingAcousticRecord).one_or_none()
@@ -88,9 +87,11 @@ def test_api_post_stripe_customer_bad_data(client, dbsession):
     assert dbsession.query(PendingAcousticRecord).one_or_none() is None
 
 
-def test_api_post_stripe_customer_missing_data(client, dbsession):
+def test_api_post_stripe_customer_missing_data(
+    client, dbsession, raw_stripe_customer_data
+):
     """Missing data from customer data is a 400 error."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     del data["description"]  # The FxA ID
     resp = client.post("/stripe", json=data)
     assert resp.status_code == 400
@@ -103,9 +104,11 @@ def test_api_post_sample_data(dbsession, client, stripe_test_json):
     assert resp.status_code == 200
 
 
-def test_api_post_stripe_trace_customer(client, dbsession, example_contact):
+def test_api_post_stripe_trace_customer(
+    client, dbsession, example_contact, raw_stripe_customer_data
+):
     """Stripe customer data can be traced via email."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     email = data["email"] = "customer+trace-me-mozilla-123@example.com"
     with capture_logs() as caplog:
         resp = client.post("/stripe", json=data)
@@ -119,9 +122,11 @@ def test_api_post_stripe_trace_customer(client, dbsession, example_contact):
     assert log["ingest_actions"] == {"created": [f"customer:{data['id']}"]}
 
 
-def test_api_post_conflicting_fxa_id(dbsession, client, contact_with_stripe_customer):
+def test_api_post_conflicting_fxa_id(
+    dbsession, client, contact_with_stripe_customer, raw_stripe_customer_data
+):
     """An existing customer with an FxA ID conflict is deleted."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     old_id = data["id"]
     new_id = old_id + "_new"
     data["id"] = new_id
@@ -154,10 +159,10 @@ def test_api_post_deleted_new_customer(dbsession, client):
 
 
 def test_api_post_stripe_from_pubsub_customer(
-    dbsession, pubsub_client, example_contact
+    dbsession, pubsub_client, example_contact, raw_stripe_customer_data
 ):
     """Stripe customer data as a PubSub push can be imported."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 1}
@@ -165,10 +170,13 @@ def test_api_post_stripe_from_pubsub_customer(
     assert par.email.stripe_customer.stripe_id == data["id"]
 
 
-def test_api_post_stripe_from_pubsub_without_contact(pubsub_client, dbsession):
+def test_api_post_stripe_from_pubsub_without_contact(
+    pubsub_client, dbsession, raw_stripe_customer_data
+):
     """Stripe customer data without a related contact can be imported from pubsub."""
-    data = stripe_customer_data()
-    resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
+    resp = pubsub_client.post(
+        "/stripe_from_pubsub", json=pubsub_wrap(raw_stripe_customer_data)
+    )
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 1}
     par = dbsession.query(PendingAcousticRecord).one_or_none()
@@ -176,12 +184,17 @@ def test_api_post_stripe_from_pubsub_without_contact(pubsub_client, dbsession):
 
 
 def test_api_post_stripe_from_pubsub_item_dict(
-    dbsession, pubsub_client, example_contact
+    dbsession,
+    pubsub_client,
+    example_contact,
+    raw_stripe_customer_data,
+    raw_stripe_subscription_data,
+    raw_stripe_invoice_data,
 ):
     """A PubSub push of multiple items, keyed by table:id, can be imported."""
-    customer_data = stripe_customer_data()
-    subscription_data = stripe_subscription_data()
-    invoice_data = stripe_invoice_data()
+    customer_data = raw_stripe_customer_data
+    subscription_data = raw_stripe_subscription_data
+    invoice_data = raw_stripe_invoice_data
     item_dict = {
         f"from_customer_table:{customer_data['description']}": customer_data,
         f"from_subscription_table:{subscription_data['id']}": subscription_data,
@@ -212,9 +225,11 @@ def test_api_post_stripe_from_pubsub_none_without_exceptions(
     assert resp.json() == {"status": "OK", "count": 0}
 
 
-def test_api_post_stripe_from_pubsub_customer_missing_data(dbsession, pubsub_client):
+def test_api_post_stripe_from_pubsub_customer_missing_data(
+    dbsession, pubsub_client, raw_stripe_customer_data
+):
     """Missing data from PubSub push is a 202, so it doesn't resend."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     del data["description"]  # The FxA ID
     resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 202  # Accepted
@@ -225,10 +240,11 @@ def test_api_post_stripe_from_pubsub_customer_missing_data(dbsession, pubsub_cli
     assert dbsession.query(PendingAcousticRecord).one_or_none() is None
 
 
-def test_api_post_stripe_from_pubsub_bad_data(dbsession, pubsub_client):
+def test_api_post_stripe_from_pubsub_bad_data(
+    dbsession, pubsub_client, raw_stripe_customer_data
+):
     """Bad data from PubSub push is a 202, so it doesn't resend."""
-    data = stripe_customer_data()
-    resp = pubsub_client.post("/stripe_from_pubsub", json=data)
+    resp = pubsub_client.post("/stripe_from_pubsub", json=raw_stripe_customer_data)
     assert resp.status_code == 202  # Accepted
     assert resp.json() == {
         "status": "Accepted but not processed",
@@ -236,10 +252,13 @@ def test_api_post_stripe_from_pubsub_bad_data(dbsession, pubsub_client):
     }
 
 
-def test_api_post_stripe_from_pubsub_list(dbsession, pubsub_client):
+def test_api_post_stripe_from_pubsub_list(
+    dbsession, pubsub_client, raw_stripe_customer_data
+):
     """A list from a PubSub push is a 202, accepted but not processed."""
-    customer_data = stripe_customer_data()
-    resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap([customer_data]))
+    resp = pubsub_client.post(
+        "/stripe_from_pubsub", json=pubsub_wrap([raw_stripe_customer_data])
+    )
     assert resp.status_code == 202
     assert resp.json() == {
         "status": "Accepted but not processed",
@@ -265,9 +284,11 @@ def test_api_post_pubsub_unknown_stripe_object(dbsession, pubsub_client):
     assert cap_logs[0]["ingest_actions"] == {"skipped": ["payment_method:pm_ABC123"]}
 
 
-def test_api_post_pubsub_trace_customer(dbsession, pubsub_client):
+def test_api_post_pubsub_trace_customer(
+    dbsession, pubsub_client, raw_stripe_customer_data
+):
     """Stripe customer data from PubSub can be traced via email."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     email = data["email"] = "customer+trace-me-mozilla-123@example.com"
     with capture_logs() as caplog:
         resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
@@ -279,9 +300,11 @@ def test_api_post_pubsub_trace_customer(dbsession, pubsub_client):
     assert caplog[0]["ingest_actions"] == {"created": [f"customer:{data['id']}"]}
 
 
-def test_api_post_pubsub_integrity_error_is_409(dbsession, pubsub_client):
+def test_api_post_pubsub_integrity_error_is_409(
+    dbsession, pubsub_client, raw_stripe_customer_data
+):
     """An integrity error is turned into a 409 Conflict"""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     err = IntegrityError(
         "INSERT INTO...", {"stripe_id": data["id"]}, "Duplicate key value"
     )
@@ -300,9 +323,11 @@ def test_api_post_pubsub_integrity_error_is_409(dbsession, pubsub_client):
     assert caplog[1]["status_code"] == 409
 
 
-def test_api_post_pubsub_deadlock_is_409(dbsession, pubsub_client):
+def test_api_post_pubsub_deadlock_is_409(
+    dbsession, pubsub_client, raw_stripe_customer_data
+):
     """A deadlock is turned into a 409 Conflict"""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     err = OperationalError("INSERT INTO...", {"stripe_id": data["id"]}, "Deadlock")
     with capture_logs() as caplog, mock.patch.object(
         dbsession, "commit", side_effect=err
@@ -320,10 +345,10 @@ def test_api_post_pubsub_deadlock_is_409(dbsession, pubsub_client):
 
 
 def test_api_post_pubsub_conflicting_fxa_id(
-    dbsession, pubsub_client, contact_with_stripe_customer
+    dbsession, pubsub_client, contact_with_stripe_customer, raw_stripe_customer_data
 ):
     """An existing customer with an FxA ID conflict is deleted."""
-    data = stripe_customer_data()
+    data = raw_stripe_customer_data
     old_id = data["id"]
     new_id = old_id + "_new"
     data["id"] = new_id


### PR DESCRIPTION
A follow-on of #628, in this PR, we move more data from `sample_data.py` to pytest fixtures in `conftest.py`, and use those fixtures in tests.

After this PR, there will be another that somehow moves `FAKE_STRIPE_ID` / `fake_stripe_id()` out of sample_data.py, then we can delete that module
