### PR TITLE
Create Stripe customer factories, use in tests

### DIFF
--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,0 +1,8 @@
+from base64 import b64encode
+from typing import Optional
+
+
+def fake_stripe_id(prefix: str, seed: str, suffix: Optional[str] = None) -> str:
+    """Create a fake Stripe ID for testing"""
+    body = b64encode(seed.encode()).decode().replace("=", "")
+    return f"{prefix}_{body}{suffix if suffix else ''}"

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,1 +1,1 @@
-from . import models
+from . import models, stripe

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -47,8 +47,8 @@ class FirefoxAccountFactory(BaseSQLAlchemyModelFactory):
     primary_email = factory.SelfAttribute("email.primary_email")
     created_date = factory.Faker("date")
     lang = factory.Faker("language_code")
-    first_service = factory.Faker("random_element", elements=["Firefox"])
-    account_deleted = factory.Faker("boolean", chance_of_getting_true=30)
+    first_service = None
+    account_deleted = False
 
     email = factory.SubFactory(factory="tests.factories.models.EmailFactory")
 

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -1,8 +1,12 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
 import factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from ctms import models
 from ctms.database import ScopedSessionLocal
+from tests.data import fake_stripe_id
 
 
 class BaseSQLAlchemyModelFactory(SQLAlchemyModelFactory):
@@ -35,6 +39,20 @@ class WaitlistFactory(BaseSQLAlchemyModelFactory):
     email = factory.SubFactory(factory="tests.factories.models.EmailFactory")
 
 
+class FirefoxAccountFactory(BaseSQLAlchemyModelFactory):
+    class Meta:
+        model = models.FirefoxAccount
+
+    fxa_id = factory.LazyFunction(lambda: uuid4().hex)
+    primary_email = factory.SelfAttribute("email.primary_email")
+    created_date = factory.Faker("date")
+    lang = factory.Faker("language_code")
+    first_service = factory.Faker("random_element", elements=["Firefox"])
+    account_deleted = factory.Faker("boolean", chance_of_getting_true=30)
+
+    email = factory.SubFactory(factory="tests.factories.models.EmailFactory")
+
+
 class EmailFactory(BaseSQLAlchemyModelFactory):
     class Meta:
         model = models.Email
@@ -58,9 +76,36 @@ class EmailFactory(BaseSQLAlchemyModelFactory):
             for _ in range(extracted):
                 NewsletterFactory(email=self, **kwargs)
 
