### PR TITLE
Fix #611, Ref #708: fix Acoustic newsletters subscription timestamps

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -240,14 +240,12 @@ class CTMSToAcousticService:
             }
 
             if newsletter.name in newsletters_mapping:
-                newsletter_dict = newsletter.dict()
-                _today = datetime.date.today().isoformat()
-                newsletter_template["create_timestamp"] = newsletter_dict.get(
-                    "create_timestamp", _today
-                )
-                newsletter_template["update_timestamp"] = newsletter_dict.get(
-                    "update_timestamp", _today
-                )
+                newsletter_template[
+                    "create_timestamp"
+                ] = newsletter.create_timestamp.date().isoformat()
+                newsletter_template[
+                    "update_timestamp"
+                ] = newsletter.update_timestamp.date().isoformat()
                 newsletter_template["newsletter_name"] = newsletter.name
                 newsletter_template["newsletter_unsub_reason"] = newsletter.unsub_reason
                 _source = newsletter.source

--- a/ctms/schemas/newsletter.py
+++ b/ctms/schemas/newsletter.py
@@ -1,9 +1,13 @@
 from datetime import datetime, timezone
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
-from pydantic import AnyUrl, Field
+from pydantic import UUID4, AnyUrl, Field
 
 from .base import ComparableBase
+from .email import EMAIL_ID_DESCRIPTION, EMAIL_ID_EXAMPLE
+
+if TYPE_CHECKING:
+    from ctms.models import Newsletter
 
 
 class NewsletterBase(ComparableBase):
@@ -44,6 +48,38 @@ class NewsletterBase(ComparableBase):
 # No need to change anything, just extend if you want to
 NewsletterInSchema = NewsletterBase
 NewsletterSchema = NewsletterBase
+
+
+class NewsletterTableSchema(NewsletterBase):
+    email_id: UUID4 = Field(
+        description=EMAIL_ID_DESCRIPTION,
+        example=EMAIL_ID_EXAMPLE,
+    )
+    create_timestamp: datetime = Field(
+        description="Newsletter data creation timestamp",
+        example="2020-12-05T19:21:50.908000+00:00",
+    )
+    update_timestamp: datetime = Field(
+        description="Newsletter data update timestamp",
+        example="2021-02-04T15:36:57.511000+00:00",
+    )
+
+    @classmethod
+    def from_newsletter(cls, newsletter: "Newsletter") -> "NewsletterTableSchema":
+        return cls(
+            email_id=newsletter.email_id,
+            name=newsletter.name,
+            subscribed=newsletter.subscribed,
+            format=newsletter.format,
+            lang=newsletter.lang,
+            source=newsletter.source,
+            unsub_reason=newsletter.unsub_reason,
+            create_timestamp=newsletter.create_timestamp,
+            update_timestamp=newsletter.update_timestamp,
+        )
+
+    class Config:
+        extra = "forbid"
 
 
 class UpdatedNewsletterInSchema(NewsletterInSchema):

--- a/ctms/schemas/waitlist.py
+++ b/ctms/schemas/waitlist.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timezone
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import UUID4, AnyUrl, Field, root_validator
 
 from .base import ComparableBase
 from .email import EMAIL_ID_DESCRIPTION, EMAIL_ID_EXAMPLE
+
+if TYPE_CHECKING:
+    from ctms.models import Waitlist
 
 
 class WaitlistBase(ComparableBase):
@@ -94,6 +97,17 @@ class WaitlistTableSchema(WaitlistBase):
         description="Waitlist data update timestamp",
         example="2021-02-04T15:36:57.511000+00:00",
     )
+
+    @classmethod
+    def from_waitlist(cls, waitlist: "Waitlist") -> "WaitlistTableSchema":
+        return cls(
+            email_id=waitlist.email_id,
+            name=waitlist.name,
+            source=waitlist.source,
+            fields=waitlist.fields,
+            create_timestamp=waitlist.create_timestamp,
+            update_timestamp=waitlist.update_timestamp,
+        )
 
     class Config:
         extra = "forbid"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,6 +28,7 @@ from ctms.crud import (
     get_all_acoustic_fields,
     get_all_acoustic_newsletters_mapping,
     get_amo_by_email_id,
+    get_contact_by_email_id,
     get_contacts_by_any_id,
     get_fxa_by_email_id,
     get_mofo_by_email_id,
@@ -218,7 +219,7 @@ def minimal_contact(minimal_contact_data, dbsession):
         get_metrics(),
     )
     dbsession.commit()
-    return minimal_contact_data
+    return get_contact_by_email_id(dbsession, minimal_contact_data.email.email_id)
 
 
 @pytest.fixture
@@ -325,7 +326,7 @@ def maximal_contact(dbsession, maximal_contact_data):
         get_metrics(),
     )
     dbsession.commit()
-    return maximal_contact_data
+    return get_contact_by_email_id(dbsession, maximal_contact_data.email.email_id)
 
 
 @pytest.fixture
