### PR TITLE
Fix #802: clarify sync behaviour of boolean fields for relations 

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -259,8 +259,10 @@ class CTMSToAcousticService:
                             )
                         # TODO: These are boolean values on our models, but in Acoustic
                         # they are configured as text values where we record `True`
-                        # and `False` as `1` and `0` respectively. We should
-                        # configure Acoustic to use a boolean column for this data.
+                        # and `False` as `1` and `0` respectively.
+                        # Note that `amo_*` and `fxa_*` fields are omitted when contact does not
+                        # have these relations.
+                        # We should configure Acoustic to use a boolean column for this data.
                         # This is being tracked in https://github.com/mozilla-it/ctms-api/issues/803
                         if acoustic_field_name in (
                             "double_opt_in",


### PR DESCRIPTION
In #804 we fixed the way boolean fields are synced on the main table. This PR is a complementary specification about the way boolean related to FxA and AMO are synced.