### PR TITLE
Use validators for `CTMSResponse` intialization

### DIFF
--- a/ctms/schemas/contact.py
+++ b/ctms/schemas/contact.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Literal, Optional, Set, Union
 from uuid import UUID
 
-from pydantic import AnyUrl, BaseModel, Field, root_validator
+from pydantic import AnyUrl, BaseModel, Field, root_validator, validator
 
 from .addons import AddOnsInSchema, AddOnsSchema
 from .base import ComparableBase
@@ -226,6 +226,18 @@ class CTMSResponse(BaseModel):
     # Retro-compat fields
     vpn_waitlist: VpnWaitlistSchema
     relay_waitlist: RelayWaitlistSchema
+
+    @validator("amo", pre=True, always=True)
+    def set_default_amo(cls, value):  # pylint: disable=no-self-argument
+        return value or AddOnsSchema()
+
+    @validator("fxa", pre=True, always=True)
+    def set_default_fxa(cls, value):  # pylint: disable=no-self-argument
+        return value or FirefoxAccountsSchema()
+
+    @validator("mofo", pre=True, always=True)
+    def set_default_mofo(cls, value):  # pylint: disable=no-self-argument
+        return value or MozillaFoundationSchema()
 
     @root_validator(pre=True)
     def legacy_waitlists(cls, values):  # pylint: disable=no-self-argument

--- a/tests/unit/test_api_patch.py
+++ b/tests/unit/test_api_patch.py
@@ -63,18 +63,7 @@ def swap_bool(existing):
 def test_patch_one_new_value(client, contact_name, group_name, key, value, request):
     """PATCH can update a single value."""
     contact = request.getfixturevalue(contact_name)
-    # Add in defaults for unset groups, and convert Python values like
-    # datetimes to JSON strings
-    expected = json.loads(
-        CTMSResponse(
-            amo=contact.amo or AddOnsSchema(),
-            email=contact.email,
-            fxa=contact.fxa or FirefoxAccountsSchema(),
-            mofo=contact.mofo or MozillaFoundationSchema(),
-            newsletters=contact.newsletters or [],
-            waitlists=contact.waitlists or [],
-        ).json()
-    )
+    expected = json.loads(CTMSResponse(**contact.dict()).json())
     existing_value = expected[group_name][key]
 
     # Set dynamic test values
@@ -140,18 +129,7 @@ def test_patch_one_new_value(client, contact_name, group_name, key, value, reque
 def test_patch_to_default(client, maximal_contact, group_name, key):
     """PATCH can set a field to the default value."""
     email_id = maximal_contact.email.email_id
-    # Add in defaults for unset groups, and convert Python values like
-    # datetimes to JSON strings
-    expected = json.loads(
-        CTMSResponse(
-            amo=maximal_contact.amo or AddOnsSchema(),
-            email=maximal_contact.email,
-            fxa=maximal_contact.fxa or FirefoxAccountsSchema(),
-            mofo=maximal_contact.mofo or MozillaFoundationSchema(),
-            newsletters=maximal_contact.newsletters or [],
-            waitlists=maximal_contact.waitlists or [],
-        ).json()
-    )
+    expected = json.loads(CTMSResponse(**maximal_contact.dict()).json())
     existing_value = expected[group_name][key]
 
     # Load the default value from the schema


### PR DESCRIPTION
This PR adds `pydantic` `@validator` methods to provide defaults when initializing CTMSResponse models, instead of doing it inline.

It also uses a `root_validator` to initialize the legacy VPN waitlist fields. I don't necessarily prefer that method over using `__init__`, but it does feel like more of a standard pydantic pattern. 