### PR TITLE
Add Stripe Subscription model factories, start to use in tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -165,7 +165,7 @@
         "filename": "tests/unit/test_acoustic_service.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 21
       }
     ],
     "tests/unit/test_auth.py": [
@@ -194,5 +194,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-12T11:30:34Z"
+  "generated_at": "2023-05-03T14:29:22Z"
 }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,13 +25,9 @@ from ctms.config import Settings
 from ctms.crud import (
     create_api_client,
     create_contact,
-    create_stripe_price,
-    create_stripe_subscription,
-    create_stripe_subscription_item,
     get_all_acoustic_fields,
     get_all_acoustic_newsletters_mapping,
     get_amo_by_email_id,
-    get_contact_by_email_id,
     get_contacts_by_any_id,
     get_fxa_by_email_id,
     get_mofo_by_email_id,
@@ -39,13 +35,7 @@ from ctms.crud import (
     get_waitlists_by_email_id,
 )
 from ctms.database import ScopedSessionLocal, SessionLocal
-from ctms.schemas import (
-    ApiClientSchema,
-    ContactSchema,
-    StripePriceCreateSchema,
-    StripeSubscriptionCreateSchema,
-    StripeSubscriptionItemCreateSchema,
-)
+from ctms.schemas import ApiClientSchema, ContactSchema
 from tests import factories
 from tests.data import fake_stripe_id
 
@@ -859,34 +849,6 @@ def raw_stripe_invoice_data(
             ],
         },
     }
-
-
-@pytest.fixture
-def contact_with_stripe_subscription(
-    dbsession,
-    example_contact,
-    stripe_customer_factory,
-    stripe_price_data,
-    stripe_subscription_data,
-    stripe_subscription_item_data,
-):
-    stripe_customer = stripe_customer_factory(
-        stripe_id=FAKE_STRIPE_CUSTOMER_ID, fxa_id=example_contact.fxa.fxa_id
-    )
-    create_stripe_price(dbsession, StripePriceCreateSchema(**stripe_price_data))
-    create_stripe_subscription(
-        dbsession, StripeSubscriptionCreateSchema(**stripe_subscription_data)
-    )
-    create_stripe_subscription_item(
-        dbsession,
-        StripeSubscriptionItemCreateSchema(
-            **stripe_subscription_item_data,
-        ),
-    )
-    dbsession.commit()
-
-    contact = get_contact_by_email_id(dbsession, stripe_customer.email.email_id)
-    return ContactSchema(**contact)
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -175,6 +175,9 @@ def dbsession(connection):
 register(factories.models.EmailFactory)
 register(factories.models.NewsletterFactory)
 register(factories.models.StripeCustomerFactory)
+register(factories.models.StripePriceFactory)
+register(factories.models.StripeSubscriptionFactory)
+register(factories.models.StripeSubscriptionItemFactory)
 register(factories.models.WaitlistFactory)
 # Stripe REST API payloads
 register(factories.stripe.StripeCustomerDataFactory)

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -275,6 +275,7 @@ def test_get_contact_by_email_id_stripe_customer_no_subscriptions(
     dbsession.commit()
 
     contact = get_contact_by_email_id(dbsession, customer.get_email_id())
+    # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert contact.products == []
 
 
@@ -328,6 +329,7 @@ def test_get_contact_by_email_id_two_stripe_subscriptions(
 
     contact = get_contact_by_email_id(dbsession, customer.get_email_id())
     assert len(contact.products) == 2
+    # pylint: disable-next=unbalanced-tuple-unpacking
     product1, product2 = contact.products
     assert product1 != product2
 


### PR DESCRIPTION
Ref: #633

This PR creates factories for Stripe Subscription (model) objects and uses them in place of the `contact_with_stripe_subscription`. 

Follow-on PRs will:
- add Stripe Invoice-related model factories
- add Stripe REST object factories