### PR TITLE
Fix #840: use version number in Sentry environment

### DIFF
--- a/ctms/exception_capture.py
+++ b/ctms/exception_capture.py
@@ -26,7 +26,7 @@ def init_sentry():
     version_info = config.get_version()
     # pylint: disable=abstract-class-instantiated
     sentry_sdk.init(
-        release=version_info.get("commit", version_info["version"]),
+        release=version_info["version"],
         debug=sentry_debug,
         send_default_pii=False,
     )


### PR DESCRIPTION
Fix #840

- [x] Would require https://github.com/mozilla-sre-deploy/deploy-ctms/pull/1 first