### PR TITLE
Remove indirection in getting contacts

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -539,11 +539,11 @@ def create_ctms_contact(
     email_id = contact.email.email_id
     existing = get_contact_by_email_id(db, email_id)
     if existing:
-        email = existing["email"].primary_email
+        email = existing.email.primary_email
         if re_trace_email.match(email):
             request.state.log_context["trace"] = email
             request.state.log_context["trace_json"] = content_json
-        if ContactInSchema(**existing).idempotent_equal(contact):
+        if ContactInSchema(**existing.dict()).idempotent_equal(contact):
             response.headers["Location"] = f"/ctms/{email_id}"
             response.status_code = 200
             return get_ctms_response_or_404(db=db, email_id=email_id)

--- a/ctms/app.py
+++ b/ctms/app.py
@@ -46,8 +46,8 @@ from .crud import (
     get_api_client_by_id,
     get_bulk_contacts,
     get_contact_by_email_id,
+    get_contacts_by_any_id,
     get_email,
-    get_emails_by_any_id,
     schedule_acoustic_record,
     update_contact,
 )
@@ -188,48 +188,6 @@ def all_ids(
         "fxa_id": fxa_id,
         "fxa_primary_email": fxa_primary_email,
     }
-
-
-def get_contacts_by_ids(
-    db: Session,
-    email_id: Optional[UUID] = None,
-    primary_email: Optional[str] = None,
-    basket_token: Optional[UUID] = None,
-    sfdc_id: Optional[str] = None,
-    mofo_contact_id: Optional[str] = None,
-    mofo_email_id: Optional[str] = None,
-    amo_user_id: Optional[str] = None,
-    fxa_id: Optional[str] = None,
-    fxa_primary_email: Optional[str] = None,
-) -> List[ContactSchema]:
-    """Get contacts by any ID.
-
-    Callers are expected to set just one ID, but if multiple are set, a contact
-    must match all IDs.
-    """
-    rows = get_emails_by_any_id(
-        db,
-        email_id,
-        primary_email,
-        basket_token,
-        sfdc_id,
-        mofo_contact_id,
-        mofo_email_id,
-        amo_user_id,
-        fxa_id,
-        fxa_primary_email,
-    )
-    return [
-        ContactSchema(
-            amo=email.amo,
-            email=email,
-            fxa=email.fxa,
-            mofo=email.mofo,
-            newsletters=email.newsletters,
-            waitlists=email.waitlists,
-        )
-        for email in rows
-    ]
 
 
 def get_bulk_contacts_by_timestamp_or_4xx(
@@ -481,7 +439,7 @@ def read_ctms_by_any_id(
             f"No identifiers provided, at least one is needed: {', '.join(ids.keys())}"
         )
         raise HTTPException(status_code=400, detail=detail)
-    contacts = get_contacts_by_ids(db, **ids)
+    contacts = get_contacts_by_any_id(db, **ids)
     traced = set()
     for contact in contacts:
         email = contact.email.primary_email
@@ -683,7 +641,7 @@ def delete_contact_by_primary_email(
     api_client: ApiClientSchema = Depends(get_enabled_api_client),
 ):
     ids = all_ids(primary_email=primary_email.lower())
-    contacts = get_contacts_by_ids(db, **ids)
+    contacts = get_contacts_by_any_id(db, **ids)
 
     if not contacts:
         raise HTTPException(status_code=404, detail=f"email {primary_email} not found!")
@@ -749,7 +707,7 @@ def read_identities(
             f"No identifiers provided, at least one is needed: {', '.join(ids.keys())}"
         )
         raise HTTPException(status_code=400, detail=detail)
-    contacts = get_contacts_by_ids(db, **ids)
+    contacts = get_contacts_by_any_id(db, **ids)
     return [contact.as_identity_response() for contact in contacts]
 
 

--- a/ctms/crud.py
+++ b/ctms/crud.py
@@ -193,7 +193,7 @@ def get_contact_by_email_id(db: Session, email_id: UUID4) -> Optional[ContactSch
     )
 
 
-def get_emails_by_any_id(
+def get_contacts_by_any_id(
     db: Session,
     email_id: Optional[UUID4] = None,
     primary_email: Optional[str] = None,
@@ -204,9 +204,9 @@ def get_emails_by_any_id(
     amo_user_id: Optional[str] = None,
     fxa_id: Optional[str] = None,
     fxa_primary_email: Optional[str] = None,
-) -> List[Email]:
+) -> List[ContactSchema]:
     """
-    Get all the data for multiple contacts by IDs as a list of Email instances.
+    Get all the data for multiple contacts by ID as a list of Contacts.
 
     Newsletters are retrieved in batches of 500 email_ids, so it will be two
     queries for most calls.
@@ -251,52 +251,18 @@ def get_emails_by_any_id(
         statement = statement.join(Email.fxa).filter_by(
             fxa_primary_email_insensitive_comparator=fxa_primary_email
         )
-    return cast(List[Email], statement.all())
-
-
-def get_contacts_by_any_id(
-    db: Session,
-    email_id: Optional[UUID4] = None,
-    primary_email: Optional[str] = None,
-    basket_token: Optional[UUID4] = None,
-    sfdc_id: Optional[str] = None,
-    mofo_contact_id: Optional[str] = None,
-    mofo_email_id: Optional[str] = None,
-    amo_user_id: Optional[str] = None,
-    fxa_id: Optional[str] = None,
-    fxa_primary_email: Optional[str] = None,
-) -> List[Dict]:
-    """
-    Get all the data for multiple contacts by ID as a list of dicts.
-
-    Newsletters are retrieved in batches of 500 email_ids, so it will be two
-    queries for most calls.
-    """
-    emails = get_emails_by_any_id(
-        db,
-        email_id,
-        primary_email,
-        basket_token,
-        sfdc_id,
-        mofo_contact_id,
-        mofo_email_id,
-        amo_user_id,
-        fxa_id,
-        fxa_primary_email,
-    )
-    data = []
-    for email in emails:
-        data.append(
-            {
-                "amo": email.amo,
-                "email": email,
-                "fxa": email.fxa,
-                "mofo": email.mofo,
-                "newsletters": email.newsletters,
-                "waitlists": email.waitlists,
-            }
+    emails = cast(List[Email], statement.all())
+    return [
+        ContactSchema(
+            amo=email.amo,
+            email=email,
+            fxa=email.fxa,
+            mofo=email.mofo,
+            newsletters=email.newsletters,
+            waitlists=email.waitlists,
         )
-    return data
+        for email in emails
+    ]
 
 
 def _acoustic_sync_retry_query(db: Session):

--- a/ctms/sync.py
+++ b/ctms/sync.py
@@ -8,14 +8,13 @@ from ctms.acoustic_service import Acoustic, AcousticUploadError, CTMSToAcousticS
 from ctms.background_metrics import BackgroundMetricService
 from ctms.crud import (
     delete_acoustic_record,
-    get_acoustic_record_as_contact,
     get_all_acoustic_records_before,
     get_all_acoustic_records_count,
     get_all_acoustic_retries_count,
+    get_contact_by_email_id,
     retry_acoustic_record,
 )
 from ctms.models import AcousticField, AcousticNewsletterMapping, PendingAcousticRecord
-from ctms.schemas import ContactSchema
 
 
 class CTMSToAcousticSync:
@@ -65,9 +64,7 @@ class CTMSToAcousticSync:
         try:
             sync_error = None
             if self.is_acoustic_enabled:
-                contact: ContactSchema = get_acoustic_record_as_contact(
-                    db, pending_record
-                )
+                contact = get_contact_by_email_id(db, pending_record.email_id)
                 try:
                     self.ctms_to_acoustic.attempt_to_upload_ctms_contact(
                         contact, main_fields, newsletters_mapping

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -883,7 +883,7 @@ def contact_with_stripe_subscription(
     dbsession.commit()
 
     contact = get_contact_by_email_id(dbsession, stripe_customer.email.email_id)
-    return ContactSchema(**contact)
+    return contact
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -525,10 +525,7 @@ def post_contact(client, dbsession, request):
         assert resp.status_code == code, resp.text
         if check_redirect:
             assert resp.headers["location"] == f"/ctms/{sample.email.email_id}"
-        saved = [
-            ContactSchema(**c)
-            for c in get_contacts_by_any_id(dbsession, **query_fields)
-        ]
+        saved = get_contacts_by_any_id(dbsession, **query_fields)
         assert len(saved) == stored_contacts
 
         # Now make sure that we skip writing default models
@@ -612,10 +609,7 @@ def put_contact(client, dbsession, request):
         sample = modifier(sample)
         resp = client.put(f"/ctms/{sample.email.email_id}", sample.json())
         assert resp.status_code == code, resp.text
-        saved = [
-            ContactSchema(**c)
-            for c in get_contacts_by_any_id(dbsession, **query_fields)
-        ]
+        saved = get_contacts_by_any_id(dbsession, **query_fields)
         assert len(saved) == stored_contacts
 
         # Now make sure that we skip writing default models

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -33,7 +33,6 @@ from ctms.crud import (
     get_contacts_from_newsletter,
     get_contacts_from_waitlist,
     get_email,
-    get_emails_by_any_id,
     get_stripe_customer_by_fxa_id,
     get_stripe_subscription_by_stripe_id,
     retry_acoustic_record,
@@ -112,82 +111,6 @@ def test_get_email_with_stripe_subscription(
 def test_get_email_miss(dbsession):
     email = get_email(dbsession, str(uuid4()))
     assert email is None
-
-
-@pytest.mark.parametrize(
-    "alt_id_name,alt_id_value",
-    [
-        ("email_id", "67e52c77-950f-4f28-accb-bb3ea1a2c51a"),
-        ("primary_email", "mozilla-fan@example.com"),
-        ("amo_user_id", "123"),
-        ("basket_token", "d9ba6182-f5dd-4728-a477-2cc11bf62b69"),
-        ("fxa_id", "611b6788-2bba-42a6-98c9-9ce6eb9cbd34"),
-        ("fxa_primary_email", "fxa-firefox-fan@example.com"),
-        ("sfdc_id", "001A000001aMozFan"),
-        ("mofo_contact_id", "5e499cc0-eeb5-4f0e-aae6-a101721874b8"),
-        ("mofo_email_id", "195207d2-63f2-4c9f-b149-80e9c408477a"),
-    ],
-)
-def test_get_emails_by_any_id(dbsession, sample_contacts, alt_id_name, alt_id_value):
-    emails = get_emails_by_any_id(dbsession, **{alt_id_name: alt_id_value})
-    assert len(emails) == 1
-    newsletter_names = [newsletter.name for newsletter in emails[0].newsletters]
-    assert sorted(newsletter_names) == newsletter_names
-
-
-def test_get_emails_by_any_id_missing(dbsession):
-    emails = get_emails_by_any_id(dbsession, basket_token=str(uuid4()))
-    assert len(emails) == 0
-
-
-@pytest.mark.parametrize(
-    "alt_id_name,alt_id_value",
-    [
-        ("amo_user_id", "123"),
-        ("fxa_primary_email", "fxa-firefox-fan@example.com"),
-        ("sfdc_id", "001A000001aMozFan"),
-        ("mofo_contact_id", "5e499cc0-eeb5-4f0e-aae6-a101721874b8"),
-    ],
-)
-def test_get_multiple_emails_by_any_id(
-    dbsession, sample_contacts, alt_id_name, alt_id_value
-):
-    dupe_id = str(uuid4())
-    create_email(
-        dbsession,
-        EmailInSchema(
-            email_id=dupe_id,
-            primary_email="dupe@example.com",
-            basket_token=str(uuid4()),
-            sfdc_id=alt_id_value
-            if alt_id_name == "sfdc_id"
-            else "other_sdfc_alt_id_value",
-        ),
-    )
-    if alt_id_name == "amo_user_id":
-        create_amo(dbsession, dupe_id, AddOnsInSchema(user_id=alt_id_value))
-    if alt_id_name == "fxa_primary_email":
-        create_fxa(
-            dbsession, dupe_id, FirefoxAccountsInSchema(primary_email=alt_id_value)
-        )
-    if alt_id_name == "mofo_contact_id":
-        create_mofo(
-            dbsession,
-            dupe_id,
-            MozillaFoundationInSchema(
-                mofo_email_id=str(uuid4()), mofo_contact_id=alt_id_value
-            ),
-        )
-
-    create_newsletter(dbsession, dupe_id, NewsletterInSchema(name="zzz_sleepy_news"))
-    create_newsletter(dbsession, dupe_id, NewsletterInSchema(name="aaa_game_news"))
-    dbsession.flush()
-
-    emails = get_emails_by_any_id(dbsession, **{alt_id_name: alt_id_value})
-    assert len(emails) == 2
-    for email in emails:
-        newsletter_names = [newsletter.name for newsletter in email.newsletters]
-        assert sorted(newsletter_names) == newsletter_names
 
 
 def test_get_contact_by_email_id_found(dbsession, example_contact):
@@ -712,7 +635,7 @@ def test_get_bulk_contacts_none(dbsession):
 def test_get_contact_by_any_id(dbsession, sample_contacts, alt_id_name, alt_id_value):
     contacts = get_contacts_by_any_id(dbsession, **{alt_id_name: alt_id_value})
     assert len(contacts) == 1
-    newsletter_names = [nl.name for nl in contacts[0]["newsletters"]]
+    newsletter_names = [nl.name for nl in contacts[0].newsletters]
     assert sorted(newsletter_names) == newsletter_names
 
 
@@ -767,7 +690,7 @@ def test_get_multiple_contacts_by_any_id(
     contacts = get_contacts_by_any_id(dbsession, **{alt_id_name: alt_id_value})
     assert len(contacts) == 2
     for contact in contacts:
-        newsletter_names = [nl.name for nl in contact["newsletters"]]
+        newsletter_names = [nl.name for nl in contact.newsletters]
         assert sorted(newsletter_names) == newsletter_names
 
 


### PR DESCRIPTION
This PR tweaks the way we query for contacts by `email_id` or my multiple IDs. Now, `get_contacts_by_email_id` returns a `Contact` object directly, and we combine the various functions we had to query multiple contacts into one `get_contacts_by_any_id` function.