### PR TITLE
Pin Basket to 2023-04-24

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - 8080:8080
   basket:
     profiles: [integration-test]
-    image: mozmeao/basket
+    image: mozmeao/basket:2023-04-24
     env_file:
       - ./tests/integration/basket.env
     command:


### PR DESCRIPTION
In https://github.com/mozmeao/basket/pull/1069 Basket tasks were transitionned to rq

This pins Basket to its previous version until we figure out how to migrate our integration test setup.