### PR TITLE
Ref #492, do not send legacy metric if new `waitlists` attribute is used

### DIFF
--- a/ctms/backport_legacy_waitlists.py
+++ b/ctms/backport_legacy_waitlists.py
@@ -17,12 +17,12 @@ def format_legacy_vpn_relay_waitlist_input(
     # Use a dict to handle all the different schemas for create, create_or_update, or update
     formatted = deepcopy(input_data) if schema_class == dict else input_data.dict()
 
-    if metrics and ("vpn_waitlist" in formatted or "relay_waitlist" in formatted):
-        metrics["legacy_waitlists_requests"].inc()
-
     if len(formatted.get("waitlists", [])) > 0:
         # We are dealing with the current format. Nothing to do.
         return input_data
+
+    if metrics and ("vpn_waitlist" in formatted or "relay_waitlist" in formatted):
+        metrics["legacy_waitlists_requests"].inc()
 
     rows = db.query(Waitlist).filter(Waitlist.email_id == email_id).all()
     existing_waitlists = {wl.name: wl for wl in rows}

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -205,6 +205,16 @@ def test_patch_relay_waitlist_legacy_reports_metric(client, minimal_contact, reg
     assert resp.status_code == 200
     assert registry.get_sample_value("ctms_legacy_waitlists_requests_total") == 0
 
+    # Legacy metric isn't sent if `waitlists` is present.
+    patch_data = {
+        "relay_waitlist": {"geo": "fr"},
+        "waitlists": [{"name": "relay", "fields": {"geo": "fr"}}],
+    }
+    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    assert resp.status_code == 200
+    assert registry.get_sample_value("ctms_legacy_waitlists_requests_total") == 0
+
+    # Metric is sent only if legacy attributes are sent.
     patch_data = {"relay_waitlist": {"geo": "fr"}}
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 200


### PR DESCRIPTION
Since Basket will pull the data before sending a patch or put ([source](https://github.com/mozmeao/basket/blob/7443f8d71e9f49be34deb803acec7bd3d728dfd8/basket/news/tasks.py#L412-L418)), and since the get response contains the legacy waitlists fields (read-only), the counter does not represent well the amount of real legacy put/patch of waitlists attributes. 

This PR makes sure we only send the metric when only legacy attributes are sent. 

This is not fully ideal, since clients may send both attributes (`waitlists`, and `relay_waitlist`/`vpn_waitlist`) and still expect that the legacy will be taken into account (which [is not the case](https://github.com/mozilla-it/ctms-api/blob/2d313c90b7da31ac0d1b28a28f7e7f1aaca73555/ctms/backport_legacy_waitlists.py#L20)) but this is the decision we made in #492 

In order to ship #722 we need to observe that no client is using the legacy way of modifying waitlists