### PR TITLE
Fix #915: Use DB instead of API for delete_bulk

### DIFF
--- a/ctms/bin/delete_bulk.py
+++ b/ctms/bin/delete_bulk.py
@@ -1,50 +1,26 @@
 #!/usr/bin/env python
-
-import sys
-
 import click
-from pydantic import BaseSettings
-from requests import Session
-from requests.auth import HTTPBasicAuth
+from pydantic import BaseSettings, PostgresDsn
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from ctms.crud import delete_contact, get_contacts_by_any_id
 
 
-class Settings(BaseSettings):
-    api_url: str = "http://127.0.0.1:8000"
-    client_id: str
-    client_secret: str
-    session: Session
+class DBSettings(BaseSettings):
+    db_url: PostgresDsn
 
     class Config:
         env_prefix = "ctms_"
 
 
-@click.group()
-@click.pass_context
-def cli(ctx):
-    """Delete a list of contacts"""
-    ctx.obj = Settings(session=Session())
-
-    response = ctx.obj.session.post(
-        f"{ctx.obj.api_url}/token",
-        auth=HTTPBasicAuth(ctx.obj.client_id, ctx.obj.client_secret),
-    )
-
-    if not response.ok:
-        print(f"{response.status_code}: {response.reason}", file=sys.stderr)
-
-    else:
-        data = response.json()
-        token = data["access_token"]
-
-        ctx.obj.session.headers.update({"Authorization": f"Bearer {token}"})
-
-
-@cli.command()
+@click.command()
 @click.option("--email")
 @click.option("--email-file", type=click.File("r"))
-@click.pass_obj
-def delete(obj, email, email_file):
+def delete(email, email_file):
     """delete single contact or a list of contacts from ctms"""
+    settings = DBSettings()
+
     to_be_deleted = []
 
     if email_file:
@@ -54,31 +30,24 @@ def delete(obj, email, email_file):
     if email:
         to_be_deleted.append(email)
 
-    for item in to_be_deleted:
-        response = obj.session.delete(f"{obj.api_url}/ctms/{item}")
-
-        if not response.ok:
-            if response.status_code == 404:
+    engine = create_engine(settings.db_url)
+    with Session(engine) as dbsession:
+        for item in to_be_deleted:
+            contacts = get_contacts_by_any_id(dbsession, primary_email=item.lower())
+            if not contacts:
                 print(f"{item} not found in CTMS")
 
-            else:
-                print(f"{response.status_code}: {response.reason}", file=sys.stderr)
+            for contact in contacts:
+                delete_contact(db=dbsession, email_id=contact.email.email_id)
 
-        else:
-            data = response.json()
-
-            for contact in data:
                 email_id = contact["email_id"]
                 msg = f"DELETING {item} (ctms id: {email_id})."
-
                 if contact["fxa_id"]:
                     msg += " fxa: YES."
-
                 if contact["mofo_contact_id"]:
                     msg += " mofo: YES."
-
                 print(msg)
 
 
 if __name__ == "__main__":
-    cli()  # pylint: disable=no-value-for-parameter
+    delete()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Fix #915

* [x] Implement command using the ORM
* [ ] Remove requirement of the `CTMS_SECRET_KEY` env var

Currently, there's a side effect of importing `crud.py`, which instantiates `Settings()`
```
Traceback (most recent call last):
  File "/Users/mathieu/Code/Mozilla/ctms-api/ctms/bin/delete_bulk.py", line 7, in <module>
    from ctms.crud import delete_contact, get_contacts_by_any_id
  File "/Users/mathieu/Code/Mozilla/ctms-api/ctms/crud.py", line 15, in <module>
    from .backport_legacy_waitlists import format_legacy_vpn_relay_waitlist_input
  File "/Users/mathieu/Code/Mozilla/ctms-api/ctms/backport_legacy_waitlists.py", line 7, in <module>
    from .models import Waitlist
  File "/Users/mathieu/Code/Mozilla/ctms-api/ctms/models.py", line 21, in <module>
    from .database import Base
  File "/Users/mathieu/Code/Mozilla/ctms-api/ctms/database.py", line 18, in <module>
    engine = engine_factory(Settings())
                            ^^^^^^^^^^
  File "/Users/mathieu/Code/Mozilla/ctms-api/.venv/lib/python3.12/site-packages/pydantic/env_settings.py", line 40, in __init__
    super().__init__(
  File "/Users/mathieu/Code/Mozilla/ctms-api/.venv/lib/python3.12/site-packages/pydantic/main.py", line 341, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 2 validation errors for Settings
db_url
  field required (type=value_error.missing)
secret_key
  field required (type=value_error.missing)
```

Should we implement #919 or just set a default value to `secret` (eg. `""`), since it is already set in prod anyway?