### PR TITLE
Add method to generate a `Contact` from an `Email`

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -155,14 +155,7 @@ def get_email_or_404(db: Session, email_id) -> Email:
 def get_contact_or_404(db: Session, email_id) -> ContactSchema:
     """Get a contact by email_ID, or raise a 404 exception."""
     email = get_email_or_404(db, email_id)
-    return ContactSchema(
-        amo=email.amo,
-        email=email,
-        fxa=email.fxa,
-        mofo=email.mofo,
-        newsletters=email.newsletters,
-        waitlists=email.waitlists,
-    )
+    return ContactSchema.from_email(email)
 
 
 def all_ids(


### PR DESCRIPTION
Adds a `ContactSchema.from_email` method so that we can consolidate that logic (that is, generating a `Contact` from an `Email` object) in one place.