### PR TITLE
Fix #814: add timestamps to newsletters and waitlists in contact responses

### DIFF
--- a/ctms/schemas/contact.py
+++ b/ctms/schemas/contact.py
@@ -16,7 +16,12 @@ from .email import (
 )
 from .fxa import FirefoxAccountsInSchema, FirefoxAccountsSchema
 from .mofo import MozillaFoundationInSchema, MozillaFoundationSchema
-from .newsletter import NewsletterInSchema, NewsletterSchema, NewsletterTableSchema
+from .newsletter import (
+    NewsletterInSchema,
+    NewsletterSchema,
+    NewsletterTableSchema,
+    NewsletterTimestampedSchema,
+)
 from .product import ProductBaseSchema, ProductSegmentEnum
 from .waitlist import (
     RelayWaitlistInSchema,
@@ -26,6 +31,7 @@ from .waitlist import (
     WaitlistInSchema,
     WaitlistSchema,
     WaitlistTableSchema,
+    WaitlistTimestampedSchema,
     validate_waitlist_newsletters,
 )
 
@@ -360,8 +366,8 @@ class CTMSResponse(BaseModel):
     email: EmailSchema
     fxa: FirefoxAccountsSchema
     mofo: MozillaFoundationSchema
-    newsletters: List[NewsletterSchema]
-    waitlists: List[WaitlistSchema]
+    newsletters: List[NewsletterTimestampedSchema]
+    waitlists: List[WaitlistTimestampedSchema]
     # Retro-compat fields
     vpn_waitlist: VpnWaitlistSchema
     relay_waitlist: RelayWaitlistSchema

--- a/ctms/schemas/newsletter.py
+++ b/ctms/schemas/newsletter.py
@@ -50,11 +50,7 @@ NewsletterInSchema = NewsletterBase
 NewsletterSchema = NewsletterBase
 
 
-class NewsletterTableSchema(NewsletterBase):
-    email_id: UUID4 = Field(
-        description=EMAIL_ID_DESCRIPTION,
-        example=EMAIL_ID_EXAMPLE,
-    )
+class NewsletterTimestampedSchema(NewsletterBase):
     create_timestamp: datetime = Field(
         description="Newsletter data creation timestamp",
         example="2020-12-05T19:21:50.908000+00:00",
@@ -62,6 +58,13 @@ class NewsletterTableSchema(NewsletterBase):
     update_timestamp: datetime = Field(
         description="Newsletter data update timestamp",
         example="2021-02-04T15:36:57.511000+00:00",
+    )
+
+
+class NewsletterTableSchema(NewsletterTimestampedSchema):
+    email_id: UUID4 = Field(
+        description=EMAIL_ID_DESCRIPTION,
+        example=EMAIL_ID_EXAMPLE,
     )
 
     class Config:

--- a/ctms/schemas/waitlist.py
+++ b/ctms/schemas/waitlist.py
@@ -60,11 +60,7 @@ WaitlistSchema = WaitlistBase
 WaitlistInSchema = WaitlistBase
 
 
-class WaitlistTableSchema(WaitlistBase):
-    email_id: UUID4 = Field(
-        description=EMAIL_ID_DESCRIPTION,
-        example=EMAIL_ID_EXAMPLE,
-    )
+class WaitlistTimestampedSchema(WaitlistBase):
     create_timestamp: datetime = Field(
         description="Waitlist data creation timestamp",
         example="2020-12-05T19:21:50.908000+00:00",
@@ -72,6 +68,13 @@ class WaitlistTableSchema(WaitlistBase):
     update_timestamp: datetime = Field(
         description="Waitlist data update timestamp",
         example="2021-02-04T15:36:57.511000+00:00",
+    )
+
+
+class WaitlistTableSchema(WaitlistTimestampedSchema):
+    email_id: UUID4 = Field(
+        description=EMAIL_ID_DESCRIPTION,
+        example=EMAIL_ID_EXAMPLE,
     )
 
     class Config:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,19 +4,17 @@ Common test configuration both unit and integration tests.
 
 from datetime import datetime
 
-import pytest
 
-
-class Whatever:
+class FuzzyAssert:
     """
     This class is a testing helper that provides flexible equality
     of values.
 
     .. code-block::
 
-        >>> Whatever(lambda x: x.startswith("a")) == "abc"
+        >>> FuzzyAssert(lambda x: x.startswith("a")) == "abc"
         True
-        >>> Whatever(lambda x: x % 2 == 0) == 11
+        >>> FuzzyAssert(lambda x: x % 2 == 0) == 11
         False
 
     It is mainly used to make sure fields contain valid dates
@@ -24,9 +22,9 @@ class Whatever:
 
     .. code-block::
 
-        >>> Whatever.iso8601() == "2020-01-01"
+        >>> FuzzyAssert.iso8601() == "2020-01-01"
         True
-        >>> Whatever.iso8601() == None
+        >>> FuzzyAssert.iso8601() == None
         False
     """
 
@@ -52,8 +50,3 @@ class Whatever:
                 return False
 
         return cls(is_iso8601_date, name="datetime")
-
-
-@pytest.fixture
-def whatever():
-    return Whatever

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,28 @@ import pytest
 
 
 class Whatever:
+    """
+    This class is a testing helper that provides flexible equality
+    of values.
+
+    .. code-block::
+
+        >>> Whatever(lambda x: x.startswith("a")) == "abc"
+        True
+        >>> Whatever(lambda x: x % 2 == 0) == 11
+        False
+
+    It is mainly used to make sure fields contain valid dates
+    without having to hardcode values:
+
+    .. code-block::
+
+        >>> Whatever.iso8601() == "2020-01-01"
+        True
+        >>> Whatever.iso8601() == None
+        False
+    """
+
     def __init__(self, test=lambda x: True, name="unnamed"):
         self.test = test
         self.name = name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""
+Common test configuration both unit and integration tests.
+"""
+
+from datetime import datetime
+
+import pytest
+
+
+class Whatever:
+    def __init__(self, test=lambda x: True, name="unnamed"):
+        self.test = test
+        self.name = name
+
+    def __eq__(self, other):
+        return self.test(other)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}.{self.name}>"
+
+    @classmethod
+    def iso8601(cls):
+        def is_iso8601_date(sdate):
+            if not isinstance(sdate, str):
+                return False
+            try:
+                datetime.fromisoformat(sdate)
+                return True
+            except ValueError:
+                return False
+
+        return cls(is_iso8601_date, name="datetime")
+
+
+@pytest.fixture
+def whatever():
+    return Whatever

--- a/tests/integration/test_basket_waitlist_subscription.py
+++ b/tests/integration/test_basket_waitlist_subscription.py
@@ -7,6 +7,8 @@ import pytest
 import requests
 from pydantic import BaseSettings
 
+from tests.conftest import FuzzyAssert
+
 TEST_FOLDER = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -110,7 +112,7 @@ def test_connectivity(url):
     resp.raise_for_status()
 
 
-def test_vpn_waitlist(whatever, ctms_headers):
+def test_vpn_waitlist(ctms_headers):
     # 1. Subscribe a certain email to the `vpn` waitlist
     email = f"integration-test-{uuid4()}@restmail.net"
     vpn_waitlist_slug = "guardian-vpn-waitlist"
@@ -137,8 +139,8 @@ def test_vpn_waitlist(whatever, ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
     # Legacy (read-only) fields.
@@ -175,8 +177,8 @@ def test_vpn_waitlist(whatever, ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
     # Legacy (read-only) fields.
@@ -205,7 +207,7 @@ def test_vpn_waitlist(whatever, ctms_headers):
     check_updated()
 
 
-def test_relay_waitlists(whatever, ctms_headers):
+def test_relay_waitlists(ctms_headers):
     email = f"stage-test-{uuid4()}@restmail.net"
     relay_waitlist_slug = "relay-waitlist"
 
@@ -235,8 +237,8 @@ def test_relay_waitlists(whatever, ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
     # Legacy (read-only) fields.
@@ -271,8 +273,8 @@ def test_relay_waitlists(whatever, ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         },
         {
             "name": "relay-vpn-bundle",
@@ -282,8 +284,8 @@ def test_relay_waitlists(whatever, ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         },
     ]
     # Legacy (read-only) fields.
@@ -315,8 +317,8 @@ def test_relay_waitlists(whatever, ctms_headers):
             "source": "https://relay.firefox.com/",
             "subscribed": False,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         },
         {
             "name": "relay-vpn-bundle",
@@ -326,8 +328,8 @@ def test_relay_waitlists(whatever, ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         },
     ]
     # Legacy (read-only) fields.

--- a/tests/integration/test_basket_waitlist_subscription.py
+++ b/tests/integration/test_basket_waitlist_subscription.py
@@ -127,6 +127,8 @@ def test_vpn_waitlist(ctms_headers):
 
     contact_details = fetch_created()
     assert contact_details["newsletters"] == []
+    del contact_details["waitlists"][0]["create_timestamp"]
+    del contact_details["waitlists"][0]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "vpn",
@@ -163,6 +165,8 @@ def test_vpn_waitlist(ctms_headers):
     # Request the full contact details again.
     contact_details = ctms_fetch(email, ctms_headers)
     assert contact_details["newsletters"] == []
+    del contact_details["waitlists"][0]["create_timestamp"]
+    del contact_details["waitlists"][0]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "vpn",
@@ -222,6 +226,8 @@ def test_relay_waitlists(ctms_headers):
     contact_details = fetch_created()
 
     # 3. CTMS should show both formats (legacy `relay_waitlist` field, and entry in `waitlists` list)
+    del contact_details["waitlists"][0]["create_timestamp"]
+    del contact_details["waitlists"][0]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "relay",
@@ -256,6 +262,10 @@ def test_relay_waitlists(ctms_headers):
 
     contact_details = check_subscribed()
     assert contact_details["newsletters"] == []
+    del contact_details["waitlists"][0]["create_timestamp"]
+    del contact_details["waitlists"][0]["update_timestamp"]
+    del contact_details["waitlists"][1]["create_timestamp"]
+    del contact_details["waitlists"][1]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "relay",
@@ -298,6 +308,10 @@ def test_relay_waitlists(ctms_headers):
     contact_details = check_unsubscribed()
     # And only one newsletter subscribed.
     assert contact_details["newsletters"] == []
+    del contact_details["waitlists"][0]["create_timestamp"]
+    del contact_details["waitlists"][0]["update_timestamp"]
+    del contact_details["waitlists"][1]["create_timestamp"]
+    del contact_details["waitlists"][1]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "fields": {"geo": "es"},

--- a/tests/integration/test_basket_waitlist_subscription.py
+++ b/tests/integration/test_basket_waitlist_subscription.py
@@ -110,7 +110,7 @@ def test_connectivity(url):
     resp.raise_for_status()
 
 
-def test_vpn_waitlist(ctms_headers):
+def test_vpn_waitlist(whatever, ctms_headers):
     # 1. Subscribe a certain email to the `vpn` waitlist
     email = f"integration-test-{uuid4()}@restmail.net"
     vpn_waitlist_slug = "guardian-vpn-waitlist"
@@ -127,8 +127,6 @@ def test_vpn_waitlist(ctms_headers):
 
     contact_details = fetch_created()
     assert contact_details["newsletters"] == []
-    del contact_details["waitlists"][0]["create_timestamp"]
-    del contact_details["waitlists"][0]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "vpn",
@@ -139,6 +137,8 @@ def test_vpn_waitlist(ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
     # Legacy (read-only) fields.
@@ -165,8 +165,6 @@ def test_vpn_waitlist(ctms_headers):
     # Request the full contact details again.
     contact_details = ctms_fetch(email, ctms_headers)
     assert contact_details["newsletters"] == []
-    del contact_details["waitlists"][0]["create_timestamp"]
-    del contact_details["waitlists"][0]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "vpn",
@@ -177,6 +175,8 @@ def test_vpn_waitlist(ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
     # Legacy (read-only) fields.
@@ -205,7 +205,7 @@ def test_vpn_waitlist(ctms_headers):
     check_updated()
 
 
-def test_relay_waitlists(ctms_headers):
+def test_relay_waitlists(whatever, ctms_headers):
     email = f"stage-test-{uuid4()}@restmail.net"
     relay_waitlist_slug = "relay-waitlist"
 
@@ -226,8 +226,6 @@ def test_relay_waitlists(ctms_headers):
     contact_details = fetch_created()
 
     # 3. CTMS should show both formats (legacy `relay_waitlist` field, and entry in `waitlists` list)
-    del contact_details["waitlists"][0]["create_timestamp"]
-    del contact_details["waitlists"][0]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "relay",
@@ -237,6 +235,8 @@ def test_relay_waitlists(ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
     # Legacy (read-only) fields.
@@ -262,10 +262,6 @@ def test_relay_waitlists(ctms_headers):
 
     contact_details = check_subscribed()
     assert contact_details["newsletters"] == []
-    del contact_details["waitlists"][0]["create_timestamp"]
-    del contact_details["waitlists"][0]["update_timestamp"]
-    del contact_details["waitlists"][1]["create_timestamp"]
-    del contact_details["waitlists"][1]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "name": "relay",
@@ -275,6 +271,8 @@ def test_relay_waitlists(ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         },
         {
             "name": "relay-vpn-bundle",
@@ -284,6 +282,8 @@ def test_relay_waitlists(ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         },
     ]
     # Legacy (read-only) fields.
@@ -308,10 +308,6 @@ def test_relay_waitlists(ctms_headers):
     contact_details = check_unsubscribed()
     # And only one newsletter subscribed.
     assert contact_details["newsletters"] == []
-    del contact_details["waitlists"][0]["create_timestamp"]
-    del contact_details["waitlists"][0]["update_timestamp"]
-    del contact_details["waitlists"][1]["create_timestamp"]
-    del contact_details["waitlists"][1]["update_timestamp"]
     assert contact_details["waitlists"] == [
         {
             "fields": {"geo": "es"},
@@ -319,6 +315,8 @@ def test_relay_waitlists(ctms_headers):
             "source": "https://relay.firefox.com/",
             "subscribed": False,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         },
         {
             "name": "relay-vpn-bundle",
@@ -328,6 +326,8 @@ def test_relay_waitlists(ctms_headers):
             },
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         },
     ]
     # Legacy (read-only) fields.

--- a/tests/unit/routers/contacts/test_api_get.py
+++ b/tests/unit/routers/contacts/test_api_get.py
@@ -67,6 +67,8 @@ def test_get_ctms_for_minimal_contact(client, dbsession, email_factory):
                 "source": newsletter.source,
                 "subscribed": newsletter.subscribed,
                 "unsub_reason": newsletter.unsub_reason,
+                "create_timestamp": newsletter.create_timestamp.isoformat(),
+                "update_timestamp": newsletter.update_timestamp.isoformat(),
             }
         ],
         "status": "ok",
@@ -133,6 +135,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": "https://www.mozilla.org/en-US/contribute/studentambassadors/",
                 "subscribed": False,
                 "unsub_reason": "Graduated, don't have time for FSA",
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "format": "T",
@@ -141,6 +145,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": "https://commonvoice.mozilla.org/fr",
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "format": "H",
@@ -149,6 +155,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": "https://www.mozilla.org/fr/firefox/accounts/",
                 "subscribed": False,
                 "unsub_reason": "done with this mailing list",
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "format": "H",
@@ -157,6 +165,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "format": "H",
@@ -165,6 +175,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "format": "H",
@@ -173,6 +185,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "format": "H",
@@ -181,6 +195,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
         ],
         "status": "ok",
@@ -193,6 +209,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": "https://a-software.mozilla.org/",
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "fields": {"geo": "cn"},
@@ -200,6 +218,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "fields": {"geo": "fr", "platform": "win64"},
@@ -207,6 +227,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": "https://super-product.mozilla.org/",
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
             {
                 "fields": {"geo": "ca", "platform": "windows,android"},
@@ -214,6 +236,8 @@ def test_get_ctms_for_maximal_contact(client, maximal_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2010-01-01T08:04:00+00:00",
+                "update_timestamp": "2020-01-28T14:50:00+00:00",
             },
         ],
     }
@@ -277,6 +301,8 @@ def test_get_ctms_for_api_example(client, example_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2020-12-05T19:21:50.908000+00:00",
+                "update_timestamp": "2021-02-04T15:36:57.511000+00:00",
             },
             {
                 "format": "H",
@@ -285,6 +311,8 @@ def test_get_ctms_for_api_example(client, example_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2020-12-05T19:21:50.908000+00:00",
+                "update_timestamp": "2021-02-04T15:36:57.511000+00:00",
             },
         ],
         "status": "ok",
@@ -297,6 +325,8 @@ def test_get_ctms_for_api_example(client, example_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2020-12-05T19:21:50.908000+00:00",
+                "update_timestamp": "2021-02-04T15:36:57.511000+00:00",
             },
             {
                 "fields": {"geo": "fr"},
@@ -304,6 +334,8 @@ def test_get_ctms_for_api_example(client, example_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2020-12-05T19:21:50.908000+00:00",
+                "update_timestamp": "2021-02-04T15:36:57.511000+00:00",
             },
             {
                 "fields": {"geo": "fr", "platform": "ios,mac"},
@@ -311,6 +343,8 @@ def test_get_ctms_for_api_example(client, example_contact):
                 "source": None,
                 "subscribed": True,
                 "unsub_reason": None,
+                "create_timestamp": "2020-12-05T19:21:50.908000+00:00",
+                "update_timestamp": "2021-02-04T15:36:57.511000+00:00",
             },
         ],
     }

--- a/tests/unit/routers/contacts/test_api_patch.py
+++ b/tests/unit/routers/contacts/test_api_patch.py
@@ -289,7 +289,7 @@ def test_patch_error_on_id_conflict(
     }
 
 
-def test_patch_to_subscribe(client, maximal_contact):
+def test_patch_to_subscribe(whatever, client, maximal_contact):
     """PATCH can subscribe to a single newsletter."""
     email_id = maximal_contact.email.email_id
     patch_data = {"newsletters": [{"name": "zzz-newsletter"}]}
@@ -297,8 +297,6 @@ def test_patch_to_subscribe(client, maximal_contact):
     assert resp.status_code == 200
     actual = resp.json()
     assert len(actual["newsletters"]) == len(maximal_contact.newsletters) + 1
-    del actual["newsletters"][-1]["create_timestamp"]
-    del actual["newsletters"][-1]["update_timestamp"]
     assert actual["newsletters"][-1] == {
         "format": "H",
         "lang": "en",
@@ -306,6 +304,8 @@ def test_patch_to_subscribe(client, maximal_contact):
         "source": None,
         "subscribed": True,
         "unsub_reason": None,
+        "create_timestamp": whatever.iso8601(),
+        "update_timestamp": whatever.iso8601(),
     }
 
 
@@ -333,7 +333,7 @@ def test_patch_to_update_subscription(client, dbsession, newsletter_factory):
     }
 
 
-def test_patch_to_unsubscribe(client, maximal_contact):
+def test_patch_to_unsubscribe(whatever, client, maximal_contact):
     """PATCH can unsubscribe by setting a newsletter field."""
     email_id = maximal_contact.email.email_id
     existing_news_data = maximal_contact.newsletters[1].dict()
@@ -353,8 +353,6 @@ def test_patch_to_unsubscribe(client, maximal_contact):
     assert resp.status_code == 200
     actual = resp.json()
     assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
-    del actual["newsletters"][1]["create_timestamp"]
-    del actual["newsletters"][1]["update_timestamp"]
     assert actual["newsletters"][1] == {
         "format": "T",
         "lang": "fr",
@@ -362,6 +360,8 @@ def test_patch_to_unsubscribe(client, maximal_contact):
         "source": "https://commonvoice.mozilla.org/fr",
         "subscribed": False,
         "unsub_reason": "Too many emails.",
+        "create_timestamp": whatever.iso8601(),
+        "update_timestamp": whatever.iso8601(),
     }
 
 
@@ -458,7 +458,7 @@ def test_patch_will_validate_waitlist_fields(client, maximal_contact):
     assert details["detail"][0]["loc"] == ["body", "waitlists", 0, "source"]
 
 
-def test_patch_to_add_a_waitlist(client, maximal_contact):
+def test_patch_to_add_a_waitlist(whatever, client, maximal_contact):
     """PATCH can add a single waitlist."""
     email_id = maximal_contact.email.email_id
     patch_data = {"waitlists": [{"name": "future-tech", "fields": {"geo": "es"}}]}
@@ -468,14 +468,14 @@ def test_patch_to_add_a_waitlist(client, maximal_contact):
     new_waitlists = actual["waitlists"]
     assert len(new_waitlists) == len(maximal_contact.waitlists) + 1
     new_waitlist = next((wl for wl in new_waitlists if wl["name"] == "future-tech"))
-    del new_waitlist["create_timestamp"]
-    del new_waitlist["update_timestamp"]
     assert new_waitlist == {
         "name": "future-tech",
         "source": None,
         "fields": {"geo": "es"},
         "subscribed": True,
         "unsub_reason": None,
+        "create_timestamp": whatever.iso8601(),
+        "update_timestamp": whatever.iso8601(),
     }
 
 
@@ -549,14 +549,12 @@ def test_patch_preserves_waitlists_if_omitted(client, maximal_contact):
     assert len(actual["waitlists"]) == len(maximal_contact.waitlists)
 
 
-def test_patch_vpn_waitlist_legacy_add(client, minimal_contact):
+def test_patch_vpn_waitlist_legacy_add(whatever, client, minimal_contact):
     email_id = minimal_contact.email.email_id
     patch_data = {"vpn_waitlist": {"geo": "fr", "platform": "win32"}}
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 200
     actual = resp.json()
-    del actual["waitlists"][0]["create_timestamp"]
-    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "vpn",
@@ -567,6 +565,8 @@ def test_patch_vpn_waitlist_legacy_add(client, minimal_contact):
             },
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
 
@@ -593,7 +593,9 @@ def test_patch_vpn_waitlist_legacy_delete_default(client, maximal_contact):
     assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
 
 
-def test_patch_vpn_waitlist_legacy_update(client, dbsession, waitlist_factory):
+def test_patch_vpn_waitlist_legacy_update(
+    whatever, client, dbsession, waitlist_factory
+):
     vpn_waitlist = waitlist_factory(
         name="vpn",
         source="https://www.example.com/vpn_signup",
@@ -606,8 +608,6 @@ def test_patch_vpn_waitlist_legacy_update(client, dbsession, waitlist_factory):
     )
     assert resp.status_code == 200
     actual = resp.json()
-    del actual["waitlists"][0]["create_timestamp"]
-    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "vpn",
@@ -615,11 +615,15 @@ def test_patch_vpn_waitlist_legacy_update(client, dbsession, waitlist_factory):
             "fields": {"geo": "it", "platform": None},
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
 
 
-def test_patch_vpn_waitlist_legacy_update_full(client, dbsession, waitlist_factory):
+def test_patch_vpn_waitlist_legacy_update_full(
+    whatever, client, dbsession, waitlist_factory
+):
     vpn_waitlist = waitlist_factory(
         name="vpn",
         source="https://www.example.com/vpn_signup",
@@ -632,8 +636,6 @@ def test_patch_vpn_waitlist_legacy_update_full(client, dbsession, waitlist_facto
     )
     assert resp.status_code == 200
     actual = resp.json()
-    del actual["waitlists"][0]["create_timestamp"]
-    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "vpn",
@@ -641,6 +643,8 @@ def test_patch_vpn_waitlist_legacy_update_full(client, dbsession, waitlist_facto
             "fields": {"geo": "it", "platform": "linux"},
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
 
@@ -686,7 +690,9 @@ def test_patch_relay_waitlist_legacy_delete_default(client, maximal_contact):
     assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
 
 
-def test_patch_relay_waitlist_legacy_update(client, dbsession, waitlist_factory):
+def test_patch_relay_waitlist_legacy_update(
+    whatever, client, dbsession, waitlist_factory
+):
     relay_waitlist = waitlist_factory(
         name="relay",
         source="https://www.example.com/relay_signup",
@@ -699,8 +705,6 @@ def test_patch_relay_waitlist_legacy_update(client, dbsession, waitlist_factory)
     )
     assert resp.status_code == 200
     actual = resp.json()
-    del actual["waitlists"][0]["create_timestamp"]
-    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "relay",
@@ -708,12 +712,14 @@ def test_patch_relay_waitlist_legacy_update(client, dbsession, waitlist_factory)
             "fields": {"geo": "it"},
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
 
 
 def test_patch_relay_waitlist_legacy_update_all(
-    client, dbsession, email_factory, waitlist_factory
+    whatever, client, dbsession, email_factory, waitlist_factory
 ):
     # Test that all relay waitlists records are updated from the legacy way.
     email = email_factory()
@@ -750,10 +756,6 @@ def test_patch_relay_waitlist_legacy_update_all(
     )
     assert resp.status_code == 200
     actual = resp.json()
-    del actual["waitlists"][0]["create_timestamp"]
-    del actual["waitlists"][0]["update_timestamp"]
-    del actual["waitlists"][1]["create_timestamp"]
-    del actual["waitlists"][1]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "relay",
@@ -761,6 +763,8 @@ def test_patch_relay_waitlist_legacy_update_all(
             "fields": {"geo": "it"},
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         },
         {
             "name": "relay-vpn-bundle",
@@ -768,12 +772,14 @@ def test_patch_relay_waitlist_legacy_update_all(
             "fields": {"geo": "it"},
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         },
     ]
 
 
 def test_subscribe_to_relay_newsletter_turned_into_relay_waitlist(
-    client, minimal_contact
+    whatever, client, minimal_contact
 ):
     email_id = minimal_contact.email.email_id
     patch_data = {
@@ -783,8 +789,6 @@ def test_subscribe_to_relay_newsletter_turned_into_relay_waitlist(
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 200
     actual = resp.json()
-    del actual["waitlists"][0]["create_timestamp"]
-    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "relay-vpn-bundle",
@@ -792,6 +796,8 @@ def test_subscribe_to_relay_newsletter_turned_into_relay_waitlist(
             "fields": {"geo": "ru"},
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         },
     ]
 
@@ -829,7 +835,7 @@ def test_unsubscribe_from_guardian_vpn_newsletter_removes_vpn_waitlist(
 
 
 def test_unsubscribe_from_relay_newsletter_removes_relay_waitlist(
-    client, minimal_contact
+    whatever, client, minimal_contact
 ):
     email_id = minimal_contact.email.email_id
     patch_data = {
@@ -838,8 +844,6 @@ def test_unsubscribe_from_relay_newsletter_removes_relay_waitlist(
     }
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     current = resp.json()
-    del current["waitlists"][0]["create_timestamp"]
-    del current["waitlists"][0]["update_timestamp"]
     assert current["waitlists"] == [
         {
             "fields": {"geo": "ru"},
@@ -847,6 +851,8 @@ def test_unsubscribe_from_relay_newsletter_removes_relay_waitlist(
             "source": None,
             "subscribed": True,
             "unsub_reason": None,
+            "create_timestamp": whatever.iso8601(),
+            "update_timestamp": whatever.iso8601(),
         }
     ]
 

--- a/tests/unit/routers/contacts/test_api_patch.py
+++ b/tests/unit/routers/contacts/test_api_patch.py
@@ -194,12 +194,8 @@ def test_patch_cannot_set_timestamps(client, maximal_contact):
     # `expected`.
     for newsletter in expected["newsletters"]:
         del newsletter["email_id"]
-        del newsletter["create_timestamp"]
-        del newsletter["update_timestamp"]
     for waitlist in expected["waitlists"]:
         del waitlist["email_id"]
-        del waitlist["create_timestamp"]
-        del waitlist["update_timestamp"]
 
     # products list is not (yet) in output schema
     assert expected["products"] == []
@@ -301,6 +297,8 @@ def test_patch_to_subscribe(client, maximal_contact):
     assert resp.status_code == 200
     actual = resp.json()
     assert len(actual["newsletters"]) == len(maximal_contact.newsletters) + 1
+    del actual["newsletters"][-1]["create_timestamp"]
+    del actual["newsletters"][-1]["update_timestamp"]
     assert actual["newsletters"][-1] == {
         "format": "H",
         "lang": "en",
@@ -330,6 +328,8 @@ def test_patch_to_update_subscription(client, dbsession, newsletter_factory):
         "source": existing_newsletter.source,
         "subscribed": existing_newsletter.subscribed,
         "unsub_reason": existing_newsletter.unsub_reason,
+        "create_timestamp": existing_newsletter.create_timestamp.isoformat(),
+        "update_timestamp": existing_newsletter.update_timestamp.isoformat(),
     }
 
 
@@ -353,6 +353,8 @@ def test_patch_to_unsubscribe(client, maximal_contact):
     assert resp.status_code == 200
     actual = resp.json()
     assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
+    del actual["newsletters"][1]["create_timestamp"]
+    del actual["newsletters"][1]["update_timestamp"]
     assert actual["newsletters"][1] == {
         "format": "T",
         "lang": "fr",
@@ -466,6 +468,8 @@ def test_patch_to_add_a_waitlist(client, maximal_contact):
     new_waitlists = actual["waitlists"]
     assert len(new_waitlists) == len(maximal_contact.waitlists) + 1
     new_waitlist = next((wl for wl in new_waitlists if wl["name"] == "future-tech"))
+    del new_waitlist["create_timestamp"]
+    del new_waitlist["update_timestamp"]
     assert new_waitlist == {
         "name": "future-tech",
         "source": None,
@@ -551,6 +555,8 @@ def test_patch_vpn_waitlist_legacy_add(client, minimal_contact):
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 200
     actual = resp.json()
+    del actual["waitlists"][0]["create_timestamp"]
+    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "vpn",
@@ -600,6 +606,8 @@ def test_patch_vpn_waitlist_legacy_update(client, dbsession, waitlist_factory):
     )
     assert resp.status_code == 200
     actual = resp.json()
+    del actual["waitlists"][0]["create_timestamp"]
+    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "vpn",
@@ -624,6 +632,8 @@ def test_patch_vpn_waitlist_legacy_update_full(client, dbsession, waitlist_facto
     )
     assert resp.status_code == 200
     actual = resp.json()
+    del actual["waitlists"][0]["create_timestamp"]
+    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "vpn",
@@ -641,6 +651,8 @@ def test_patch_relay_waitlist_legacy_add(client, minimal_contact):
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 200
     actual = resp.json()
+    del actual["waitlists"][0]["create_timestamp"]
+    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "relay",
@@ -687,6 +699,8 @@ def test_patch_relay_waitlist_legacy_update(client, dbsession, waitlist_factory)
     )
     assert resp.status_code == 200
     actual = resp.json()
+    del actual["waitlists"][0]["create_timestamp"]
+    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "relay",
@@ -736,6 +750,10 @@ def test_patch_relay_waitlist_legacy_update_all(
     )
     assert resp.status_code == 200
     actual = resp.json()
+    del actual["waitlists"][0]["create_timestamp"]
+    del actual["waitlists"][0]["update_timestamp"]
+    del actual["waitlists"][1]["create_timestamp"]
+    del actual["waitlists"][1]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "relay",
@@ -765,6 +783,8 @@ def test_subscribe_to_relay_newsletter_turned_into_relay_waitlist(
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 200
     actual = resp.json()
+    del actual["waitlists"][0]["create_timestamp"]
+    del actual["waitlists"][0]["update_timestamp"]
     assert actual["waitlists"] == [
         {
             "name": "relay-vpn-bundle",
@@ -818,6 +838,8 @@ def test_unsubscribe_from_relay_newsletter_removes_relay_waitlist(
     }
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     current = resp.json()
+    del current["waitlists"][0]["create_timestamp"]
+    del current["waitlists"][0]["update_timestamp"]
     assert current["waitlists"] == [
         {
             "fields": {"geo": "ru"},

--- a/tests/unit/routers/contacts/test_api_patch.py
+++ b/tests/unit/routers/contacts/test_api_patch.py
@@ -17,6 +17,7 @@ from ctms.schemas import (
     MozillaFoundationSchema,
 )
 from ctms.schemas.waitlist import WaitlistInSchema
+from tests.conftest import FuzzyAssert
 from tests.unit.conftest import create_full_contact
 
 
@@ -289,7 +290,7 @@ def test_patch_error_on_id_conflict(
     }
 
 
-def test_patch_to_subscribe(whatever, client, maximal_contact):
+def test_patch_to_subscribe(client, maximal_contact):
     """PATCH can subscribe to a single newsletter."""
     email_id = maximal_contact.email.email_id
     patch_data = {"newsletters": [{"name": "zzz-newsletter"}]}
@@ -304,8 +305,8 @@ def test_patch_to_subscribe(whatever, client, maximal_contact):
         "source": None,
         "subscribed": True,
         "unsub_reason": None,
-        "create_timestamp": whatever.iso8601(),
-        "update_timestamp": whatever.iso8601(),
+        "create_timestamp": FuzzyAssert.iso8601(),
+        "update_timestamp": FuzzyAssert.iso8601(),
     }
 
 
@@ -333,7 +334,7 @@ def test_patch_to_update_subscription(client, dbsession, newsletter_factory):
     }
 
 
-def test_patch_to_unsubscribe(whatever, client, maximal_contact):
+def test_patch_to_unsubscribe(client, maximal_contact):
     """PATCH can unsubscribe by setting a newsletter field."""
     email_id = maximal_contact.email.email_id
     existing_news_data = maximal_contact.newsletters[1].dict()
@@ -360,8 +361,8 @@ def test_patch_to_unsubscribe(whatever, client, maximal_contact):
         "source": "https://commonvoice.mozilla.org/fr",
         "subscribed": False,
         "unsub_reason": "Too many emails.",
-        "create_timestamp": whatever.iso8601(),
-        "update_timestamp": whatever.iso8601(),
+        "create_timestamp": FuzzyAssert.iso8601(),
+        "update_timestamp": FuzzyAssert.iso8601(),
     }
 
 
@@ -458,7 +459,7 @@ def test_patch_will_validate_waitlist_fields(client, maximal_contact):
     assert details["detail"][0]["loc"] == ["body", "waitlists", 0, "source"]
 
 
-def test_patch_to_add_a_waitlist(whatever, client, maximal_contact):
+def test_patch_to_add_a_waitlist(client, maximal_contact):
     """PATCH can add a single waitlist."""
     email_id = maximal_contact.email.email_id
     patch_data = {"waitlists": [{"name": "future-tech", "fields": {"geo": "es"}}]}
@@ -474,8 +475,8 @@ def test_patch_to_add_a_waitlist(whatever, client, maximal_contact):
         "fields": {"geo": "es"},
         "subscribed": True,
         "unsub_reason": None,
-        "create_timestamp": whatever.iso8601(),
-        "update_timestamp": whatever.iso8601(),
+        "create_timestamp": FuzzyAssert.iso8601(),
+        "update_timestamp": FuzzyAssert.iso8601(),
     }
 
 
@@ -549,7 +550,7 @@ def test_patch_preserves_waitlists_if_omitted(client, maximal_contact):
     assert len(actual["waitlists"]) == len(maximal_contact.waitlists)
 
 
-def test_patch_vpn_waitlist_legacy_add(whatever, client, minimal_contact):
+def test_patch_vpn_waitlist_legacy_add(client, minimal_contact):
     email_id = minimal_contact.email.email_id
     patch_data = {"vpn_waitlist": {"geo": "fr", "platform": "win32"}}
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
@@ -565,8 +566,8 @@ def test_patch_vpn_waitlist_legacy_add(whatever, client, minimal_contact):
             },
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
 
@@ -593,9 +594,7 @@ def test_patch_vpn_waitlist_legacy_delete_default(client, maximal_contact):
     assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
 
 
-def test_patch_vpn_waitlist_legacy_update(
-    whatever, client, dbsession, waitlist_factory
-):
+def test_patch_vpn_waitlist_legacy_update(client, dbsession, waitlist_factory):
     vpn_waitlist = waitlist_factory(
         name="vpn",
         source="https://www.example.com/vpn_signup",
@@ -615,15 +614,13 @@ def test_patch_vpn_waitlist_legacy_update(
             "fields": {"geo": "it", "platform": None},
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
 
 
-def test_patch_vpn_waitlist_legacy_update_full(
-    whatever, client, dbsession, waitlist_factory
-):
+def test_patch_vpn_waitlist_legacy_update_full(client, dbsession, waitlist_factory):
     vpn_waitlist = waitlist_factory(
         name="vpn",
         source="https://www.example.com/vpn_signup",
@@ -643,8 +640,8 @@ def test_patch_vpn_waitlist_legacy_update_full(
             "fields": {"geo": "it", "platform": "linux"},
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
 
@@ -690,9 +687,7 @@ def test_patch_relay_waitlist_legacy_delete_default(client, maximal_contact):
     assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
 
 
-def test_patch_relay_waitlist_legacy_update(
-    whatever, client, dbsession, waitlist_factory
-):
+def test_patch_relay_waitlist_legacy_update(client, dbsession, waitlist_factory):
     relay_waitlist = waitlist_factory(
         name="relay",
         source="https://www.example.com/relay_signup",
@@ -712,14 +707,14 @@ def test_patch_relay_waitlist_legacy_update(
             "fields": {"geo": "it"},
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
 
 
 def test_patch_relay_waitlist_legacy_update_all(
-    whatever, client, dbsession, email_factory, waitlist_factory
+    client, dbsession, email_factory, waitlist_factory
 ):
     # Test that all relay waitlists records are updated from the legacy way.
     email = email_factory()
@@ -763,8 +758,8 @@ def test_patch_relay_waitlist_legacy_update_all(
             "fields": {"geo": "it"},
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         },
         {
             "name": "relay-vpn-bundle",
@@ -772,14 +767,14 @@ def test_patch_relay_waitlist_legacy_update_all(
             "fields": {"geo": "it"},
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         },
     ]
 
 
 def test_subscribe_to_relay_newsletter_turned_into_relay_waitlist(
-    whatever, client, minimal_contact
+    client, minimal_contact
 ):
     email_id = minimal_contact.email.email_id
     patch_data = {
@@ -796,8 +791,8 @@ def test_subscribe_to_relay_newsletter_turned_into_relay_waitlist(
             "fields": {"geo": "ru"},
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         },
     ]
 
@@ -835,7 +830,7 @@ def test_unsubscribe_from_guardian_vpn_newsletter_removes_vpn_waitlist(
 
 
 def test_unsubscribe_from_relay_newsletter_removes_relay_waitlist(
-    whatever, client, minimal_contact
+    client, minimal_contact
 ):
     email_id = minimal_contact.email.email_id
     patch_data = {
@@ -851,8 +846,8 @@ def test_unsubscribe_from_relay_newsletter_removes_relay_waitlist(
             "source": None,
             "subscribed": True,
             "unsub_reason": None,
-            "create_timestamp": whatever.iso8601(),
-            "update_timestamp": whatever.iso8601(),
+            "create_timestamp": FuzzyAssert.iso8601(),
+            "update_timestamp": FuzzyAssert.iso8601(),
         }
     ]
 

--- a/tests/unit/routers/contacts/test_bulk.py
+++ b/tests/unit/routers/contacts/test_bulk.py
@@ -121,12 +121,8 @@ def test_get_ctms_bulk_by_timerange(
     # The reponse does not show `email_id` and timestamp fields.
     for newsletter in dict_contact_expected["newsletters"]:
         del newsletter["email_id"]
-        del newsletter["create_timestamp"]
-        del newsletter["update_timestamp"]
     for waitlist in dict_contact_expected["waitlists"]:
         del waitlist["email_id"]
-        del waitlist["create_timestamp"]
-        del waitlist["update_timestamp"]
 
     assert dict_contact_expected == dict_contact_actual
     assert results["next"] is not None


### PR DESCRIPTION
I'm not a big fan for those `del actual["create_timestamp"]` in the tests.

We could either have a `omit(dict, keys="")` util, or, better IMO, we could have a test util to fuzzy match values instead of actual timestamp values.

For example:

https://github.com/mozilla/normandy/blob/8ec2b525493ee0af7da3e8beee4be4f1669f740c/normandy/base/tests/__init__.py#L12-L51

```py
        assert serializer.data == {
            "signature": Whatever.regex(r"[a-f0-9]{40}"),
            "x5u": Whatever.startswith(signature.x5u),
            "timestamp": Whatever.iso8601(),
            "public_key": Whatever.regex(r"[a-zA-Z0-9/+]{160}"),
        }
```
https://github.com/mozilla/normandy/blob/8ec2b525493ee0af7da3e8beee4be4f1669f740c/normandy/recipes/tests/api/v1/test_serializers.py#L140-L145