### PR TITLE
Fix #647: fix bulk update for pending records

### DIFF
--- a/ctms/bin/acoustic.py
+++ b/ctms/bin/acoustic.py
@@ -193,8 +193,8 @@ def do_resync(
     print(f"Force resync of {resetted + len(to_resync)} contacts")
     if to_resync and (assume_yes or confirm("Continue?")):
         bulk_schedule_acoustic_records(dbsession, to_resync)
-        dbsession.commit()
-        print("Done.")
+    dbsession.commit()
+    print("Done.")
     return os.EX_OK
 
 

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -7,7 +7,7 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, cast
 
 from pydantic import UUID4
-from sqlalchemy import asc, or_, update
+from sqlalchemy import asc, or_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, joinedload, load_only, selectinload
 
@@ -381,8 +381,8 @@ def reset_retry_acoustic_records(db: Session):
         db.query(PendingAcousticRecord).filter(PendingAcousticRecord.retry > 0).all()
     )
     count = len(pending_records)
-    db.execute(
-        update(PendingAcousticRecord),
+    db.bulk_update_mappings(
+        PendingAcousticRecord,
         [{"id": record.id, "retry": 0} for record in (pending_records)],
     )
     return count

--- a/tests/unit/test_bin_acoustic_resync.py
+++ b/tests/unit/test_bin_acoustic_resync.py
@@ -32,7 +32,9 @@ def test_main_force_resync_by_email_list(dbsession, maximal_contact, tmpdir):
     assert len(dbsession.query(PendingAcousticRecord).all()) > 0
 
 
-def test_main_force_resync_by_reset_retry(dbsession, maximal_contact):
+def test_main_force_resync_by_reset_retry(dbsession, minimal_contact, maximal_contact):
+    record = PendingAcousticRecord(email_id=minimal_contact.email.email_id, retry=99)
+    dbsession.add(record)
     record = PendingAcousticRecord(email_id=maximal_contact.email.email_id, retry=99)
     dbsession.add(record)
     dbsession.flush()


### PR DESCRIPTION
With the previous code, the SQL query was `UPDATE pending_records SET id=X, retry=0`, without `WHERE` close. Leading to an integrity error when more than 1 pending record was updated.