+    @factory.post_generation
+    def fxa(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if extracted:
+            FirefoxAccountFactory(email=self, **kwargs)
+
+
+class StripeCustomerFactory(BaseSQLAlchemyModelFactory):
+    class Meta:
+        model = models.StripeCustomer
+
+    stripe_id = factory.LazyFunction(lambda: fake_stripe_id("cus", "customer"))
+    fxa_id = factory.SelfAttribute("fxa.fxa_id")
+    default_source_id = factory.LazyFunction(
+        lambda: fake_stripe_id("card", "default_payment")
+    )
+    invoice_settings_default_payment_method_id = factory.LazyFunction(
+        lambda: fake_stripe_id("pm", "default_payment")
+    )
+    stripe_created = factory.LazyFunction(lambda: datetime.now(timezone.utc))
+    deleted = False
+
+    fxa = factory.SubFactory(factory=FirefoxAccountFactory)
+
 
 __all__ = (
-    "NewsletterFactory",
     "EmailFactory",
+    "FirefoxAccountFactory",
+    "NewsletterFactory",
+    "StripeCustomerFactory",
     "WaitlistFactory",
 )

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -21,7 +21,7 @@ class NewsletterFactory(BaseSQLAlchemyModelFactory):
     lang = factory.Faker("language_code")
     source = factory.Faker("url")
 
-    email = factory.SubFactory(factory="tests.unit.factories.EmailFactory")
+    email = factory.SubFactory(factory="tests.factories.models.EmailFactory")
 
 
 class WaitlistFactory(BaseSQLAlchemyModelFactory):
@@ -32,7 +32,7 @@ class WaitlistFactory(BaseSQLAlchemyModelFactory):
     source = factory.Faker("url")
     fields = {}
 
-    email = factory.SubFactory(factory="tests.unit.factories.EmailFactory")
+    email = factory.SubFactory(factory="tests.factories.models.EmailFactory")
 
 
 class EmailFactory(BaseSQLAlchemyModelFactory):
@@ -62,4 +62,5 @@ class EmailFactory(BaseSQLAlchemyModelFactory):
 __all__ = (
     "NewsletterFactory",
     "EmailFactory",
+    "WaitlistFactory",
 )

--- a/tests/factories/stripe.py
+++ b/tests/factories/stripe.py
@@ -1,0 +1,39 @@
+from uuid import uuid4
+
+import factory
+
+from tests.data import fake_stripe_id
+
+
+class StripeCustomerDataFactory(factory.DictFactory):
+    class Params:
+        fxa_id = factory.LazyFunction(lambda: uuid4().hex)
+
+    id = factory.LazyFunction(lambda: fake_stripe_id("cus", "customer"))
+    object = "customer"
+    address = None
+    balance = 0
+    created = factory.Faker("unix_time")
+    currency = "usd"
+    default_source = None
+    delinquent = False
+    description = factory.LazyAttribute(lambda o: o.fxa_id)
+    discount = None
+    email = factory.Faker("email")
+    invoice_prefix = factory.Faker("bothify", text="###???###")
+    invoice_settings = {
+        "custom_fields": None,
+        "default_payment_method": fake_stripe_id("pm", "payment_method"),
+        "footer": None,
+    }
+    livemode = False
+    metadata = factory.Dict({"userid": factory.SelfAttribute("..description")})
+    name = factory.Faker("name")
+    next_invoice_sequence = factory.Faker("pyint")
+    phone = None
+    preferred_locales = []
+    shipping = None
+    tax_exempt = "none"
+
+
+__all__ = ("StripeCustomerDataFactory",)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,7 +51,7 @@ from ctms.schemas import (
     StripeSubscriptionItemCreateSchema,
 )
 
-from . import factories
+from tests import factories
 
 MY_FOLDER = os.path.dirname(__file__)
 TEST_FOLDER = os.path.dirname(MY_FOLDER)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -175,9 +175,13 @@ def dbsession(connection):
     transaction.rollback()
 
 
-register(factories.EmailFactory)
-register(factories.NewsletterFactory)
-register(factories.WaitlistFactory)
+# Database models
+register(factories.models.EmailFactory)
+register(factories.models.NewsletterFactory)
+register(factories.models.StripeCustomerFactory)
+register(factories.models.WaitlistFactory)
+# Stripe REST API payloads
+register(factories.stripe.StripeCustomerDataFactory)
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -50,8 +50,8 @@ from ctms.schemas import (
     StripeSubscriptionCreateSchema,
     StripeSubscriptionItemCreateSchema,
 )
-
 from tests import factories
+from tests.data import fake_stripe_id
 
 MY_FOLDER = os.path.dirname(__file__)
 TEST_FOLDER = os.path.dirname(MY_FOLDER)
@@ -68,13 +68,6 @@ SAMPLE_CONTACT_PARAMS = [
     ("simple_default_contact_data", {"amo"}),
     ("default_newsletter_contact_data", {"newsletters"}),
 ]
-
-
-def fake_stripe_id(prefix: str, seed: str, suffix: Optional[str] = None) -> str:
-    """Create a fake Stripe ID for testing"""
-    body = b64encode(seed.encode()).decode().replace("=", "")
-    return f"{prefix}_{body}{suffix if suffix else ''}"
-
 
 FAKE_STRIPE_CUSTOMER_ID = fake_stripe_id("cus", "customer")
 FAKE_STRIPE_INVOICE_ID = fake_stripe_id("in", "invoice")

--- a/tests/unit/test_api_stripe.py
+++ b/tests/unit/test_api_stripe.py
@@ -12,6 +12,7 @@ from structlog.testing import capture_logs
 from ctms.app import app, get_pubsub_claim
 from ctms.models import PendingAcousticRecord
 from tests.data import fake_stripe_id
+from tests.unit.conftest import FAKE_STRIPE_CUSTOMER_ID
 
 
 def pubsub_wrap(data):
@@ -57,10 +58,14 @@ def pubsub_client(anon_client):
 
 
 def test_api_post_stripe_customer(
-    client, dbsession, example_contact, raw_stripe_customer_data
+    client, dbsession, email_factory, stripe_customer_data_factory
 ):
     """Stripe customer data can be imported."""
-    data = raw_stripe_customer_data
+    email = email_factory(fxa=True)
+    dbsession.commit()
+    data = stripe_customer_data_factory(
+        email=email.primary_email, fxa_id=email.fxa.fxa_id
+    )
     resp = client.post("/stripe", json=data)
     assert resp.status_code == 200
     par = dbsession.query(PendingAcousticRecord).one_or_none()
@@ -68,10 +73,10 @@ def test_api_post_stripe_customer(
 
 
 def test_api_post_stripe_customer_without_contact(
-    client, dbsession, raw_stripe_customer_data
+    client, dbsession, stripe_customer_data_factory
 ):
     """Stripe customer data without a related contact can be imported."""
-    data = raw_stripe_customer_data
+    data = stripe_customer_data_factory()
     resp = client.post("/stripe", json=data)
     assert resp.status_code == 200
     par = dbsession.query(PendingAcousticRecord).one_or_none()
@@ -87,29 +92,30 @@ def test_api_post_stripe_customer_bad_data(client, dbsession):
     assert dbsession.query(PendingAcousticRecord).one_or_none() is None
 
 
-def test_api_post_stripe_customer_missing_data(
-    client, dbsession, raw_stripe_customer_data
-):
+def test_api_post_stripe_customer_missing_data(client, stripe_customer_data_factory):
     """Missing data from customer data is a 400 error."""
-    data = raw_stripe_customer_data
-    del data["description"]  # The FxA ID
-    resp = client.post("/stripe", json=data)
+    resp = client.post("/stripe", json=stripe_customer_data_factory(fxa_id=None))
     assert resp.status_code == 400
     assert resp.json() == {"detail": "Unable to process Stripe object."}
 
 
-def test_api_post_sample_data(dbsession, client, stripe_test_json):
+def test_api_post_sample_data(client, stripe_test_json):
     """Stripe sample data can be POSTed directly."""
     resp = client.post("/stripe", json=stripe_test_json)
     assert resp.status_code == 200
 
 
 def test_api_post_stripe_trace_customer(
-    client, dbsession, example_contact, raw_stripe_customer_data
+    client, dbsession, email_factory, stripe_customer_data_factory
 ):
     """Stripe customer data can be traced via email."""
-    data = raw_stripe_customer_data
-    email = data["email"] = "customer+trace-me-mozilla-123@example.com"
+    email = email_factory(
+        primary_email="customer+trace-me-mozilla-123@example.com", fxa=True
+    )
+    dbsession.commit()
+    data = stripe_customer_data_factory(
+        email=email.primary_email, fxa_id=email.fxa.fxa_id
+    )
     with capture_logs() as caplog:
         resp = client.post("/stripe", json=data)
     assert resp.status_code == 200
@@ -117,19 +123,20 @@ def test_api_post_stripe_trace_customer(
     assert par.email.stripe_customer.stripe_id == data["id"]
     assert len(caplog) == 1
     log = caplog[0]
-    assert log["trace"] == email
+    assert log["trace"] == data["email"]
     assert log["trace_json"] == data
     assert log["ingest_actions"] == {"created": [f"customer:{data['id']}"]}
 
 
 def test_api_post_conflicting_fxa_id(
-    dbsession, client, contact_with_stripe_customer, raw_stripe_customer_data
+    dbsession, client, stripe_customer_factory, stripe_customer_data_factory
 ):
     """An existing customer with an FxA ID conflict is deleted."""
-    data = raw_stripe_customer_data
-    old_id = data["id"]
-    new_id = old_id + "_new"
-    data["id"] = new_id
+    existing = stripe_customer_factory(stripe_id=fake_stripe_id("cus", "old"))
+    old_id = existing.stripe_id
+    dbsession.commit()
+    new_id = fake_stripe_id("cus", "new")
+    data = stripe_customer_data_factory(id=new_id, fxa_id=existing.fxa_id)
     with capture_logs() as caplog:
         resp = client.post("/stripe", json=data)
     assert resp.status_code == 200
@@ -143,7 +150,7 @@ def test_api_post_conflicting_fxa_id(
     assert log["fxa_id_conflict"] == data["description"]
 
 
-def test_api_post_deleted_new_customer(dbsession, client):
+def test_api_post_deleted_new_customer(client):
     """A new customer who starts out deleted is skipped."""
     stripe_id = fake_stripe_id("cus", "new_but_deleted")
     data = {"deleted": True, "id": stripe_id, "object": "customer"}
@@ -159,10 +166,14 @@ def test_api_post_deleted_new_customer(dbsession, client):
 
 
 def test_api_post_stripe_from_pubsub_customer(
-    dbsession, pubsub_client, example_contact, raw_stripe_customer_data
+    dbsession, pubsub_client, email_factory, stripe_customer_data_factory
 ):
     """Stripe customer data as a PubSub push can be imported."""
-    data = raw_stripe_customer_data
+    email = email_factory(fxa=True)
+    dbsession.commit()
+    data = stripe_customer_data_factory(
+        email=email.primary_email, fxa_id=email.fxa.fxa_id
+    )
     resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 1}
@@ -171,12 +182,11 @@ def test_api_post_stripe_from_pubsub_customer(
 
 
 def test_api_post_stripe_from_pubsub_without_contact(
-    pubsub_client, dbsession, raw_stripe_customer_data
+    pubsub_client, dbsession, stripe_customer_data_factory
 ):
     """Stripe customer data without a related contact can be imported from pubsub."""
-    resp = pubsub_client.post(
-        "/stripe_from_pubsub", json=pubsub_wrap(raw_stripe_customer_data)
-    )
+    data = stripe_customer_data_factory()
+    resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 1}
     par = dbsession.query(PendingAcousticRecord).one_or_none()
@@ -187,12 +197,14 @@ def test_api_post_stripe_from_pubsub_item_dict(
     dbsession,
     pubsub_client,
     example_contact,
-    raw_stripe_customer_data,
+    stripe_customer_data_factory,
     raw_stripe_subscription_data,
     raw_stripe_invoice_data,
 ):
     """A PubSub push of multiple items, keyed by table:id, can be imported."""
-    customer_data = raw_stripe_customer_data
+    customer_data = stripe_customer_data_factory(
+        id=FAKE_STRIPE_CUSTOMER_ID, fxa_id=example_contact.fxa.fxa_id
+    )
     subscription_data = raw_stripe_subscription_data
     invoice_data = raw_stripe_invoice_data
     item_dict = {
@@ -207,30 +219,24 @@ def test_api_post_stripe_from_pubsub_item_dict(
     assert par.email.stripe_customer.stripe_id == customer_data["id"]
 
 
-def test_api_post_stripe_from_pubsub_none_without_exceptions(
-    dbsession, pubsub_client, example_contact
-):
+def test_api_post_stripe_from_pubsub_none_without_exceptions(pubsub_client):
     """A PubSub push of multiple items, keyed by table:id with no value associated."""
-    try:
-        item_dict = {
-            "from_customer_table:stripe_id": None,
-            "from_subscription_table:subscription_id": None,
-            "from_invoice_table:invoice_id": None,
-        }
-        resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(item_dict))
-    except Exception as e:  # pylint: disable=broad-except
-        assert False, e
+    item_dict = {
+        "from_customer_table:stripe_id": None,
+        "from_subscription_table:subscription_id": None,
+        "from_invoice_table:invoice_id": None,
+    }
+    resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(item_dict))
 
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 0}
 
 
 def test_api_post_stripe_from_pubsub_customer_missing_data(
-    dbsession, pubsub_client, raw_stripe_customer_data
+    dbsession, pubsub_client, stripe_customer_data_factory
 ):
     """Missing data from PubSub push is a 202, so it doesn't resend."""
-    data = raw_stripe_customer_data
-    del data["description"]  # The FxA ID
+    data = stripe_customer_data_factory(fxa_id=None)
     resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 202  # Accepted
     assert resp.json() == {
@@ -240,11 +246,9 @@ def test_api_post_stripe_from_pubsub_customer_missing_data(
     assert dbsession.query(PendingAcousticRecord).one_or_none() is None
 
 
-def test_api_post_stripe_from_pubsub_bad_data(
-    dbsession, pubsub_client, raw_stripe_customer_data
-):
+def test_api_post_stripe_from_pubsub_bad_data(pubsub_client):
     """Bad data from PubSub push is a 202, so it doesn't resend."""
-    resp = pubsub_client.post("/stripe_from_pubsub", json=raw_stripe_customer_data)
+    resp = pubsub_client.post("/stripe_from_pubsub", json={"foo": "bar"})
     assert resp.status_code == 202  # Accepted
     assert resp.json() == {
         "status": "Accepted but not processed",
@@ -252,13 +256,10 @@ def test_api_post_stripe_from_pubsub_bad_data(
     }
 
 
-def test_api_post_stripe_from_pubsub_list(
-    dbsession, pubsub_client, raw_stripe_customer_data
-):
+def test_api_post_stripe_from_pubsub_list(pubsub_client, stripe_customer_data_factory):
     """A list from a PubSub push is a 202, accepted but not processed."""
-    resp = pubsub_client.post(
-        "/stripe_from_pubsub", json=pubsub_wrap([raw_stripe_customer_data])
-    )
+    data = stripe_customer_data_factory()
+    resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap([data]))
     assert resp.status_code == 202
     assert resp.json() == {
         "status": "Accepted but not processed",
@@ -266,14 +267,14 @@ def test_api_post_stripe_from_pubsub_list(
     }
 
 
-def test_api_post_pubsub_sample_data(dbsession, pubsub_client, stripe_test_json):
+def test_api_post_pubsub_sample_data(pubsub_client, stripe_test_json):
     """Stripe sample data can be POSTed from PubSub."""
     resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(stripe_test_json))
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 1}
 
 
-def test_api_post_pubsub_unknown_stripe_object(dbsession, pubsub_client):
+def test_api_post_pubsub_unknown_stripe_object(pubsub_client):
     """An unknown Stripe object is silently ignored."""
     data = {"object": "payment_method", "id": "pm_ABC123"}
     with capture_logs() as cap_logs:
@@ -285,26 +286,33 @@ def test_api_post_pubsub_unknown_stripe_object(dbsession, pubsub_client):
 
 
 def test_api_post_pubsub_trace_customer(
-    dbsession, pubsub_client, raw_stripe_customer_data
+    dbsession, pubsub_client, email_factory, stripe_customer_data_factory
 ):
     """Stripe customer data from PubSub can be traced via email."""
-    data = raw_stripe_customer_data
-    email = data["email"] = "customer+trace-me-mozilla-123@example.com"
+    email = email_factory(
+        primary_email="customer+trace-me-mozilla-123@example.com", fxa=True
+    )
+    dbsession.commit()
+
+    data = stripe_customer_data_factory(
+        email=email.primary_email, fxa_id=email.fxa.fxa_id
+    )
     with capture_logs() as caplog:
         resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
+
     assert resp.status_code == 200
     assert resp.json() == {"status": "OK", "count": 1}
     assert len(caplog) == 1
-    assert caplog[0]["trace"] == email
+    assert caplog[0]["trace"] == email.primary_email
     assert caplog[0]["trace_json"] == data
     assert caplog[0]["ingest_actions"] == {"created": [f"customer:{data['id']}"]}
 
 
 def test_api_post_pubsub_integrity_error_is_409(
-    dbsession, pubsub_client, raw_stripe_customer_data
+    dbsession, pubsub_client, stripe_customer_data_factory
 ):
     """An integrity error is turned into a 409 Conflict"""
-    data = raw_stripe_customer_data
+    data = stripe_customer_data_factory()
     err = IntegrityError(
         "INSERT INTO...", {"stripe_id": data["id"]}, "Duplicate key value"
     )
@@ -324,10 +332,10 @@ def test_api_post_pubsub_integrity_error_is_409(
 
 
 def test_api_post_pubsub_deadlock_is_409(
-    dbsession, pubsub_client, raw_stripe_customer_data
+    dbsession, pubsub_client, stripe_customer_data_factory
 ):
     """A deadlock is turned into a 409 Conflict"""
-    data = raw_stripe_customer_data
+    data = stripe_customer_data_factory()
     err = OperationalError("INSERT INTO...", {"stripe_id": data["id"]}, "Deadlock")
     with capture_logs() as caplog, mock.patch.object(
         dbsession, "commit", side_effect=err
@@ -345,13 +353,14 @@ def test_api_post_pubsub_deadlock_is_409(
 
 
 def test_api_post_pubsub_conflicting_fxa_id(
-    dbsession, pubsub_client, contact_with_stripe_customer, raw_stripe_customer_data
+    dbsession, pubsub_client, stripe_customer_factory, stripe_customer_data_factory
 ):
     """An existing customer with an FxA ID conflict is deleted."""
-    data = raw_stripe_customer_data
-    old_id = data["id"]
-    new_id = old_id + "_new"
-    data["id"] = new_id
+    existing = stripe_customer_factory(stripe_id=fake_stripe_id("cus", "old"))
+    old_id = existing.stripe_id
+    dbsession.commit()
+    new_id = fake_stripe_id("cus", "new")
+    data = stripe_customer_data_factory(id=new_id, fxa_id=existing.fxa_id)
     with capture_logs() as caplog:
         resp = pubsub_client.post("/stripe_from_pubsub", json=pubsub_wrap(data))
     assert resp.status_code == 200

--- a/tests/unit/test_api_stripe.py
+++ b/tests/unit/test_api_stripe.py
@@ -11,7 +11,7 @@ from structlog.testing import capture_logs
 
 from ctms.app import app, get_pubsub_claim
 from ctms.models import PendingAcousticRecord
-from tests.unit.conftest import fake_stripe_id
+from tests.data import fake_stripe_id
 
 
 def pubsub_wrap(data):

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -59,7 +59,7 @@ from ctms.schemas import (
     StripeSubscriptionCreateSchema,
     StripeSubscriptionItemCreateSchema,
 )
-from tests.unit.conftest import fake_stripe_id
+from tests.data import fake_stripe_id
 
 # Treat all SQLAlchemy warnings as errors
 pytestmark = pytest.mark.filterwarnings("error::sqlalchemy.exc.SAWarning")

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -60,6 +60,7 @@ from ctms.schemas import (
     StripeSubscriptionItemCreateSchema,
 )
 from tests.data import fake_stripe_id
+from tests.unit.conftest import FAKE_STRIPE_CUSTOMER_ID
 
 # Treat all SQLAlchemy warnings as errors
 pytestmark = pytest.mark.filterwarnings("error::sqlalchemy.exc.SAWarning")
@@ -79,26 +80,19 @@ def test_get_email(dbsession, example_contact):
     assert sorted(waitlists_names) == waitlists_names
 
 
-def test_get_email_with_stripe_customer(
-    dbsession, stripe_customer_data, contact_with_stripe_customer
-):
-    """`stripe_customer_data` is used when building `contact_with_stripe_customer`"""
-    email_id = contact_with_stripe_customer.email.email_id
-    email = get_email(dbsession, email_id)
-    assert email.email_id == email_id
-    newsletter_names = [newsletter.name for newsletter in email.newsletters]
-    assert newsletter_names == ["firefox-welcome", "mozilla-welcome"]
-    assert sorted(newsletter_names) == newsletter_names
+def test_get_email_with_stripe_customer(dbsession, stripe_customer_factory):
+    stripe_customer = stripe_customer_factory()
+    dbsession.commit()
 
-    assert email.stripe_customer.stripe_id == stripe_customer_data["stripe_id"]
-    assert len(email.stripe_customer.subscriptions) == 0
+    email = get_email(dbsession, stripe_customer.email.email_id)
+    assert email.email_id == stripe_customer.email.email_id
+    assert email.stripe_customer.stripe_id == stripe_customer.stripe_id
 
 
 def test_get_email_with_stripe_subscription(
-    dbsession, contact_with_stripe_subscription, stripe_customer_data, stripe_price_data
+    dbsession, contact_with_stripe_subscription, stripe_price_data
 ):
-    """`stripe_customer_data` and `stripe_price_data` is used when building
-    `contact_with_stripe_subscription`"""
+    """`stripe_price_data` is used when building `contact_with_stripe_subscription`"""
     email_id = contact_with_stripe_subscription.email.email_id
     email = get_email(dbsession, email_id)
     assert email.email_id == email_id
@@ -107,7 +101,7 @@ def test_get_email_with_stripe_subscription(
     assert newsletter_names == ["firefox-welcome", "mozilla-welcome"]
     assert sorted(newsletter_names) == newsletter_names
 
-    assert email.stripe_customer.stripe_id == stripe_customer_data["stripe_id"]
+    assert email.stripe_customer.stripe_id == FAKE_STRIPE_CUSTOMER_ID
     assert len(email.stripe_customer.subscriptions) == 1
     assert len(email.stripe_customer.subscriptions[0].subscription_items) == 1
     assert (
@@ -371,10 +365,13 @@ def test_get_acoustic_record_no_stripe_customer(dbsession, example_contact):
 
 
 def test_get_acoustic_record_no_stripe_subscriptions(
-    dbsession, contact_with_stripe_customer
+    dbsession, stripe_customer_factory
 ):
     """A contact with no Stripe subscriptions has no subscriptions."""
-    email_id = contact_with_stripe_customer.email.email_id
+    stripe_customer = stripe_customer_factory()
+    dbsession.commit()
+
+    email_id = stripe_customer.email.email_id
     pending = PendingAcousticRecord(email_id=email_id)
     contact = get_acoustic_record_as_contact(dbsession, pending)
     assert not contact.products
@@ -773,23 +770,31 @@ def test_get_multiple_contacts_by_any_id(
         assert sorted(newsletter_names) == newsletter_names
 
 
-@pytest.mark.parametrize("with_lock", ("for_update", "no_lock"))
-@pytest.mark.parametrize("fxa_id_source", ("existing", "new"))
-def test_get_stripe_customer_by_fxa_id(
-    dbsession, contact_with_stripe_customer, fxa_id_source, with_lock
+@pytest.mark.parametrize("with_lock", (True, False))
+def test_get_stripe_customer_by_existing_fxa_id(
+    dbsession, with_lock, stripe_customer_factory
 ):
-    """A StripeCustomer can be fetched by fxa_id."""
-    if fxa_id_source == "existing":
-        fxa_id = contact_with_stripe_customer.fxa.fxa_id
-    else:
-        fxa_id = str(uuid4())
-    customer = get_stripe_customer_by_fxa_id(
-        dbsession, fxa_id, for_update=(with_lock == "for_update")
-    )
-    if fxa_id_source == "existing":
-        assert customer.fxa_id == fxa_id
-    else:
-        assert customer is None
+    """A StripeCustomer can be fetched by an existing fxa_id."""
+    stripe_customer = stripe_customer_factory()
+    dbsession.commit()
+
+    fxa_id = stripe_customer.fxa.fxa_id
+    customer = get_stripe_customer_by_fxa_id(dbsession, fxa_id, for_update=with_lock)
+    assert customer.fxa_id == fxa_id
+
+
+@pytest.mark.parametrize("with_lock", (True, False))
+def test_get_stripe_customer_by_nonexistent_fxa_id(
+    dbsession, with_lock, stripe_customer_factory
+):
+    """A StripeCustomer with a nonexistent fx_id should not exist."""
+    # So we know that there's at least some stripe customer data
+    stripe_customer_factory()
+    dbsession.commit()
+
+    fxa_id = str(uuid4().hex)
+    customer = get_stripe_customer_by_fxa_id(dbsession, fxa_id, for_update=with_lock)
+    assert customer is None
 
 
 @pytest.fixture()
@@ -797,7 +802,6 @@ def stripe_objects(
     dbsession,
     example_contact,
     maximal_contact,
-    stripe_customer_data,
     stripe_price_data,
     stripe_subscription_data,
     stripe_subscription_item_data,
@@ -842,11 +846,18 @@ def stripe_objects(
         objs.append(obj)
 
         # Create Customer data
-        cus_data = stripe_customer_data
-        cus_data["stripe_id"] = fake_stripe_id("cus", f"cus_{contact_idx}")
-        cus_data["fxa_id"] = contact.fxa.fxa_id
+        customer_stripe_id = fake_stripe_id("cus", f"cus_{contact_idx}")
         obj["customer"] = create_stripe_customer(
-            dbsession, StripeCustomerCreateSchema(**cus_data)
+            dbsession,
+            StripeCustomerCreateSchema(
+                stripe_id=customer_stripe_id,
+                stripe_created=datetime.now(timezone.utc),
+                fxa_id=contact.fxa.fxa_id,
+                default_source_id=None,
+                invoice_settings_default_payment_method_id=fake_stripe_id(
+                    "pm", "payment_method"
+                ),
+            ),
         )
 
         # Create Subscriptions / Invoices and related items
@@ -855,7 +866,7 @@ def stripe_objects(
             sub_data["stripe_id"] = fake_stripe_id(
                 "sub", f"cus_{contact_idx}_sub_{sub_inv_idx}"
             )
-            sub_data["stripe_customer_id"] = cus_data["stripe_id"]
+            sub_data["stripe_customer_id"] = customer_stripe_id
             sub_obj = {
                 "obj": create_stripe_subscription(
                     dbsession, StripeSubscriptionCreateSchema(**sub_data)
@@ -868,7 +879,7 @@ def stripe_objects(
             inv_data["stripe_id"] = fake_stripe_id(
                 "sub", f"cus_{contact_idx}_inv_{sub_inv_idx}"
             )
-            inv_data["stripe_customer_id"] = stripe_customer_data["stripe_id"]
+            inv_data["stripe_customer_id"] = customer_stripe_id
             inv_obj = {
                 "obj": create_stripe_invoice(
                     dbsession, StripeInvoiceCreateSchema(**inv_data)

--- a/tests/unit/test_ingest_stripe.py
+++ b/tests/unit/test_ingest_stripe.py
@@ -41,7 +41,8 @@ from ctms.schemas import (
     StripeSubscriptionCreateSchema,
     StripeSubscriptionItemCreateSchema,
 )
-from tests.unit.conftest import fake_stripe_id, unix_timestamp
+from tests.data import fake_stripe_id
+from tests.unit.conftest import unix_timestamp
 
 
 @pytest.fixture


### PR DESCRIPTION
Ref: #633 

Deletes these fixtures:
- `stripe_customer_data`
- `raw_stripe_customer_data`
- `contact_with_stripe_customer`

In favor of factory usage in tests