### PR TITLE
Configure Dependabot to check root dir for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
We moved Dockerfiles to the root directory in b037a13, so we're updating the Dependabot config accordingly