### PR TITLE
Allow for more testing flexibility for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,7 @@ start: .env
 
 .PHONY: test
 test: .env $(INSTALL_STAMP)
-	${DOCKER_COMPOSE} up --wait postgres
-	bin/test.sh
-ifneq (1, ${MK_KEEP_DOCKER_UP})
-	# Due to https://github.com/docker/compose/issues/2791 we have to explicitly
-	# rm all running containers
-	${DOCKER_COMPOSE} down
-endif
+	COVERAGE_REPORT=1 bin/test.sh
 
 .PHONY: integration-test
 integration-test: .env setup $(INSTALL_STAMP)

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+DOCKER_COMPOSE=${DOCKER_COMPOSE:-"docker-compose"}
 POETRY_RUN="poetry run"
 
 CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
@@ -10,6 +11,18 @@ BASE_DIR="$(dirname "$CURRENT_DIR")"
 # without this, some tests fail because of off-by-timezone errors.
 export TZ=UTC
 
-$POETRY_RUN coverage run --rcfile "${BASE_DIR}/pyproject.toml" -m pytest
-$POETRY_RUN coverage report --rcfile "${BASE_DIR}/pyproject.toml" -m --fail-under 80
-$POETRY_RUN coverage html --rcfile "${BASE_DIR}/pyproject.toml"
+${DOCKER_COMPOSE} up --wait postgres
+
+$POETRY_RUN coverage run --rcfile "${BASE_DIR}/pyproject.toml" -m pytest $@
+
+if [[ -z "${COVERAGE_REPORT-x}" ]]; then
+    $POETRY_RUN coverage report --rcfile "${BASE_DIR}/pyproject.toml" -m --fail-under 80
+    $POETRY_RUN coverage html --rcfile "${BASE_DIR}/pyproject.toml"
+fi
+
+
+if [[ -z "${MK_KEEP_DOCKER_UP-x}" ]]; then
+    # Due to https://github.com/docker/compose/issues/2791 we have to explicitly
+    # rm all running containers
+    ${DOCKER_COMPOSE} down
+fi


### PR DESCRIPTION
Move all logic required for running the test suite into the `bin/test.sh` script so that we have more flexibility for how we run the tests.

We can still run `make test`, which will run all of the tests and produce a coverage report like before. But now, we can _also_ run `bin/test.sh` to optionally enable the coverage report and supply `pytest` args for more flexibility in how we run the test suite for local development, e.g. `bin/test.sh -k "test_module"`