### PR TITLE
Refactor some canned fixtures for tests (minmal/maximal contacts, example contact)

### DIFF
--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -93,7 +93,7 @@ class AmoAccountFactory(BaseSQLAlchemyModelFactory):
     last_login = factory.Faker("date_object")
     location = factory.Faker("city")
     profile_url = factory.LazyAttribute(
-        lambda obj: f"https://www.example.com/{obj.display_name}"
+        lambda obj: f"https://ex.com/{obj.display_name}",
     )
     user = True
     user_id = factory.Faker("pystr", max_chars=40)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -199,18 +199,6 @@ def create_full_contact(db, contact: ContactSchema):
 
 
 @pytest.fixture
-def most_minimal_contact(dbsession):
-    contact = ContactSchema(
-        email=schemas.EmailSchema(
-            email_id=UUID("62d8d3c6-95f3-4ed6-b176-7f69acff22f6"),
-            primary_email="ctms-most-minimal-user@example.com",
-        ),
-    )
-    create_full_contact(dbsession, contact)
-    return contact
-
-
-@pytest.fixture
 def minimal_contact_data() -> ContactSchema:
     email_id = UUID("93db83d4-4119-4e0c-af87-a713786fa81d")
     return ContactSchema(

--- a/tests/unit/routers/contacts/test_api.py
+++ b/tests/unit/routers/contacts/test_api.py
@@ -1,6 +1,6 @@
 """Unit tests for cross-API functionality"""
 
-from typing import Any, Optional, Set, Tuple
+from typing import Optional, Set
 from uuid import uuid4
 
 import pytest
@@ -9,7 +9,7 @@ from ctms.schemas import ContactInSchema, ContactSchema, NewsletterInSchema
 from ctms.schemas.waitlist import WaitlistInSchema
 from tests.unit.conftest import SAMPLE_CONTACT_PARAMS
 
-API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
+API_TEST_CASES = (
     ("GET", "/ctms", {"primary_email": "contact@example.com"}),
     ("GET", "/ctms/332de237-cab7-4461-bcc3-48e68f42bd5c", None),
     (
@@ -44,51 +44,49 @@ API_TEST_CASES: Tuple[Tuple[str, str, Any], ...] = (
     (
         "DELETE",
         "/ctms/contact@example.com",
-        [
-            {
-                "email_id": str(uuid4()),
-                "primary_email": "contact@example.com",
-                "basket_token": str(uuid4()),
-                "sfcd_id": str(),
-                "mofo_contact_id": str(),
-                "mofo_email_id": str(),
-                "amo_user_id": str(),
-                "fxa_id": str(),
-                "fxa_primary_email": str(),
-            }
-        ],
+        None,
     ),
 )
 
 
 @pytest.mark.parametrize("method,path,params", API_TEST_CASES)
-def test_unauthorized_api_call_fails(
-    anon_client, example_contact, method, path, params
-):
+def test_unauthorized_api_call_fails(anon_client, method, path, params):
     """Calling the API without credentials fails."""
-    if method == "GET":
-        resp = anon_client.get(path, params=params)
+    if method in ("GET", "DELETE"):
+        resp = anon_client.request(method, path)
     else:
-        assert method in ("PATCH", "POST", "PUT", "DELETE")
+        assert method in ("PATCH", "POST", "PUT")
         resp = anon_client.request(method, path, json=params)
     assert resp.status_code == 401
     assert resp.json() == {"detail": "Not authenticated"}
 
 
 @pytest.mark.parametrize("method,path,params", API_TEST_CASES)
-def test_authorized_api_call_succeeds(client, example_contact, method, path, params):
-    """Calling the API without credentials fails."""
+def test_authorized_api_call_succeeds(
+    client, dbsession, email_factory, method, path, params
+):
+    """Calling the API with credentials succeeds."""
+
+    email_factory(
+        email_id="332de237-cab7-4461-bcc3-48e68f42bd5c",
+        primary_email="contact@example.com",
+    )
+    dbsession.commit()
+
     if method == "GET":
-        resp = client.get(path, params=params)
+        resp = client.request(method, path, params=params)
+        assert resp.status_code == 200
+    elif method == "DELETE":
+        resp = client.request(method, path)
         assert resp.status_code == 200
     else:
-        assert method in ("PATCH", "POST", "PUT", "DELETE")
+        assert method in ("PATCH", "POST", "PUT")
         resp = client.request(method, path, json=params)
         if method == "PUT":
             assert resp.status_code in {200, 201}  # Either creates or updates
         elif method == "POST":
             assert resp.status_code == 201
-        else:  # PATCH, DELETE
+        else:  # PATCH
             assert resp.status_code == 200
 
 

--- a/tests/unit/routers/contacts/test_api_delete.py
+++ b/tests/unit/routers/contacts/test_api_delete.py
@@ -6,8 +6,10 @@ def test_delete_contact_by_primary_email_not_found(client):
     assert resp.status_code == 404
 
 
-def test_delete_contact_by_primary_email(client, maximal_contact):
-    primary_email = maximal_contact.email.primary_email
+def test_delete_contact_by_primary_email(client, dbsession, email_factory):
+    primary_email = email_factory().primary_email
+    dbsession.commit()
+
     resp = client.delete(f"/ctms/{primary_email}")
     assert resp.status_code == 200
     resp = client.delete(f"/ctms/{primary_email}")
@@ -17,7 +19,7 @@ def test_delete_contact_by_primary_email(client, maximal_contact):
 def test_delete_contact_by_primary_email_with_basket_token_unset(
     client, dbsession, email_factory
 ):
-    email = email_factory()
+    email = email_factory(basket_token=None)
     dbsession.commit()
 
     resp = client.delete(f"/ctms/{email.primary_email}")

--- a/tests/unit/routers/contacts/test_api_delete.py
+++ b/tests/unit/routers/contacts/test_api_delete.py
@@ -15,8 +15,10 @@ def test_delete_contact_by_primary_email(client, maximal_contact):
 
 
 def test_delete_contact_by_primary_email_with_basket_token_unset(
-    client, most_minimal_contact
+    client, dbsession, email_factory
 ):
-    primary_email = most_minimal_contact.email.primary_email
-    resp = client.delete(f"/ctms/{primary_email}")
+    email = email_factory()
+    dbsession.commit()
+
+    resp = client.delete(f"/ctms/{email.primary_email}")
     assert resp.status_code == 200

--- a/tests/unit/routers/contacts/test_api_get_by_alt_id.py
+++ b/tests/unit/routers/contacts/test_api_get_by_alt_id.py
@@ -17,14 +17,31 @@ import pytest
         ("mofo_email_id", "195207d2-63f2-4c9f-b149-80e9c408477a"),
     ],
 )
-def test_get_ctms_by_alt_id(maximal_contact, client, alt_id_name, alt_id_value):
+def test_get_ctms_by_alt_id(
+    dbsession, email_factory, client, alt_id_name, alt_id_value
+):
     """The desired contact can be fetched by alternate ID."""
-    email_id = maximal_contact.email.email_id
+    email_factory(
+        email_id="67e52c77-950f-4f28-accb-bb3ea1a2c51a",
+        primary_email="mozilla-fan@example.com",
+        basket_token="d9ba6182-f5dd-4728-a477-2cc11bf62b69",
+        sfdc_id="001A000001aMozFan",
+        amo=True,
+        amo__user_id="123",
+        fxa=True,
+        fxa__fxa_id="611b6788-2bba-42a6-98c9-9ce6eb9cbd34",
+        fxa__primary_email="fxa-firefox-fan@example.com",
+        mofo=True,
+        mofo__mofo_contact_id="5e499cc0-eeb5-4f0e-aae6-a101721874b8",
+        mofo__mofo_email_id="195207d2-63f2-4c9f-b149-80e9c408477a",
+    )
+    dbsession.commit()
+
     resp = client.get("/ctms", params={alt_id_name: alt_id_value})
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
-    assert data[0]["email"]["email_id"] == str(email_id)
+    assert data[0]["email"]["email_id"] == "67e52c77-950f-4f28-accb-bb3ea1a2c51a"
 
 
 def test_get_ctms_by_no_ids_is_error(client, dbsession):

--- a/tests/unit/routers/contacts/test_api_patch.py
+++ b/tests/unit/routers/contacts/test_api_patch.py
@@ -1,9 +1,11 @@
 """Tests for PATCH /ctms/{email_id}"""
 
 import json
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from fastapi.encoders import jsonable_encoder
 
 from ctms.schemas import (
     AddOnsInSchema,
@@ -128,11 +130,21 @@ def test_patch_one_new_value(client, contact_name, group_name, key, value, reque
         ("mofo", "mofo_relevant"),
     ),
 )
-def test_patch_to_default(client, maximal_contact, group_name, key):
+def test_patch_to_default(client, dbsession, email_factory, group_name, key):
     """PATCH can set a field to the default value."""
-    email_id = maximal_contact.email.email_id
-    expected = json.loads(
-        CTMSResponse(**maximal_contact.model_dump()).model_dump_json()
+    email = email_factory(
+        sfdc_id="001A000001aMozFan",
+        unsubscribe_reason="You know what you did.",
+        double_opt_in=True,
+        fxa=True,
+        fxa__first_service="abc",
+        mofo=True,
+        amo=True,
+    )
+    dbsession.commit()
+
+    expected = jsonable_encoder(
+        CTMSResponse(**ContactSchema.from_email(email).model_dump())
     )
     existing_value = expected[group_name][key]
 
@@ -140,7 +152,8 @@ def test_patch_to_default(client, maximal_contact, group_name, key):
     field = {
         "amo": AddOnsSchema(),
         "email": EmailSchema(
-            email_id=email_id, primary_email=maximal_contact.email.primary_email
+            email_id=email.email_id,
+            primary_email=email.primary_email,
         ),
         "fxa": FirefoxAccountsSchema(),
         "mofo": MozillaFoundationSchema(),
@@ -151,7 +164,9 @@ def test_patch_to_default(client, maximal_contact, group_name, key):
     expected[group_name][key] = default_value
     assert existing_value != default_value
 
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
     assert actual["status"] == "ok"
@@ -161,12 +176,16 @@ def test_patch_to_default(client, maximal_contact, group_name, key):
     assert actual == expected
 
 
-def test_patch_cannot_set_timestamps(client, maximal_contact):
+def test_patch_cannot_set_timestamps(client, dbsession, email_factory):
     """PATCH can not set timestamps directly."""
-    email_id = maximal_contact.email.email_id
-    expected = json.loads(maximal_contact.model_dump_json())
-    new_ts = "2021-04-07T10:00:00+00:00"
-    assert expected["amo"]["create_timestamp"] == "2017-05-12T15:16:00+00:00"
+    email = email_factory(amo=True)
+    dbsession.commit()
+
+    expected = jsonable_encoder(
+        CTMSResponse(**ContactSchema.from_email(email).model_dump())
+    )
+    new_ts = datetime.now(tz=UTC).isoformat()
+    assert expected["amo"]["create_timestamp"] == email.amo.create_timestamp.isoformat()
     assert expected["amo"]["create_timestamp"] != new_ts
     assert expected["amo"]["update_timestamp"] != new_ts
     assert expected["email"]["create_timestamp"] != new_ts
@@ -181,7 +200,9 @@ def test_patch_cannot_set_timestamps(client, maximal_contact):
             "update_timestamp": new_ts,
         },
     }
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
     assert actual["status"] == "ok"
@@ -191,36 +212,27 @@ def test_patch_cannot_set_timestamps(client, maximal_contact):
     assert actual["amo"]["update_timestamp"] != new_ts
     expected["amo"]["update_timestamp"] = actual["amo"]["update_timestamp"]
     expected["email"]["update_timestamp"] = actual["email"]["update_timestamp"]
-    # `actual` comes from a `CTMSResponse`, and `expected` is a `ContactSchema`
-    # that has timestamps.
-    # Since this test compares the two instances directly, we strip the timestamps from
-    # `expected`.
-    for newsletter in expected["newsletters"]:
-        del newsletter["email_id"]
-    for waitlist in expected["waitlists"]:
-        del waitlist["email_id"]
-    # The response shows computed fields for retro-compat. Contact schema
-    # does not have them.
-    # TODO waitlist: remove once Basket reads from `waitlists` list.
-    del actual["vpn_waitlist"]
-    del actual["relay_waitlist"]
     assert actual == expected
 
 
-def test_patch_cannot_change_email_id(client, maximal_contact):
+def test_patch_cannot_change_email_id(client, dbsession, email_factory):
     """PATCH cannot change the email_id."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory()
+    dbsession.commit()
+
     patch_data = {"email": {"email_id": str(uuid4())}}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data)
+    resp = client.patch(f"/ctms/{email.email_id}", json=patch_data)
     assert resp.status_code == 422
     assert resp.json() == {"detail": "cannot change email_id"}
 
 
-def test_patch_cannot_set_email_to_null(client, maximal_contact):
+def test_patch_cannot_set_email_to_null(client, dbsession, email_factory):
     """PATCH cannot set the email address to null."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory()
+    dbsession.commit()
+
     patch_data = {"email": {"primary_email": None}}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data)