@@ -353,7 +354,7 @@ def example_contact(dbsession, example_contact_data):
         get_metrics(),
     )
     dbsession.commit()
-    return example_contact_data
+    return get_contact_by_email_id(dbsession, example_contact_data.email.email_id)
 
 
 @pytest.fixture

--- a/tests/unit/test_api_patch.py
+++ b/tests/unit/test_api_patch.py
@@ -1,5 +1,6 @@
 """Tests for PATCH /ctms/{email_id}"""
 import json
+from operator import itemgetter
 from uuid import uuid4
 
 import pytest
@@ -69,14 +70,20 @@ def test_patch_one_new_value(client, contact_name, group_name, key, value, reque
     """PATCH can update a single value."""
     contact = request.getfixturevalue(contact_name)
     expected = json.loads(CTMSResponse(**contact.dict()).json())
-    expected["newsletters"] = [
-        omit_keys(nl, "email_id", "create_timestamp", "update_timestamp")
-        for nl in expected["newsletters"]
-    ]
-    expected["waitlists"] = [
-        omit_keys(nl, "email_id", "create_timestamp", "update_timestamp")
-        for nl in expected["waitlists"]
-    ]
+    expected["newsletters"] = sorted(
+        [
+            omit_keys(nl, "email_id", "create_timestamp", "update_timestamp")
+            for nl in expected["newsletters"]
+        ],
+        key=itemgetter("name"),
+    )
+    expected["waitlists"] = sorted(
+        [
+            omit_keys(nl, "email_id", "create_timestamp", "update_timestamp")
+            for nl in expected["waitlists"]
+        ],
+        key=itemgetter("name"),
+    )
     existing_value = expected[group_name][key]
 
     # Set dynamic test values

--- a/tests/unit/test_bulk.py
+++ b/tests/unit/test_bulk.py
@@ -109,6 +109,18 @@ def test_get_ctms_bulk_by_timerange(
     assert "items" in results
     assert len(results["items"]) > 0
     dict_contact_expected = sorted_list[1].dict()
+    # Since the contact data contains more info than the response, let's strip fields
+    # to be able to compare dict down the line (sic).
+    omit_fields = ("email_id", "create_timestamp", "update_timestamp")
+    dict_contact_expected["newsletters"] = [
+        {k: v for k, v in nl.items() if k not in omit_fields}
+        for nl in dict_contact_expected["newsletters"]
+    ]
+    dict_contact_expected["waitlists"] = [
+        {k: v for k, v in wl.items() if k not in omit_fields}
+        for wl in dict_contact_expected["waitlists"]
+    ]
+
     dict_contact_actual = CTMSResponse.parse_obj(results["items"][0]).dict()
     # products list is not (yet) in output schema
     assert dict_contact_expected["products"] == []

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -453,9 +453,10 @@ def test_get_bulk_contacts_some_after_higher_limit(
         limit=2,
         after_email_id=after_id,
     )
-    assert len(bulk_contact_list) == 2
-    assert last_contact in bulk_contact_list
-    assert sorted_list[-2] in bulk_contact_list
+    bulk_contact_list_ids = [c.email.email_id for c in bulk_contact_list]
+    assert len(bulk_contact_list_ids) == 2
+    assert last_contact.email.email_id in bulk_contact_list_ids
+    assert sorted_list[-2].email.email_id in bulk_contact_list_ids
 
 
 def test_get_bulk_contacts_some_after(
@@ -482,7 +483,7 @@ def test_get_bulk_contacts_some_after(
         after_email_id=after_id,
     )
     assert len(bulk_contact_list) == 1
-    assert last_contact in bulk_contact_list
+    assert bulk_contact_list[0].email.email_id == last_contact.email.email_id
 
 
 def test_get_bulk_contacts_some(
@@ -502,9 +503,10 @@ def test_get_bulk_contacts_some(
         limit=10,
     )
     assert len(bulk_contact_list) >= 3
-    assert example_contact in bulk_contact_list
-    assert maximal_contact in bulk_contact_list
-    assert minimal_contact in bulk_contact_list
+    bulk_contact_list_ids = [c.email.email_id for c in bulk_contact_list]
+    assert example_contact.email.email_id in bulk_contact_list_ids
+    assert maximal_contact.email.email_id in bulk_contact_list_ids
+    assert minimal_contact.email.email_id in bulk_contact_list_ids
 
 
 def test_get_bulk_contacts_one(dbsession, example_contact):


### PR DESCRIPTION
Fix #611, Ref #708

In this pull-request, I fix a piece of code that never worked: the newsletter subscription timestamps sent to Acoustic were never read from the database.

Basically schemas do not read thetimestamps fields from the DB. This could be a possible fix, but my confidence in its elegance is kind of low.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2ExcmE5MHJjOG1tOWEwNzlub2YzOHRpd3dyOHhsZ29xaGpsZDJwZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/bqVVk1mOjQhig/giphy.gif)

This codebase has a really dark power of demotivation. Especially if you ever worked with tools like Django Rest Framework.

Plus, most test case assertions are not designed in a flexible way.