### PR TITLE
Adjust integration tests to Basket changes, fix bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ integration-test: .env setup $(INSTALL_STAMP)
 ifneq (1, ${MK_KEEP_DOCKER_UP})
 	# Due to https://github.com/docker/compose/issues/2791 we have to explicitly
 	# rm all running containers
-	${DOCKER_COMPOSE} down --remove-orphans
+	${DOCKER_COMPOSE} --profile integration-test down --remove-orphans
 endif
 
 .PHONY: update-secrets

--- a/ctms/backport_legacy_waitlists.py
+++ b/ctms/backport_legacy_waitlists.py
@@ -68,6 +68,7 @@ def format_legacy_vpn_relay_waitlist_input(
                 to_update.append(
                     WaitlistInSchema(
                         name="vpn",
+                        source=existing_waitlists["vpn"].source if has_vpn else None,
                         fields={"geo": parsed_vpn.geo, "platform": parsed_vpn.platform},
                     )
                 )
@@ -121,7 +122,9 @@ def format_legacy_vpn_relay_waitlist_input(
                     for waitlist in relay_waitlists:
                         to_update.append(
                             WaitlistInSchema(
-                                name=waitlist.name, fields={"geo": parsed_relay.geo}
+                                name=waitlist.name,
+                                source=waitlist.source,
+                                fields={"geo": parsed_relay.geo},
                             )
                         )
 

--- a/ctms/schemas/contact.py
+++ b/ctms/schemas/contact.py
@@ -244,7 +244,10 @@ class CTMSResponse(BaseModel):
                     geo=waitlist.fields.get("geo"),
                     platform=waitlist.fields.get("platform"),
                 )
-            if waitlist.name.startswith("relay"):
+            if (
+                waitlist.name.startswith("relay")
+                and kwargs["relay_waitlist"].geo is None
+            ):
                 kwargs["relay_waitlist"] = RelayWaitlistSchema(
                     geo=waitlist.fields.get("geo")
                 )

--- a/tests/integration/basket-db-init.sql
+++ b/tests/integration/basket-db-init.sql
@@ -11,7 +11,8 @@ INSERT IGNORE INTO news_newsletter (
     `private`,
     indent,
     firefox_confirm,
-    is_mofo
+    is_mofo,
+    is_waitlist
 ) VALUES (
     'relay-waitlist', -- slug
     'relay', -- title
@@ -25,7 +26,8 @@ INSERT IGNORE INTO news_newsletter (
     false, -- private
     false, -- indent
     false, -- firefox_confirm
-    false -- is_mofo
+    false, -- is_mofo
+    true -- is_waitlist
 );
 INSERT IGNORE INTO news_newsletter (
     slug,
@@ -40,7 +42,8 @@ INSERT IGNORE INTO news_newsletter (
     `private`,
     indent,
     firefox_confirm,
-    is_mofo
+    is_mofo,
+    is_waitlist
 ) VALUES (
     'relay-phone-masking-waitlist', -- slug
     'relay phone', -- title
@@ -54,7 +57,8 @@ INSERT IGNORE INTO news_newsletter (
     false, -- private
     false, -- indent
     false, -- firefox_confirm
-    false -- is_mofo
+    false, -- is_mofo
+    true -- is_waitlist
 );
 INSERT IGNORE INTO news_newsletter (
     slug,
@@ -69,7 +73,8 @@ INSERT IGNORE INTO news_newsletter (
     `private`,
     indent,
     firefox_confirm,
-    is_mofo
+    is_mofo,
+    is_waitlist
 ) VALUES (
     'relay-vpn-bundle-waitlist', -- slug
     'relay bundle', -- title
@@ -83,7 +88,8 @@ INSERT IGNORE INTO news_newsletter (
     false, -- private
     false, -- indent
     false, -- firefox_confirm
-    false -- is_mofo
+    false, -- is_mofo
+    true -- is_waitlist
 );
 INSERT IGNORE INTO news_newsletter (
     slug,
@@ -98,7 +104,8 @@ INSERT IGNORE INTO news_newsletter (
     `private`,
     indent,
     firefox_confirm,
-    is_mofo
+    is_mofo,
+    is_waitlist
 ) VALUES (
     'graceland-waitlist', -- slug
     'graceland', -- title
@@ -112,7 +119,8 @@ INSERT IGNORE INTO news_newsletter (
     false, -- private
     false, -- indent
     false, -- firefox_confirm
-    false -- is_mofo
+    false, -- is_mofo
+    true -- is_waitlist
 );
 INSERT IGNORE INTO news_newsletter (
     slug,
@@ -127,7 +135,8 @@ INSERT IGNORE INTO news_newsletter (
     `private`,
     indent,
     firefox_confirm,
-    is_mofo
+    is_mofo,
+    is_waitlist
 ) VALUES (
     'guardian-vpn-waitlist', -- slug
     'vpn', -- title
@@ -141,5 +150,6 @@ INSERT IGNORE INTO news_newsletter (
     false, -- private
     false, -- indent
     false, -- firefox_confirm
-    false -- is_mofo
+    false, -- is_mofo
+    true -- is_waitlist
 );

--- a/tests/integration/test_basket_waitlist_subscription.py
+++ b/tests/integration/test_basket_waitlist_subscription.py
@@ -246,6 +246,9 @@ def test_relay_waitlists(ctms_headers):
             },
         },
     ]
+    # If multiple `relay-` waitlists are present, the `geo` field of the
+    # first waitlist is set as the value of `relay_waitlist["geo"]`. This
+    # property is intended for legacy consumers
     assert contact_details["relay_waitlist"] == {
         "geo": "es",
     }


### PR DESCRIPTION
Adjusts some aspects of the integration tests so that they match the latest changes to basket.

There are still some issues with `to_vendor` (https://github.com/mozmeao/basket/issues/1012), so we'll need to add more test cases here when that's figured out so we can capture regressions.