### PR TITLE
Fix #812: fix Acoustic create_timestamp column

### DIFF
--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -256,7 +256,7 @@ class CTMSToAcousticService:
                         # TODO: The create_timestamp is currently a Date field in Acoustic.
                         # Sending time information will prevent Acoustic to set the value properly.
                         # We should configure Acoustic to use a Timestamp for this data.
-                        # This is being tracked in https://github.com/mozilla-it/ctms-api/issues/803
+                        # This is being tracked in https://github.com/mozilla-it/ctms-api/issues/563
                         if acoustic_field_name == "create_timestamp":
                             inner_value = inner_value.date()
 

--- a/ctms/acoustic_service.py
+++ b/ctms/acoustic_service.py
@@ -253,6 +253,13 @@ class CTMSToAcousticService:
                         self.context["trace"] = inner_value
 
                     if acoustic_field_name in main_fields:
+                        # TODO: The create_timestamp is currently a Date field in Acoustic.
+                        # Sending time information will prevent Acoustic to set the value properly.
+                        # We should configure Acoustic to use a Timestamp for this data.
+                        # This is being tracked in https://github.com/mozilla-it/ctms-api/issues/803
+                        if acoustic_field_name == "create_timestamp":
+                            inner_value = inner_value.date()
+
                         if acoustic_field_name == "fxa_created_date":
                             inner_value = self.fxa_created_date_string_to_datetime(
                                 inner_value

--- a/tests/unit/test_acoustic_service.py
+++ b/tests/unit/test_acoustic_service.py
@@ -291,6 +291,9 @@ def test_ctms_to_acoustic_minimal_fields(
         waitlist_acoustic_fields,
         acoustic_newsletters_mapping,
     )
+    assert main[
+        "create_timestamp"
+    ] == minimal_contact.email.create_timestamp.date().strftime("%m/%d/%Y")
     assert main["email"] == minimal_contact.email.primary_email
     assert main["basket_token"] == str(minimal_contact.email.basket_token)
     assert main["mailing_country"] == minimal_contact.email.mailing_country


### PR DESCRIPTION
The regression introduced in https://github.com/mozilla-it/ctms-api/commit/4ee09507cc461bcf5e4538dd167203a8ac8fe43d was not spotted because no unit test was asserting the output format of the `create_timestamp` format.

Also, Acoustic was ignoring silently the value sent in the `create_timestamp` column instead of rejecting the row. 

Note that we could have expected that sending `"05/21/2021 16:39:02"` for a `Date` field would have been ok...