### PR TITLE
Remove notion of `trivial` logs

### DIFF
--- a/ctms/app.py
+++ b/ctms/app.py
@@ -60,12 +60,7 @@ async def log_request_middleware(request: Request, call_next):
         context = request.state.log_context
         if request.path_params:
             context["path_params"] = request.path_params
-        if "trivial_code" in context:
-            if status_code == context["trivial_code"]:
-                context["trivial"] = True
-            del context["trivial_code"]
-        if context["trivial"] is False:
-            del context["trivial"]
+
         log_line = get_log_line(request, status_code, context.get("client_id"))
         duration = time.monotonic() - start_time
         duration_s = round(duration, 3)

--- a/ctms/bin/acoustic_sync.py
+++ b/ctms/bin/acoustic_sync.py
@@ -57,9 +57,6 @@ def main(db, settings):
         else:
             to_sleep = settings.acoustic_loop_min_secs - duration_s
 
-        if context["count_total"] == 0:
-            context["trivial"] = True
-
         logger.info(
             "sync_service cycle complete",
             loop_duration_s=round(duration_s, 3),

--- a/ctms/log.py
+++ b/ctms/log.py
@@ -105,7 +105,6 @@ def context_from_request(request: Request) -> Dict:
     if request.client:
         host = request.client.host
     context: Dict[str, Any] = {
-        "trivial": False,  # For filtering in papertrail, place early in log
         "client_host": host,
         "method": request.method,
         "path": request.url.path,

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -163,9 +163,6 @@ traceback) are logged at ``ERROR`` level (Severity 3). Some of the fields are:
   requested.
 * ``trace``: An email matching the trace pattern, such as
   ``test+trace_me_mozilla_2021@example.com``
-* ``trivial``: `true` if a request is a monitoring request, such as
-  ``GET /__lbheartbeat__``. These can be excluded to focus on the "non-trivial"
-  requests.
 
 ### Acoustic Sync Process Logging Fields
 
@@ -197,7 +194,6 @@ type ``"ctms.bin.acoustic_sync"`` and these fields:
 * ``retry_backlog``: The number of contacts in the retry backlog, including those past the ``retry_limit``.
 * ``retry_limit``: The number of times to retry syncing a contact before giving up.
 * ``sync_backlog``: The number of contacts in the backlog before syncing.
-* ``trivial``: ``true`` if no contacts processed, omitted if some processed.
 
 For each contact, a log message at ``DEBUG`` level (Severity 7) is emitted, or
 at ``ERROR`` level (Severity 3) on exceptions, with type

--- a/tests/unit/bin/test_acoustic_sync.py
+++ b/tests/unit/bin/test_acoustic_sync.py
@@ -94,7 +94,6 @@ def test_main_no_contacts(dbsession, test_env):
         "retry_backlog": 0,
         "retry_limit": 6,
         "sync_backlog": 0,
-        "trivial": True,
     }
     assert loop_duration_s + loop_sleep_s == pytest.approx(5.0, 0.001)
     assert caplog[1]["event"] == "sync_service cycle complete"


### PR DESCRIPTION
in PR #210, we introduced the notion of "trivial" requests to allow us to more-quickly filter logs in Papertrail for logs that actually mattered. This was partially due to the fact that Papertrail had poor filtering capabilities.

Now, since we're using a better logging platform, we can remove this "trivial" flag for logs and use Google Cloud's superior filtering capabilities to do our filtering.