### PR TITLE
Fix database migration history

### DIFF
--- a/migrations/versions/20230629_5bfd08b53489_create_update_timestamp_mixin.py
+++ b/migrations/versions/20230629_5bfd08b53489_create_update_timestamp_mixin.py
@@ -16,7 +16,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "5bfd08b53489"  # pragma: allowlist secret
-down_revision = "a016433d3e8b"  # pragma: allowlist secret
+down_revision = "2a0489304e03"  # pragma: allowlist secret
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Merging #707 after #723 led to multiple alembic heads. This fixes it.