### PR TITLE
Use timestamps instead of dates in Acoustic records

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -68,12 +68,9 @@ def force_bytes(s, encoding="utf-8", strings_only=False, errors="strict"):
 def transform_field_for_acoustic(data):
     """Transform data type for Acoustic."""
     if isinstance(data, bool):
-        if data:
-            return "Yes"
-        return "No"
+        return "Yes" if data else "No"
     if isinstance(data, datetime.datetime):
-        # Acoustic doesn't have timestamps, so make timestamps into dates.
-        data = data.date()
+        return data.strftime("%m/%d/%Y %H:%M:%S")
     if isinstance(data, datetime.date):
         return data.strftime("%m/%d/%Y")
     if isinstance(data, UUID):
@@ -381,19 +378,12 @@ class CTMSToAcousticService:
 
         return waitlist_rows, acoustic_main_table
 
-    @staticmethod
-    def to_acoustic_timestamp(dt_val):
-        """Transform datetime for products relational table."""
-        if dt_val:
-            return dt_val.strftime("%m/%d/%Y %H:%M:%S")
-        return ""
-
     def _product_converter(self, contact):
         """Create the rows for the product subscription table in Acoustic."""
         contact_email_id = str(contact.email.email_id)
         product_rows = []
         template: Dict[str, str] = {"email_id": contact_email_id}
-        to_ts = CTMSToAcousticService.to_acoustic_timestamp
+        to_ts = transform_field_for_acoustic
         for product in contact.products:
             row: Dict[str, str] = template.copy()
             row.update(

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -7,7 +7,7 @@ import pytest
 from structlog.testing import capture_logs
 
 from ctms import acoustic_service
-from ctms.acoustic_service import CTMSToAcousticService, transform_field_for_acoustic
+from ctms.acoustic_service import transform_field_for_acoustic
 from ctms.crud import get_contact_by_email_id, get_newsletters_by_email_id
 from ctms.schemas.contact import ContactSchema
 
@@ -551,25 +551,13 @@ def test_ctms_to_acoustic_traced_email(
         ),
         (
             datetime.datetime(2021, 11, 8, 9, 6, tzinfo=datetime.timezone.utc),
-            "11/08/2021",
+            "11/08/2021 09:06:00",
         ),
         (datetime.date(2021, 11, 8), "11/08/2021"),
     ),
 )
 def test_transform_field_for_acoustic(value, expected):
     assert transform_field_for_acoustic(value) == expected
-
-
-def test_to_acoustic_timestamp():
-    """Python datetimes are converted to Acoustic timestamps."""
-    the_datetime = datetime.datetime(2021, 11, 8, 9, 6, tzinfo=datetime.timezone.utc)
-    acoustic_ts = CTMSToAcousticService.to_acoustic_timestamp(the_datetime)
-    assert acoustic_ts == "11/08/2021 09:06:00"
-
-
-def test_to_acoustic_timestamp_null():
-    """Null datetimes are converted to an empty string."""
-    assert CTMSToAcousticService.to_acoustic_timestamp(None) == ""
 
 
 def test_transform_fxa_created_date(base_ctms_acoustic_service):


### PR DESCRIPTION
This is a drive-by that I found out while working on #762
There were two contradictory code comments. 

From what I understand in the docs, the queries don't take the time part into account, but timestamps can be stored.
https://help.goacoustic.com/hc/en-us/articles/360043347833-Queries-and-time-stamp-fields

```
Timestamp | Allows date and time in format mm/dd/yyyy hh:mm:ss
```

**Update**

Trying to store a date in timestamp column fails actually:

https://mozilla.sentry.io/issues/4320526677/?referrer=slack&alert_rule_id=13795152&alert_type=issue

So this becomes a bug fix. 
