### PR TITLE
Fix #630: allow 'geo' field to be None or missing in waitlists

### DIFF
--- a/ctms/schemas/waitlist.py
+++ b/ctms/schemas/waitlist.py
@@ -107,7 +107,8 @@ def validate_waitlist_fields(name: str, fields: dict):
     if name == "relay":
 
         class RelayFieldsSchema(ComparableBase):
-            geo: str = Field(
+            geo: Optional[str] = Field(
+                default=None,
                 max_length=100,
                 description="Waitlist country",
                 example="fr",
@@ -121,7 +122,8 @@ def validate_waitlist_fields(name: str, fields: dict):
     elif name == "vpn":
 
         class VPNFieldsSchema(ComparableBase):
-            geo: str = Field(
+            geo: Optional[str] = Field(
+                default=None,
                 max_length=100,
                 description="Waitlist country",
                 example="fr",

--- a/tests/unit/test_api_get.py
+++ b/tests/unit/test_api_get.py
@@ -1,6 +1,7 @@
 """Unit tests for GET /ctms/{email_id}"""
 from uuid import uuid4
 
+import pytest
 from structlog.testing import capture_logs
 
 from ctms.models import Email
@@ -338,3 +339,15 @@ def test_get_ctms_with_tracing(client, dbsession):
     assert len(caplog) == 1
     assert caplog[0]["trace"] == email
     assert "trace_json" not in caplog[0]
+
+
+@pytest.mark.parametrize("waitlist_name", ["vpn", "relay"])
+def test_get_ctms_without_geo_in_waitlist(
+    waitlist_name, client, dbsession, waitlist_factory
+):
+    existing_waitlist = waitlist_factory(name=waitlist_name, fields={})
+    dbsession.flush()
+    email_id = existing_waitlist.email.email_id
+
+    resp = client.get(f"/ctms/{email_id}")
+    assert resp.status_code == 200

--- a/tests/unit/test_schema_waitlist.py
+++ b/tests/unit/test_schema_waitlist.py
@@ -42,12 +42,9 @@ def test_waitlist_with_invalid_input_data(data):
     "data",
     [
         # VPN
-        {"name": "vpn", "fields": {"geo": None}},
-        {"name": "vpn", "fields": {"platform": "linux"}},
         {"name": "vpn", "fields": {"geo": "b", "platform": "win64", "extra": "boom"}},
         # Relay
         {"name": "relay"},
-        {"name": "relay", "fields": {"geo": None}},
         {"name": "relay", "fields": {"geo": "fr", "extra": "boom"}},
         {"name": "relay", "fields": {"foo": "bar"}},
     ],

--- a/tests/unit/test_schema_waitlist.py
+++ b/tests/unit/test_schema_waitlist.py
@@ -44,7 +44,6 @@ def test_waitlist_with_invalid_input_data(data):
         # VPN
         {"name": "vpn", "fields": {"geo": "b", "platform": "win64", "extra": "boom"}},
         # Relay
-        {"name": "relay"},
         {"name": "relay", "fields": {"geo": "fr", "extra": "boom"}},
         {"name": "relay", "fields": {"foo": "bar"}},
     ],
@@ -58,12 +57,17 @@ def test_relay_and_vpn_waitlist_invalid_data(data):
     "data",
     [
         # VPN
-        {"name": "vpn", "fields": {"geo": "b"}},
+        {"name": "vpn"},
+        {"name": "vpn", "fields": {}},
+        {"name": "vpn", "fields": {"geo": None}},
         {"name": "vpn", "fields": {"geo": ""}},
+        {"name": "vpn", "fields": {"geo": "b"}},
         {"name": "vpn", "fields": {"geo": "b", "platform": ""}},
         {"name": "vpn", "fields": {"geo": "b", "platform": None}},
         {"name": "vpn", "fields": {"geo": "b", "platform": "win64"}},
         # Relay
+        {"name": "relay"},
+        {"name": "relay", "fields": {}},
         {"name": "relay", "fields": {"geo": "b"}},
         {"name": "relay", "fields": {"geo": ""}},
         {"name": "relay", "fields": {"geo": "b"}},


### PR DESCRIPTION
Restore the behavior we had prior to #470 