+    resp = client.patch(f"/ctms/{email.email_id}", json=patch_data)
     assert resp.status_code == 422
     assert resp.json() == {
         "detail": [
@@ -247,10 +259,13 @@ def test_patch_cannot_set_email_to_null(client, maximal_contact):
         ("fxa", "fxa_id"),
     ),
 )
-def test_patch_error_on_id_conflict(
-    client, dbsession, maximal_contact, group_name, key
-):
+def test_patch_error_on_id_conflict(client, dbsession, group_name, key, email_factory):
     """PATCH returns an error on ID conflicts, and makes none of the changes."""
+    email = email_factory(mofo=True, fxa=True)
+    dbsession.commit()
+
+    existing_contact = ContactSchema.from_email(email)
+
     conflict_id = str(uuid4())
     conflicting_data = ContactSchema(
         amo=AddOnsInSchema(user_id="1337"),
@@ -270,7 +285,7 @@ def test_patch_error_on_id_conflict(
     )
     create_full_contact(dbsession, conflicting_data)
 
-    existing_value = getattr(getattr(maximal_contact, group_name), key)
+    existing_value = getattr(getattr(existing_contact, group_name), key)
     conflicting_value = getattr(getattr(conflicting_data, group_name), key)
     assert existing_value
     assert conflicting_value
@@ -281,7 +296,7 @@ def test_patch_error_on_id_conflict(
     patch_data["vpn_waitlist"] = {"geo": "XX"}
     patch_data["relay_waitlist"] = {"geo": "XX"}
 
-    email_id = maximal_contact.email.email_id
+    email_id = existing_contact.email.email_id
     resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
     assert resp.status_code == 409
     assert resp.json() == {
@@ -292,15 +307,19 @@ def test_patch_error_on_id_conflict(
     }
 
 
-def test_patch_to_subscribe(client, maximal_contact):
+def test_patch_to_subscribe(client, dbsession, email_factory):
     """PATCH can subscribe to a single newsletter."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory(newsletters=1)
+    dbsession.commit()
+
     patch_data = {"newsletters": [{"name": "zzz-newsletter"}]}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len(actual["newsletters"]) == len(maximal_contact.newsletters) + 1
-    assert actual["newsletters"][-1] == {
+    assert len(actual["newsletters"]) == 2
+    assert actual["newsletters"][1] == {
         "format": "H",
         "lang": "en",
         "name": "zzz-newsletter",
@@ -336,13 +355,16 @@ def test_patch_to_update_subscription(client, dbsession, newsletter_factory):
     }
 
 
-def test_patch_to_unsubscribe(client, maximal_contact):
+def test_patch_to_unsubscribe(client, dbsession, email_factory, newsletter_factory):
     """PATCH can unsubscribe by setting a newsletter field."""
-    email_id = maximal_contact.email.email_id
-    existing_news_data = maximal_contact.newsletters[1].model_dump()
-    assert existing_news_data["subscribed"]
-    assert existing_news_data["name"] == "common-voice"
-    assert existing_news_data["unsub_reason"] is None
+    email = email_factory()
+    existing_newsletter = newsletter_factory(name="common-voice", email=email)
+    dbsession.commit()
+
+    assert len(email.newsletters) == 1
+    assert existing_newsletter.subscribed
+    assert existing_newsletter.name == "common-voice"
+    assert existing_newsletter.unsub_reason is None
     patch_data = {
         "newsletters": [
             {
@@ -352,25 +374,29 @@ def test_patch_to_unsubscribe(client, maximal_contact):
             }
         ]
     }
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
-    assert actual["newsletters"][1] == {
-        "format": "T",
-        "lang": "fr",
+    assert len(actual["newsletters"]) == len(email.newsletters)
+    assert actual["newsletters"][0] == {
+        "format": existing_newsletter.format,
+        "lang": existing_newsletter.lang,
         "name": "common-voice",
-        "source": "https://commonvoice.mozilla.org/fr",
+        "source": existing_newsletter.source,
         "subscribed": False,
         "unsub_reason": "Too many emails.",
-        "create_timestamp": FuzzyAssert.iso8601(),
+        "create_timestamp": existing_newsletter.create_timestamp.isoformat(),
         "update_timestamp": FuzzyAssert.iso8601(),
     }
 
 
-def test_patch_to_unsubscribe_but_not_subscribed(client, maximal_contact):
+def test_patch_to_unsubscribe_but_not_subscribed(client, dbsession, email_factory):
     """PATCH doesn't create a record when unsubscribing to a new newsletter."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory(newsletters=1)
+    dbsession.commit()
+
     unknown_name = "zzz-unknown-newsletter"
     patch_data = {
         "newsletters": [
@@ -381,30 +407,40 @@ def test_patch_to_unsubscribe_but_not_subscribed(client, maximal_contact):
             }
         ]
     }
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
-    assert not any(nl["name"] == unknown_name for nl in actual["newsletters"])
+    assert len(actual["newsletters"]) == 1
+    assert actual["newsletters"][0]["name"] != unknown_name
 
 
-def test_patch_unsubscribe_all(client, maximal_contact):
+def test_patch_unsubscribe_all(client, dbsession, email_factory):
     """PATCH with newsletters set to "UNSUBSCRIBE" unsubscribes all newsletters."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory(newsletters=2)
+    dbsession.commit()
+
     patch_data = {"newsletters": "UNSUBSCRIBE"}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len(actual["newsletters"]) == len(maximal_contact.newsletters)
+    assert len(actual["newsletters"]) == 2
     assert all(not nl["subscribed"] for nl in actual["newsletters"])
 
 
 @pytest.mark.parametrize("group_name", ("amo", "fxa", "mofo"))
-def test_patch_to_delete_group(client, maximal_contact, group_name):
+def test_patch_to_delete_group(client, dbsession, email_factory, group_name):
     """PATCH with a group set to "DELETE" resets the group to defaults."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory(amo=True, fxa=True, mofo=True)
+    dbsession.commit()
+
     patch_data = {group_name: "DELETE"}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
     defaults = {
@@ -427,12 +463,15 @@ def test_patch_to_delete_deleted_group(client, minimal_contact):
     assert actual["mofo"] == default_mofo
 
 
-def test_patch_will_validate_waitlist_fields(client, maximal_contact):
+def test_patch_will_validate_waitlist_fields(client, dbsession, email_factory):
     """PATCH validates waitlist schema."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory()
+    dbsession.commit()
 
     patch_data = {"waitlists": [{"name": "future-tech", "source": 42}]}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 422
     details = resp.json()
     assert details["detail"][0]["loc"] == [
@@ -444,16 +483,18 @@ def test_patch_will_validate_waitlist_fields(client, maximal_contact):
     ]
 
 
-def test_patch_to_add_a_waitlist(client, maximal_contact):
+def test_patch_to_add_a_waitlist(client, dbsession, email_factory):
     """PATCH can add a single waitlist."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory()
+    dbsession.commit()
+
     patch_data = {"waitlists": [{"name": "future-tech", "fields": {"geo": "es"}}]}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    new_waitlists = actual["waitlists"]
-    assert len(new_waitlists) == len(maximal_contact.waitlists) + 1
-    new_waitlist = next((wl for wl in new_waitlists if wl["name"] == "future-tech"))
+    [new_waitlist] = actual["waitlists"]
     assert new_waitlist == {
         "name": "future-tech",
         "source": None,
@@ -465,75 +506,91 @@ def test_patch_to_add_a_waitlist(client, maximal_contact):
     }
 
 
-def test_patch_does_not_add_an_unsubscribed_waitlist(client, maximal_contact):
-    email_id = maximal_contact.email.email_id
+def test_patch_does_not_add_an_unsubscribed_waitlist(client, dbsession, email_factory):
+    email = email_factory()
+    dbsession.commit()
+
     patch_data = {"waitlists": [{"name": "future-tech", "subscribed": False}]}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
-    assert resp.status_code == 200
-    actual = resp.json()
-    assert len(actual["waitlists"]) == len(maximal_contact.waitlists)
-
-
-def test_patch_to_update_a_waitlist(client, maximal_contact):
-    """PATCH can update a waitlist."""
-    email_id = maximal_contact.email.email_id
-    existing = [
-        WaitlistInSchema(**wl.model_dump()).model_dump()
-        for wl in maximal_contact.waitlists
-    ]
-    existing[0]["fields"]["geo"] = "ca"
-    patch_data = {"waitlists": existing}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
-    assert resp.status_code == 200
-    actual = resp.json()
-    assert (
-        actual["waitlists"][0]["fields"]["geo"]
-        != maximal_contact.waitlists[0].fields["geo"]
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
     )
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert len(actual["waitlists"]) == 0
 
 
-def test_patch_to_remove_a_waitlist(client, maximal_contact):
+def test_patch_to_update_a_waitlist(client, dbsession, email_factory, waitlist_factory):
+    """PATCH can update a waitlist."""
+    email = email_factory()
+    waitlist = waitlist_factory(fields={"geo": "fr"}, email=email)
+    dbsession.commit()
+
+    patched_waitlist = (
+        WaitlistInSchema.from_orm(waitlist)
+        .copy(update={"fields": {"geo": "ca"}})
+        .model_dump()
+    )
+    patch_data = {"waitlists": [patched_waitlist]}
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
+    assert resp.status_code == 200
+    actual = resp.json()
+    assert actual["waitlists"][0]["fields"]["geo"] == "ca"
+
+
+def test_patch_to_remove_a_waitlist(client, dbsession, email_factory, waitlist_factory):
     """PATCH can remove a single waitlist."""
-    email_id = maximal_contact.email.email_id
-    existing = [wl.model_dump() for wl in maximal_contact.waitlists]
+    email = email_factory()
+    waitlist_factory(name="bye-bye", email=email)
+    dbsession.commit()
+
     patch_data = {
         "waitlists": [
             WaitlistInSchema(
-                **{
-                    **existing[-1],
-                    "subscribed": False,
-                    "unsub_reason": "Not interested",
-                }
+                name="bye-bye", subscribed=False, unsub_reason="Not interested"
             ).model_dump()
         ]
     }
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len(actual["waitlists"]) == len(maximal_contact.waitlists)
-    unsubscribed = [wl for wl in actual["waitlists"] if not wl["subscribed"]]
-    assert len(unsubscribed) == 1
-    assert unsubscribed[0]["unsub_reason"] == "Not interested"
+    [unsubscribed] = actual["waitlists"]
+    assert unsubscribed["subscribed"] is False
+    assert unsubscribed["unsub_reason"] == "Not interested"
 
 
-def test_patch_to_remove_all_waitlists(client, maximal_contact):
+def test_patch_to_remove_all_waitlists(client, dbsession, email_factory):
     """PATCH can remove all waitlists."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory(waitlists=2)
+    assert all(wl.subscribed for wl in email.waitlists)
+    dbsession.commit()
+
     patch_data = {"waitlists": "UNSUBSCRIBE"}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
+
     assert resp.status_code == 200
     actual = resp.json()
     assert not any(wl["subscribed"] for wl in actual["waitlists"])
 
 
-def test_patch_preserves_waitlists_if_omitted(client, maximal_contact):
+def test_patch_preserves_waitlists_if_omitted(client, dbsession, email_factory):
     """PATCH won't update waitlists if omitted."""
-    email_id = maximal_contact.email.email_id
+    email = email_factory(waitlists=2)
+    dbsession.commit()
+
     patch_data = {"email": {"first_name": "Jeff"}}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
+
     assert resp.status_code == 200
     actual = resp.json()
-    assert len(actual["waitlists"]) == len(maximal_contact.waitlists)
+    assert len(actual["waitlists"]) == len(email.waitlists)
 
 
 def test_patch_vpn_waitlist_legacy_add(client, minimal_contact):
@@ -558,26 +615,43 @@ def test_patch_vpn_waitlist_legacy_add(client, minimal_contact):
     ]
 
 
-def test_patch_vpn_waitlist_legacy_delete(client, maximal_contact):
-    email_id = maximal_contact.email.email_id
-    before = len(maximal_contact.waitlists)
+def test_patch_vpn_waitlist_legacy_delete(
+    client, dbsession, email_factory, waitlist_factory
+):
+    email = email_factory()
+    waitlist_factory(
+        name="vpn", fields={"geo": "ca", "platform": "windows,android"}, email=email
+    )
+    dbsession.commit()
+    assert len([wl for wl in email.waitlists if wl.subscribed]) == 1
 
     patch_data = {"vpn_waitlist": "DELETE"}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
+
     assert resp.status_code == 200
     actual = resp.json()
-    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
+    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == 0
 
 
-def test_patch_vpn_waitlist_legacy_delete_default(client, maximal_contact):
-    email_id = maximal_contact.email.email_id
-    before = len(maximal_contact.waitlists)
+def test_patch_vpn_waitlist_legacy_delete_default(
+    client, dbsession, email_factory, waitlist_factory
+):
+    email = email_factory()
+    waitlist_factory(
+        name="vpn", fields={"geo": "ca", "platform": "windows,android"}, email=email
+    )
+    dbsession.commit()
+    assert len([wl for wl in email.waitlists if wl.subscribed]) == 1
 
     patch_data = {"vpn_waitlist": {"geo": None, "platform": None}}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
+    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == 0
 
 
 def test_patch_vpn_waitlist_legacy_update(client, dbsession, waitlist_factory):
@@ -651,26 +725,38 @@ def test_patch_relay_waitlist_legacy_add(client, minimal_contact):
     ]
 
 
-def test_patch_relay_waitlist_legacy_delete(client, maximal_contact):
-    email_id = maximal_contact.email.email_id
-    before = len(maximal_contact.waitlists)
+def test_patch_relay_waitlist_legacy_delete(
+    client, dbsession, email_factory, waitlist_factory
+):
+    email = email_factory()
+    waitlist_factory(name="relay", fields={"geo": "cn"}, email=email)
+    dbsession.commit()
+    assert len([wl for wl in email.waitlists if wl.subscribed]) == 1
 
     patch_data = {"relay_waitlist": "DELETE"}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
+    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == 0
 
 
-def test_patch_relay_waitlist_legacy_delete_default(client, maximal_contact):
-    email_id = maximal_contact.email.email_id
-    before = len(maximal_contact.waitlists)
+def test_patch_relay_waitlist_legacy_delete_default(
+    client, dbsession, email_factory, waitlist_factory
+):
+    email = email_factory()
+    waitlist_factory(name="relay", fields={"geo": "cn"}, email=email)
+    dbsession.commit()
+    assert len([wl for wl in email.waitlists if wl.subscribed]) == 1
 
     patch_data = {"relay_waitlist": {"geo": None}}
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     assert resp.status_code == 200
     actual = resp.json()
-    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == before - 1
+    assert len([wl for wl in actual["waitlists"] if wl["subscribed"]]) == 0
 
 
 def test_patch_relay_waitlist_legacy_update(client, dbsession, waitlist_factory):
@@ -784,35 +870,45 @@ def test_subscribe_to_relay_newsletter_turned_into_relay_waitlist(
 
 
 def test_unsubscribe_from_all_newsletters_removes_all_waitlists(
-    client, maximal_contact
+    client, dbsession, email_factory
 ):
-    email_id = maximal_contact.email.email_id
-    assert len(maximal_contact.waitlists) > 0
+    email = email_factory(newsletters=1, waitlists=1)
+    dbsession.commit()
+    assert len(email.waitlists) == 1
 
     patch_data = {
         "newsletters": "UNSUBSCRIBE",
     }
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
     current = resp.json()
     assert not any(wl["subscribed"] for wl in current["waitlists"])
 
 
 def test_unsubscribe_from_guardian_vpn_newsletter_removes_vpn_waitlist(
-    client, maximal_contact
+    client, dbsession, email_factory, waitlist_factory
 ):
-    email_id = maximal_contact.email.email_id
-    wl_names = {wl.name for wl in maximal_contact.waitlists}
-    assert "vpn" in wl_names
+    email = email_factory()
+    waitlist_factory(
+        name="vpn",
+        fields={"geo": "ca", "platform": "windows,android"},
+        email=email,
+    )
+    dbsession.commit()
 
     patch_data = {
         "newsletters": [
             {"name": "guardian-vpn-waitlist", "subscribed": False},
         ]
     }
-    resp = client.patch(f"/ctms/{email_id}", json=patch_data, allow_redirects=True)
+    resp = client.patch(
+        f"/ctms/{email.email_id}", json=patch_data, allow_redirects=True
+    )
+
     current = resp.json()
-    wl_names = {wl["name"] for wl in current["waitlists"] if wl["subscribed"]}
-    assert "vpn" not in wl_names
+    [wl] = current["waitlists"]
+    assert wl["subscribed"] is False
 
 
 def test_unsubscribe_from_relay_newsletter_removes_relay_waitlist(

--- a/tests/unit/routers/contacts/test_api_put.py
+++ b/tests/unit/routers/contacts/test_api_put.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 import pytest
 from structlog.testing import capture_logs
 
+from ctms.schemas import ContactPutSchema
 from tests.unit.conftest import SAMPLE_CONTACT_PARAMS
 
 from .test_api import _compare_written_contacts
@@ -14,15 +15,19 @@ PUT_TEST_PARAMS = pytest.mark.parametrize(
 )
 
 
-def test_create_or_update_basic_id_is_different(client, minimal_contact):
+def test_create_or_update_basic_id_is_different(client):
     """This should fail since we require an email_id to PUT"""
 
+    contact = ContactPutSchema(
+        email={"email_id": str(uuid4()), "primary_email": "hello@example.com"}
+    )
     # This id is different from the one in the contact
     resp = client.put(
-        "/ctms/d16c4ec4-caa0-4bf2-a06f-1bbf07bf03c7",
-        content=minimal_contact.model_dump_json(),
+        f"/ctms/{str(uuid4())}",
+        content=contact.model_dump_json(),
     )
     assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"] == "email_id in path must match email_id in contact"
 
 
 @PUT_TEST_PARAMS

--- a/tests/unit/routers/contacts/test_bulk.py
+++ b/tests/unit/routers/contacts/test_bulk.py
@@ -2,78 +2,48 @@
 
 import urllib.parse
 from datetime import timedelta
-from typing import Tuple
 
 import pytest
 
 from ctms.schemas import BulkRequestSchema, ContactSchema, CTMSResponse
 
-INVALID_BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
-    (
-        "GET",
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=2021-01-29T09%3A26%3A57.511000%2B00%3A00&limit=-11&after=OTNkYjgzZDQtNDExOS00ZTBjLWFmODctYTcxMzc4NmZhODFkLDIwMjAtMDEtMjIgMTU6MjQ6MDArMDA6MDA=",
-    ),
-    (
-        "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=1001&after=&mofo_relevant=",
-    ),
-    (
-        "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=-3&after=&mofo_relevant=",
-    ),
-    (
-        "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&after=null",
-    ),
-    (
-        "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&limit=null",
-    ),
-    (
-        "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&after=hello",
-    ),
-    (
-        "GET",
         "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&mofo_relevant=nah",
-    ),
+    ],
 )
-BULK_TEST_CASES: Tuple[Tuple[str, str], ...] = (
-    (
-        "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=2021-01-29T09%3A26%3A57.511000%2B00%3A00&limit=1&after=OTNkYjgzZDQtNDExOS00ZTBjLWFmODctYTcxMzc4NmZhODFkLDIwMjAtMDEtMjIgMTU6MjQ6MDArMDA6MDA=",
-    ),
-    (
-        "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=100&after=&mofo_relevant=",
-    ),
-    (
-        "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00",
-    ),
-    (
-        "GET",
-        "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&mofo_relevant=yes",
-    ),
-)
+def test_authorized_bulk_call_errs_on_validation(client, path):
+    """Calling the API with invlaid query parameters fails"""
 
-
-@pytest.mark.parametrize("method,path", INVALID_BULK_TEST_CASES)
-def test_authorized_bulk_call_errs_on_validation(client, example_contact, method, path):
-    """Calling the API without credentials fails."""
     resp = client.get(path)
     assert resp.status_code == 422
 
 
-@pytest.mark.parametrize("method,path", BULK_TEST_CASES)
-def test_authorized_bulk_call_succeeds(client, example_contact, method, path):
-    """Calling the API without credentials fails."""
+BULK_TEST_CASES = (
+    "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=2021-01-29T09%3A26%3A57.511000%2B00%3A00&limit=1&after=OTNkYjgzZDQtNDExOS00ZTBjLWFmODctYTcxMzc4NmZhODFkLDIwMjAtMDEtMjIgMTU6MjQ6MDArMDA6MDA=",
+    "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&end=&limit=100&after=&mofo_relevant=",
+    "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00",
+    "/updates?start=2020-01-22T03%3A24%3A00%2B00%3A00&mofo_relevant=yes",
+)
+
+
+@pytest.mark.parametrize("path", BULK_TEST_CASES)
+def test_authorized_bulk_call_succeeds(client, path):
+    """Calling the API with credentials succeeds."""
     resp = client.get(path)
     assert resp.status_code == 200
 
 
-@pytest.mark.parametrize("method,path", BULK_TEST_CASES)
-def test_unauthorized_api_call_fails(anon_client, example_contact, method, path):
+@pytest.mark.parametrize("path", BULK_TEST_CASES)
+def test_unauthorized_api_call_fails(anon_client, path):
     """Calling the API without credentials fails."""
     resp = anon_client.get(path)
     assert resp.status_code == 401

--- a/tests/unit/routers/contacts/test_private_api.py
+++ b/tests/unit/routers/contacts/test_private_api.py
@@ -14,18 +14,24 @@ API_TEST_CASES: Tuple[Tuple[str, Any], ...] = (
 
 
 @pytest.mark.parametrize("path,params", API_TEST_CASES)
-def test_unauthorized_api_call_fails(anon_client, example_contact, path, params):
+def test_authorized_api_call_succeeds(client, dbsession, email_factory, path, params):
+    """Calling the API with credentials succeeds."""
+    email_factory(
+        email_id="332de237-cab7-4461-bcc3-48e68f42bd5c",
+        basket_token="c4a7d759-bb52-457b-896b-90f1d3ef8433",
+    )
+    dbsession.commit()
+
+    resp = client.get(path, params=params)
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize("path,params", API_TEST_CASES)
+def test_unauthorized_api_call_fails(anon_client, path, params):
     """Calling the API without credentials fails."""
     resp = anon_client.get(path, params=params)
     assert resp.status_code == 401
     assert resp.json() == {"detail": "Not authenticated"}
-
-
-@pytest.mark.parametrize("path,params", API_TEST_CASES)
-def test_authorized_api_call_succeeds(client, example_contact, path, params):
-    """Calling the API without credentials fails."""
-    resp = client.get(path, params=params)
-    assert resp.status_code == 200
 
 
 def identity_response_for_contact(contact):

--- a/tests/unit/routers/contacts/test_private_api.py
+++ b/tests/unit/routers/contacts/test_private_api.py
@@ -102,25 +102,26 @@ def test_get_identities_by_two_alt_id_match(client, dbsession, email_factory):
     assert resp.json() == [identity]
 
 
-def test_get_identities_by_two_alt_id_mismatch_fails(
-    client, minimal_contact, example_contact
-):
+def test_get_identities_by_two_alt_id_mismatch_fails(client, dbsession, email_factory):
     """GET /identities with two non-matching IDs returns an empty identities list."""
-    email = minimal_contact.email.primary_email
-    amo_user_id = example_contact.amo.user_id
-    assert amo_user_id
+    email_1 = email_factory(amo=True)
+    email_2 = email_factory(amo=True)
+    dbsession.commit()
 
-    resp = client.get(f"/identities?primary_email={email}&amo_user_id={amo_user_id}")
+    resp = client.get(
+        f"/identities?primary_email={email_1.primary_email}&amo_user_id={email_2.amo.user_id}"
+    )
     assert resp.status_code == 200
     assert resp.json() == []
 
 
-def test_get_identities_by_two_alt_id_one_blank_fails(client, minimal_contact):
+def test_get_identities_by_two_alt_id_one_blank_fails(client, dbsession, email_factory):
     """GET /identities with an empty parameter returns an empty list."""
-    email = minimal_contact.email.primary_email
-    assert not minimal_contact.amo
+    email = email_factory()
+    dbsession.commit()
+    assert not email.amo
 
-    resp = client.get(f"/identities?primary_email={email}&amo_user_id=")
+    resp = client.get(f"/identities?primary_email={email.email_id}&amo_user_id=")
     assert resp.status_code == 200
     assert resp.json() == []
 

--- a/tests/unit/test_crud.py
+++ b/tests/unit/test_crud.py
@@ -79,14 +79,13 @@ def test_get_email_miss(dbsession):
     assert email is None
 
 
-def test_get_contact_by_email_id_found(dbsession, example_contact):
-    email_id = example_contact.email.email_id
-    contact = get_contact_by_email_id(dbsession, email_id)
-    assert contact.email.email_id == email_id
-    # pylint: disable-next=not-an-iterable
-    newsletter_names = [nl.name for nl in contact.newsletters]
-    assert newsletter_names == ["firefox-welcome", "mozilla-welcome"]
-    assert sorted(newsletter_names) == newsletter_names
+def test_get_contact_by_email_id_found(dbsession, email_factory):
+    email = email_factory()
+    dbsession.commit()
+
+    contact = get_contact_by_email_id(dbsession, email.email_id)
+
+    assert contact.email.email_id == email.email_id
 
 
 def test_get_contact_by_email_id_miss(dbsession):

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -68,14 +68,12 @@ def test_token_request_log(anon_client, client_id_and_secret):
     assert log["headers"]["cookie"] == "[OMITTED]"
 
 
-def test_log_omits_emails(client, maximal_contact):
+def test_log_omits_emails(client, email_factory):
     """The logger omits emails from query params."""
-    email_id = str(maximal_contact.email.email_id)
-    email = maximal_contact.email.primary_email
-    fxa_email = maximal_contact.fxa.primary_email
+    email = email_factory(fxa=True)
     url = (
-        f"/ctms?primary_email={email}&fxa_primary_email={fxa_email}"
-        f"&email_id={email_id}"
+        f"/ctms?primary_email={email.primary_email}&fxa_primary_email={email.fxa.primary_email}"
+        f"&email_id={email.email_id}"
     )
     with capture_logs() as cap_logs:
         resp = client.get(url)
@@ -83,7 +81,7 @@ def test_log_omits_emails(client, maximal_contact):
     assert len(cap_logs) == 1
     log = cap_logs[0]
     assert log["query"] == {
-        "email_id": email_id,
+        "email_id": str(email.email_id),
         "fxa_primary_email": "[OMITTED]",
         "primary_email": "[OMITTED]",
     }

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -9,9 +9,12 @@ from structlog.testing import capture_logs
 from ctms.log import configure_logging
 
 
-def test_request_log(client, minimal_contact):
+def test_request_log(client, dbsession, email_factory):
     """A request is logged."""
-    email_id = str(minimal_contact.email.email_id)
+    email = email_factory()
+    dbsession.commit()
+    email_id = str(email.email_id)
+
     with capture_logs() as cap_logs:
         resp = client.get(
             f"/ctms/{email_id}",


### PR DESCRIPTION
This PR takes a big swing at removing the usage of ambiguous canned fixutures in tests, namely:

- `most_minimal_contact`
- `minimal_contact`
- `maximal_contact`
- `example_contact`

I say ambiguous because at a glance, it's hard to know what the differences are between these fixtures.

Instead, we use factories to build models and commit those models to the database as needed in each test. This results in sometimes more verbose, but (in my opinion) clearer tests.

These fixtures aren't totally removed yet. In future PRs, we'll have to untangle them from how they're used in parametrized tests and other complex fixtures (e.g. `{put, post}_contact`)