### PR TITLE
Migrate integration tests to MariaDB v11

### DIFF
--- a/bin/integration-test.sh
+++ b/bin/integration-test.sh
@@ -12,7 +12,7 @@ DOCKER_COMPOSE=${DOCKER_COMPOSE-"docker-compose"}
 export TZ=UTC
 
 # Create newsletters in basket
-cat tests/integration/basket-db-init.sql | $DOCKER_COMPOSE exec -T mysql mysql -u root -h mysql basket
+cat tests/integration/basket-db-init.sql | $DOCKER_COMPOSE exec -T mysql mariadb -u root -h mysql basket
 
 # Create token in CTMS (will only work with specific CTMS_SECRET, see .sql source)
 cat tests/integration/ctms-db-init.sql | $DOCKER_COMPOSE exec -T postgres psql --user postgres -d postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,7 +87,7 @@ services:
       retries: 10
   mysql:
     profiles: [integration-test]
-    image: mariadb:10.9.6
+    image: mariadb:10
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=basket

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,12 +87,12 @@ services:
       retries: 10
   mysql:
     profiles: [integration-test]
-    image: mariadb:10
+    image: mariadb
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=basket
     healthcheck:
-      test: mysql --user=root --password="" --execute "SHOW DATABASES;"
+      test: mariadb --user=root --password="" --execute "SHOW DATABASES;"
       interval: 3s
       timeout: 1s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,7 +87,7 @@ services:
       retries: 10
   mysql:
     profiles: [integration-test]
-    image: mariadb
+    image: mariadb:10.9.6
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=basket


### PR DESCRIPTION
Our integration tests started to fail 6 days ago.

mariadb v11 was released and we were using `:latest`. Pinning to v10 fixes the tests.

The upgrade notes don't seem to mention anything relevant https://mariadb.com/kb/en/upgrading-from-mariadb-10-11-to-mariadb-11-0/
But here it is mentionned that official images don't have the `mysql` alias anymore...
https://mariadb.com/kb/en/mariadb-11-0-1-release-notes/#docker-official-images